### PR TITLE
muxer bouncing and tag corruption

### DIFF
--- a/ingest/entryWriter.go
+++ b/ingest/entryWriter.go
@@ -286,7 +286,7 @@ func (ew *EntryWriter) WriteWithHint(ent *entry.Entry) (bool, error) {
 // WriteBatch takes a slice of entries and writes them,
 // this function is useful in multithreaded environments where
 // we want to lessen the impact of hits on a channel by threads
-func (ew *EntryWriter) WriteBatch(ents [](*entry.Entry)) error {
+func (ew *EntryWriter) WriteBatch(ents [](*entry.Entry)) (int, error) {
 	var err error
 
 	ew.mtx.Lock()
@@ -294,11 +294,11 @@ func (ew *EntryWriter) WriteBatch(ents [](*entry.Entry)) error {
 
 	for i := range ents {
 		if _, err = ew.writeEntry(ents[i], false); err != nil {
-			return err
+			return i, err
 		}
 	}
 
-	return nil
+	return len(ents), nil
 }
 
 func (ew *EntryWriter) writeEntry(ent *entry.Entry, flush bool) (bool, error) {

--- a/ingest/entryWriter_test.go
+++ b/ingest/entryWriter_test.go
@@ -322,9 +322,10 @@ func performBatchCycles(t *testing.T, count int) (time.Duration, uint64) {
 		totalBytes += ent.Size()
 		//check if we need to throw a batch
 		if entsIndex >= cap(ents) {
-			err = etCli.WriteBatch(ents[0:entsIndex])
-			if err != nil {
+			if n, err := etCli.WriteBatch(ents[0:entsIndex]); err != nil {
 				t.Fatal(err)
+			} else if n != entsIndex {
+				t.Fatal("failed to write all entries")
 			}
 			entsIndex = 0
 		}
@@ -332,9 +333,10 @@ func performBatchCycles(t *testing.T, count int) (time.Duration, uint64) {
 		entsIndex++
 	}
 	if entsIndex > 0 {
-		err = etCli.WriteBatch(ents[0:entsIndex])
-		if err != nil {
+		if n, err := etCli.WriteBatch(ents[0:entsIndex]); err != nil {
 			t.Fatal(err)
+		} else if n != entsIndex {
+			t.Fatal("failed two write full batch")
 		}
 	}
 
@@ -463,8 +465,7 @@ func BenchmarkBatch(b *testing.B) {
 		totalBytes += ent.Size()
 		//check if we need to throw a batch
 		if entsIndex >= cap(ents) {
-			err = etCli.WriteBatch(ents[0:entsIndex])
-			if err != nil {
+			if _, err = etCli.WriteBatch(ents[0:entsIndex]); err != nil {
 				b.Fatal(err)
 			}
 			entsIndex = 0
@@ -473,8 +474,7 @@ func BenchmarkBatch(b *testing.B) {
 		entsIndex++
 	}
 	if entsIndex > 0 {
-		err = etCli.WriteBatch(ents[0:entsIndex])
-		if err != nil {
+		if _, err = etCli.WriteBatch(ents[0:entsIndex]); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/ingest/ingestConnection.go
+++ b/ingest/ingestConnection.go
@@ -113,11 +113,16 @@ func (igst *IngestConnection) WriteEntry(ent *entry.Entry) error {
 }
 
 // WriteBatchEntry DOES NOT populate the source on write, the caller must do so
-func (igst *IngestConnection) WriteBatchEntry(ents []*entry.Entry) error {
+func (igst *IngestConnection) WriteBatchEntry(ents []*entry.Entry) (err error) {
+	_, err = igst.writeBatchEntry(ents)
+	return
+}
+
+func (igst *IngestConnection) writeBatchEntry(ents []*entry.Entry) (int, error) {
 	igst.mtx.RLock()
 	defer igst.mtx.RUnlock()
 	if igst.running == false {
-		return errors.New("Not running")
+		return 0, errors.New("Not running")
 	}
 	return igst.ew.WriteBatch(ents)
 }

--- a/ingest/muxer.go
+++ b/ingest/muxer.go
@@ -1452,7 +1452,7 @@ func (eq *emergencyQueue) clear(igst *IngestConnection, tt *tagTrans) (ok bool) 
 					if !ok {
 						// could not translate, push it back on the queue and bail
 						// first we need to reverse the ones we have already translated, ugh
-						for j := 0; j <= i; j++ {
+						for j := 0; j < i; j++ {
 							blk[j].Tag = tt.Reverse(blk[j].Tag)
 						}
 						eq.push(e, blk)

--- a/ingesters/kafka_consumer/config_test.go
+++ b/ingesters/kafka_consumer/config_test.go
@@ -59,12 +59,6 @@ func TestBasicConfig(t *testing.T) {
 	if cfg.Secret() != `IngestSecrets` {
 		t.Fatal("invalid secret")
 	}
-	if cfg.MaxCachedData() != 1024*1024*1024 {
-		t.Fatal("invalid cache size")
-	}
-	if cfg.LocalFileCachePath() != `/opt/gravwell/cache/kafka.cache` {
-		t.Fatal("invalid cache path")
-	}
 	if len(cfg.Consumers) != 3 {
 		t.Fatal(fmt.Sprintf("invalid listener counts: %d != 7", len(cfg.Consumers)))
 	}
@@ -83,24 +77,32 @@ Pipe-Backend-Target=/opt/gravwell/comms/pipe #a named pipe connection, this shou
 Ingest-Cache-Path=/opt/gravwell/cache/kafka.cache #adding an ingest cache for local storage when uplinks fail
 Max-Ingest-Cache=1024 #Number of MB to store, localcache will only store 1GB before stopping.  This is a safety net
 Log-Level=INFO
-Log-File=/opt/gravwell/log/kafka.log
+Log-File=/tmp/kafka.log
 
 [Consumer "default"]
 	Leader="127.0.0.1"
 	Topic="foo"
-	Tag-Name=foo
+	Default-Tag=foo
+	Tags=bar*
+	Tags=*baz
+	Tag-Header=TAG
 
 [Consumer "test"]
 	Leader="127.0.0.1:1234"
 	Topic="test"
-	Tag-Name=test
+	Default-Tag=foo
+	Tags=bar*
+	Tags=*baz
+	Source-Header=SRC
 
 [Consumer "test2"]
 	Leader="[dead::beef]:1234"
 	Topic="test2"
-	Tag-Name=test2
-	Key-As-Source=true
-	Header-As-Source=TS
-	Source-As-Text=true
+	Default-Tag=foo
+	Tags=bar*
+	Tags=*baz
+	Source-As-Binary=true
+	Tag-Header=TAG
+	Source-Header=SRC
 `
 )

--- a/ingesters/kafka_consumer/consumer.go
+++ b/ingesters/kafka_consumer/consumer.go
@@ -306,7 +306,6 @@ func (kc *kafkaConsumer) flush(session sarama.ConsumerGroupSession, msgs []*sara
 		if ent.Tag, ent.SRC, err = kc.resolveSourceAndTag(m); err != nil {
 			return
 		}
-		fmt.Println(ent.Tag, string(ent.Data))
 		if err = kc.pproc.ProcessContext(ent, kc.ctx); err != nil {
 			return
 		}

--- a/ingesters/kafka_consumer/consumer.go
+++ b/ingesters/kafka_consumer/consumer.go
@@ -306,6 +306,7 @@ func (kc *kafkaConsumer) flush(session sarama.ConsumerGroupSession, msgs []*sara
 		if ent.Tag, ent.SRC, err = kc.resolveSourceAndTag(m); err != nil {
 			return
 		}
+		fmt.Println(ent.Tag, string(ent.Data))
 		if err = kc.pproc.ProcessContext(ent, kc.ctx); err != nil {
 			return
 		}

--- a/ingesters/kafka_consumer/kafka.conf
+++ b/ingesters/kafka_consumer/kafka.conf
@@ -12,9 +12,11 @@ Log-File=/opt/gravwell/log/kafka.log
 ############## Example Consumer Configs #####################
 #[Consumer "default"]
 #	Leader="127.0.0.1"
-#	Tag-Name=default
+#	Default-Tag=default   #send bad tag names to default tag
+#	Tags=*                #allow all tags
 #	Topic=default
-#
+#	Tag-Header=TAG        #look for the tag in the kafka TAG header
+#	Source-Header=SRC     #look for the source in the kafka SRC header
 #
 #[Consumer "test"]
 #	Leader="127.0.0.1:9092"


### PR DESCRIPTION
fixing issue where muxer could build up a list of entries and resend them, potentially even corrupting tag assignments when an ingest connection repeatedly bounces while under high load