### PR TITLE
fix #19 by modifying default kafka ingester config

### DIFF
--- a/ingesters/kafka_consumer/kafka.conf
+++ b/ingesters/kafka_consumer/kafka.conf
@@ -2,10 +2,10 @@
 Ingest-Secret = IngestSecrets
 Connection-Timeout = 0
 Insecure-Skip-TLS-Verify=false
-Cleartext-Backend-Target=127.0.0.1:4023 #example of adding a cleartext connection
+#Cleartext-Backend-Target=127.0.0.1:4023 #example of adding a cleartext connection
 #Cleartext-Backend-Target=127.1.0.1:4023 #example of adding another cleartext connection
 #Encrypted-Backend-Target=127.1.1.1:4024 #example of adding an encrypted connection
-#Pipe-Backend-Target=/opt/gravwell/comms/pipe #a named pipe connection, this should be used when ingester is on the same machine as a backend
+Pipe-Backend-Target=/opt/gravwell/comms/pipe #a named pipe connection, this should be used when ingester is on the same machine as a backend
 Log-Level=INFO
 Log-File=/opt/gravwell/log/kafka.log
 


### PR DESCRIPTION
Our shell installers expect a particular format so they can re-write the config files during installation. This change enables that.

Fixes #19 