### PR TITLE
ingest: add transition stub from old boltdb cache to neucache

### DIFF
--- a/ingest/boltcache.go
+++ b/ingest/boltcache.go
@@ -94,6 +94,7 @@ func boltTransition(c MuxerConfig) error {
 	if err != nil {
 		return err
 	}
+	defer os.RemoveAll(tmpd)
 
 	cc, err := chancacher.NewChanCacher(0, tmpd, 0)
 	if err != nil {

--- a/ingest/boltcache.go
+++ b/ingest/boltcache.go
@@ -1,0 +1,867 @@
+/*************************************************************************
+ * Copyright 2017 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
+package ingest
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+	"unsafe"
+
+	bolt "go.etcd.io/bbolt"
+
+	"github.com/gravwell/gravwell/v3/chancacher"
+	"github.com/gravwell/gravwell/v3/ingest/entry"
+)
+
+const (
+	defaultTickInterval = time.Second
+	defaultCacheSize    = 1024 * 1024 * 4   //4MB
+	defaultMaxCacheSize = 1024 * 1024 * 512 //512MB
+)
+
+var (
+	dbTimeout       time.Duration = 100 * time.Millisecond
+	dbMmapSize      int           = defaultCacheSize
+	dbOpenMode      os.FileMode   = 0660                        //user and group R/W but nothing for other
+	dbBucketName    []byte        = []byte(`ic`)                // this is the bucket that will hold entries
+	dbTagBucketName []byte        = []byte(`tagmap`)            // this bucket will hold the tag list
+	dbTagKey        []byte        = []byte(`__CACHE_TAG_KEY__`) // special tag to hold tag list
+
+	ErrActiveHotBlocks        = errors.New("There are active hotblocks, close pitched data")
+	ErrNoActiveDB             = errors.New("No active database")
+	ErrNoKey                  = errors.New("No key set on entry block")
+	ErrCacheAlreadyRunning    = errors.New("Cache already running")
+	ErrCacheNotRunning        = errors.New("Cache is not running")
+	ErrBucketMissing          = errors.New("Cache bucket is missing")
+	ErrCannotSyncWhileRunning = errors.New("Cannot sync while running")
+	ErrCannotPopWhileRunning  = errors.New("Cannot pop while running")
+	ErrInvalidKey             = errors.New("Key bytes are invalid")
+	ErrBoltLockFailed         = errors.New("Failed to acquire lock for ingest cache.  The file is locked by another process")
+)
+
+type IngestCacheConfig struct {
+	FileBackingLocation string
+	TickInterval        time.Duration
+	MemoryCacheSize     uint64
+	MaxCacheSize        uint64
+}
+
+type IngestCache struct {
+	mtx             *sync.Mutex
+	fileBacked      bool   //whether we are going to push to a file when there are no outputs available
+	storeLoc        string //location of boltDB
+	storedBlocks    int
+	count           uint64
+	cacheSize       uint64
+	storeSize       uint64
+	maxMemCacheSize uint64
+	maxCacheSize    uint64
+	hotBlocks       map[entry.EntryKey]*entry.EntryBlock
+	currKey         entry.EntryKey
+	currBlock       *entry.EntryBlock //just a pointer into the hotBlocks map value, NOT A COPY
+	db              *bolt.DB
+	err             error
+	running         bool
+	wg              sync.WaitGroup
+	stCh            chan bool
+}
+
+func boltTransition(c MuxerConfig) error {
+	// check if we have a bolt cache
+	// with regular files we'll just assume are bolt caches...
+	fi, err := os.Stat(c.CachePath)
+	if err != nil {
+		return nil
+	}
+	if fi.IsDir() {
+		return nil
+	}
+
+	// We probably do. Create a temporary chancacher, read the bolt cache
+	// into it, and then shuffle the files around.
+	tmpd, err := ioutil.TempDir("", "ingestCacheTransition")
+	if err != nil {
+		return err
+	}
+
+	cc, err := chancacher.NewChanCacher(0, tmpd, 0)
+	if err != nil {
+		return err
+	}
+
+	bc, err := NewIngestCache(IngestCacheConfig{
+		FileBackingLocation: c.CachePath,
+	})
+	if err != nil {
+		return err
+	}
+
+	// process!
+	if bc.Count() > 0 {
+		// tags
+		ctags, err := bc.GetTagList()
+		if err != nil {
+			return err
+		}
+
+		// bolt tags just map to their index in the returned slice, so
+		// we can generate the tags for chancacher with a simple range.
+		tagMap := make(map[string]entry.EntryTag)
+		for i, v := range ctags {
+			tagMap[v] = entry.EntryTag(i)
+		}
+		err = writeTagCache(tagMap, tmpd)
+		if err != nil {
+			return nil
+		}
+
+		// now simply read/write each entry from/to the old/new cache
+		for {
+			eb, err := bc.PopBlock()
+			if err != nil {
+				return err
+			}
+			if eb == nil {
+				break
+			}
+			ents := eb.Entries()
+			for _, v := range ents {
+				cc.In <- v
+			}
+		}
+
+		close(cc.In)
+		cc.Commit()
+	}
+
+	// Shuffle files
+	bc.Close()
+	err = os.Remove(c.CachePath)
+	if err != nil {
+		return err
+	}
+	err = os.MkdirAll(filepath.Join(c.CachePath, "e"), 0755)
+	if err != nil {
+		return err
+	}
+	err = os.Rename(filepath.Join(tmpd, "cache_a"), filepath.Join(c.CachePath, "e", "cache_a"))
+	if err != nil {
+		return err
+	}
+	err = os.Rename(filepath.Join(tmpd, "cache_b"), filepath.Join(c.CachePath, "e", "cache_b"))
+	if err != nil {
+		return err
+	}
+	err = os.Rename(filepath.Join(tmpd, "tagcache"), filepath.Join(c.CachePath, "tagcache"))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// NewIngestCache creates a ingest cache and gets a handle on the store if specified.
+// If the store can't be opened when asked for, we return an error
+func NewIngestCache(c IngestCacheConfig) (*IngestCache, error) {
+	var fileBacked bool
+	var db *bolt.DB
+	var blockCount int
+	var count uint64
+	if c.FileBackingLocation != `` {
+		fileBacked = true
+		//attempt to open the bolt database
+		dbConfig := bolt.Options{
+			InitialMmapSize: dbMmapSize,
+			Timeout:         dbTimeout,
+		}
+		var err error
+		db, err = bolt.Open(c.FileBackingLocation, dbOpenMode, &dbConfig)
+		if err != nil {
+			if err == bolt.ErrTimeout {
+				return nil, ErrBoltLockFailed
+			}
+			return nil, err
+		}
+
+		//create our bucket in case it doesn't exist
+		err = db.Update(func(t *bolt.Tx) error {
+			if _, err := t.CreateBucketIfNotExists(dbBucketName); err != nil {
+				return err
+			}
+			return nil
+		})
+		if err != nil {
+			db.Close()
+			return nil, err
+		}
+
+		//also create the tag bucket if it doesn't exist
+		err = db.Update(func(t *bolt.Tx) error {
+			if _, err := t.CreateBucketIfNotExists(dbTagBucketName); err != nil {
+				return err
+			}
+			return nil
+		})
+		if err != nil {
+			db.Close()
+			return nil, err
+		}
+
+		blockCount = getKVCount(db)
+		count, err = getEntryCount(db)
+		if err != nil {
+			db.Close()
+			return nil, err
+		}
+	}
+	//simple sanity check
+	if db == nil && fileBacked {
+		return nil, errors.New("Designated file backing did not generate storage handle")
+	}
+
+	var currDataSize uint64
+	if fileBacked {
+		fi, err := os.Stat(c.FileBackingLocation)
+		if err != nil {
+			db.Close()
+			return nil, err
+		}
+		currDataSize = uint64(fi.Size())
+	}
+
+	if c.MemoryCacheSize <= 0 {
+		c.MemoryCacheSize = defaultCacheSize
+	}
+
+	if c.MaxCacheSize <= 0 {
+		c.MaxCacheSize = defaultMaxCacheSize
+	}
+
+	if c.TickInterval <= 0 {
+		c.TickInterval = defaultTickInterval
+	}
+
+	//should be ready to go
+	return &IngestCache{
+		mtx:             &sync.Mutex{},
+		fileBacked:      fileBacked,
+		storeLoc:        c.FileBackingLocation,
+		maxMemCacheSize: c.MemoryCacheSize,
+		maxCacheSize:    c.MaxCacheSize,
+		hotBlocks:       map[entry.EntryKey]*entry.EntryBlock{},
+		db:              db,
+		storedBlocks:    blockCount,
+		count:           count,
+		storeSize:       currDataSize,
+		stCh:            make(chan bool, 1),
+	}, nil
+}
+
+func (ic *IngestCache) GetTagList() ([]string, error) {
+	ic.mtx.Lock()
+	defer ic.mtx.Unlock()
+	if ic.db == nil {
+		return []string{}, nil
+	}
+	return getTagList(ic.db)
+}
+
+func getTagList(db *bolt.DB) ([]string, error) {
+	var buff []byte
+	var tags []string
+	if err := db.View(func(tx *bolt.Tx) error {
+		bkt := tx.Bucket(dbTagBucketName)
+		if bkt == nil {
+			return ErrBucketMissing
+		}
+		lBuff := bkt.Get(dbTagKey)
+		if lBuff == nil {
+			return nil
+		}
+		buff = append([]byte(nil), lBuff...)
+		return nil
+	}); err != nil {
+		return tags, err
+	}
+	if buff == nil {
+		return tags, nil
+	}
+
+	err := json.Unmarshal(buff, &tags)
+	return tags, err
+}
+
+func (ic *IngestCache) UpdateStoredTagList(tags []string) error {
+	ic.mtx.Lock()
+	defer ic.mtx.Unlock()
+
+	if ic.db == nil {
+		return nil
+	}
+	return putTagList(ic.db, tags)
+}
+
+func putTagList(db *bolt.DB, tags []string) error {
+	buff, err := json.Marshal(tags)
+	if err != nil {
+		return err
+	}
+	if err := db.Update(func(tx *bolt.Tx) error {
+		bkt := tx.Bucket(dbTagBucketName)
+		if bkt == nil {
+			return ErrBucketMissing
+		}
+		if err := bkt.Put(dbTagKey, buff); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Close flushes hot blocks to the store and closes the cache
+func (ic *IngestCache) Close() error {
+	ic.mtx.Lock()
+	defer ic.mtx.Unlock()
+	if ic.db == nil {
+		if len(ic.hotBlocks) != 0 {
+			return ErrActiveHotBlocks
+		}
+		return nil //nothing to flush and no DB to flush to
+	}
+	if err := ic.flushHotBlocks(); err != nil {
+		return err
+	}
+	if err := ic.db.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// HotBlocks returns the number of blocks currently held in memory
+func (ic *IngestCache) HotBlocks() int {
+	return len(ic.hotBlocks)
+}
+
+// StoredBlocks returns the total number of blocks held in the store
+func (ic *IngestCache) StoredBlocks() int {
+	ic.mtx.Lock()
+	defer ic.mtx.Unlock()
+	return ic.storedBlocks
+}
+
+func getKVCount(db *bolt.DB) int {
+	var blocks int
+	//we can get the stats for the entire DB because there is only one bucket
+	if err := db.View(func(tx *bolt.Tx) error {
+		bkt := tx.Bucket(dbBucketName)
+		if bkt == nil {
+			return ErrBucketMissing
+		}
+		blocks = bkt.Stats().KeyN
+		return nil
+	}); err != nil {
+		return 0
+	}
+	return blocks
+}
+
+func (ic *IngestCache) getStoredBlocks() int {
+	if !ic.fileBacked || ic.db == nil {
+		return 0
+	}
+	return getKVCount(ic.db)
+}
+
+// MemoryCacheSize returns how much is held in memory
+func (ic *IngestCache) MemoryCacheSize() uint64 {
+	return ic.cacheSize
+}
+
+//Count returns the number of entries held, including in the storage system
+func (ic *IngestCache) Count() uint64 {
+	return ic.count
+}
+
+// Sync flushes all hot blocks to the data store.  If we an in memory only cache
+// then we throw an error
+func (ic *IngestCache) Sync() error {
+	ic.mtx.Lock()
+	defer ic.mtx.Unlock()
+	if ic.running {
+		return ErrCannotSyncWhileRunning
+	}
+	return ic.flushHotBlocks() //ONLY call this externally when we aren't running
+}
+
+func (ic *IngestCache) Start(eChan chan *entry.Entry, bChan chan []*entry.Entry) error {
+	ic.mtx.Lock()
+	defer ic.mtx.Unlock()
+	if ic.running {
+		return ErrCacheAlreadyRunning
+	}
+	started := make(chan error)
+	ic.wg.Add(1)
+	go ic.routine(eChan, bChan, started)
+	if err := <-started; err != nil {
+		return err
+	}
+	ic.running = true
+	return nil
+}
+
+func (ic *IngestCache) Stop() error {
+	ic.mtx.Lock()
+	if !ic.running {
+		ic.mtx.Unlock()
+		return ErrCacheNotRunning
+	}
+	ic.mtx.Unlock()
+	//try to send the stop signal
+	select {
+	case ic.stCh <- true:
+	default:
+	}
+	//wait for the closure
+	ic.wg.Wait()
+	return ic.err
+}
+
+func (ic *IngestCache) routine(echan chan *entry.Entry, bchan chan []*entry.Entry, started chan error) {
+	defer ic.wg.Done()
+
+	//get the current storage size
+	if ic.fileBacked {
+		fi, err := os.Stat(ic.storeLoc)
+		if err != nil {
+			started <- err
+			return
+		}
+		ic.storeSize = uint64(fi.Size())
+	}
+	started <- nil
+
+routineLoop:
+	for {
+		select {
+		case ent, ok := <-echan:
+			if !ok {
+				break routineLoop
+			}
+			if ic.addEntry(ent) && ic.fileBacked {
+				//we need to trim the cache to the store
+				if err := ic.trimMemoryCache(); err != nil {
+					ic.err = err
+					break routineLoop
+				}
+			}
+			ic.count++
+		case set, ok := <-bchan:
+			if !ok {
+				break routineLoop
+			}
+			for _, e := range set {
+				if e == nil {
+					continue
+				}
+				if ic.addEntry(e) && ic.fileBacked {
+					//we need to trim the cache to the store
+					if err := ic.trimMemoryCache(); err != nil {
+						ic.err = err
+						break routineLoop
+					}
+				}
+				ic.count++
+			}
+		case _ = <-ic.stCh:
+			break routineLoop
+		}
+		if ic.fileBacked && ic.maxCacheSize > 0 {
+			//check if we have hit the cache limit, if so wait for the signal stating that we can unload
+			if ic.storeSize > ic.maxCacheSize {
+				//just wait for signal to stop
+				<-ic.stCh
+				break routineLoop
+			}
+		}
+	}
+	ic.running = false
+}
+
+// addEntry will add an entry to the cache and returns a boolean
+// indicating whether we need to push some blocks to the store
+func (ic *IngestCache) addEntry(ent *entry.Entry) bool {
+	k := ent.Key()
+	if k != ic.currKey {
+		//see if we can find the block in the hotblock set
+		blk, ok := ic.hotBlocks[k]
+		if !ok {
+			blk = &entry.EntryBlock{}
+			ic.hotBlocks[k] = blk
+		}
+		ic.currBlock = blk
+		ic.currKey = k
+	}
+	//at this point the currBlock points at the right key
+	ic.currBlock.Add(ent)
+	ic.cacheSize += ent.Size()
+	if ic.cacheSize >= ic.maxMemCacheSize {
+		return true
+	}
+	return false
+}
+
+// addBlock will add a slice of entries back into the cache
+// this is just a convenience wrapper
+func (ic *IngestCache) addBlock(blk []*entry.Entry) bool {
+	var trimRequired bool
+	for i := range blk {
+		if blk[i] != nil {
+			if ic.addEntry(blk[i]) {
+				trimRequired = true
+			}
+		}
+	}
+	return trimRequired
+}
+
+func (ic *IngestCache) trimMemoryCache() error {
+	for k, v := range ic.hotBlocks {
+		if v == ic.currBlock && len(ic.hotBlocks) != 1 {
+			continue //skip the hotblock
+		}
+		//grab the block and attempt to push it to the store
+		if err := ic.pushBlock(k, v); err != nil {
+			return err
+		}
+		delete(ic.hotBlocks, k)
+		ic.cacheSize -= v.Size()
+		if ic.cacheSize < ic.maxMemCacheSize {
+			break
+		}
+	}
+	if len(ic.hotBlocks) == 0 {
+		ic.cacheSize = 0
+		ic.currKey = 0
+		ic.currBlock = nil
+	}
+	return nil
+}
+
+// flushHotBlocks pushes all our hot blocks to the store
+func (ic *IngestCache) flushHotBlocks() error {
+	if len(ic.hotBlocks) == 0 {
+		//nothing to flush
+		return nil
+	}
+	if ic.db == nil {
+		//db isn't hot, can't flush
+		return ErrNoActiveDB
+	}
+
+	//iterate over the hot blocks, pushing to DB
+	for k, v := range ic.hotBlocks {
+		if err := ic.pushBlock(k, v); err != nil {
+			return err
+		}
+		ic.cacheSize -= v.Size()
+		delete(ic.hotBlocks, k)
+	}
+
+	//there should be no hot blocks, remove current keys and block
+	ic.currKey = 0
+	ic.currBlock = nil
+	ic.cacheSize = 0
+	return nil
+}
+
+// getBlockBuff pulls a block, if the block does not exist we return nil
+// an error is only returned on an actual DB error
+func (ic *IngestCache) getBlockBuff(key []byte) ([]byte, error) {
+	var buff []byte
+	if err := ic.db.View(func(tx *bolt.Tx) error {
+		bkt := tx.Bucket(dbBucketName)
+		if bkt == nil {
+			return ErrBucketMissing
+		}
+		lBuff := bkt.Get(key)
+		if lBuff == nil {
+			return nil
+		}
+		buff = append([]byte(nil), lBuff...)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return buff, nil
+}
+
+// pushBlock will attempt to pull the current block, merge the incoming block,
+// and write it to the store
+func (ic *IngestCache) pushBlock(key entry.EntryKey, blk *entry.EntryBlock) error {
+	var newBlock bool
+	//some basic sanity checks
+	if blk == nil || blk.Size() == 0 {
+		return nil //no reason to push anything
+	}
+	//check our key, if one isn't set, try to pull it from the block
+	if key == 0 {
+		if blk.Key() == 0 {
+			return ErrNoKey
+		}
+		key = entry.EntryKey(blk.Key()) //set the key
+	}
+
+	dbKey := makeKey(key)
+	buff, err := ic.getBlockBuff(dbKey)
+	if err != nil {
+		return err
+	}
+	if buff == nil {
+		newBlock = true
+	}
+	oldSize := len(buff)
+	//pull current block with this key from the store and append our current block
+	buff, err = blk.EncodeAppend(buff)
+	if err != nil {
+		return err
+	}
+	addSize := uint64(len(buff) - oldSize)
+	if err := ic.db.Update(func(tx *bolt.Tx) error {
+		bkt := tx.Bucket(dbBucketName)
+		if bkt == nil {
+			return ErrBucketMissing
+		}
+		if err := bkt.Put(dbKey, buff); err != nil {
+			return err
+		}
+		ic.storeSize += addSize
+		return nil
+	}); err != nil {
+		return err
+	}
+	if newBlock {
+		ic.storedBlocks++
+	}
+	return nil
+}
+
+// PopBlock will pop any available block and hand it back
+// the block is entirely removed from the cache
+func (ic *IngestCache) PopBlock() (*entry.EntryBlock, error) {
+	ic.mtx.Lock()
+	defer ic.mtx.Unlock()
+	if ic.running {
+		return nil, ErrCannotPopWhileRunning
+	}
+	if !ic.fileBacked {
+		return ic.popHotBlock(), nil
+	}
+	key, blk, err := ic.popStoreBlock()
+	if err != nil {
+		return nil, err
+	}
+	if key != 0 {
+		blk = ic.popAndMergeHotBlock(key, blk)
+		ic.storeSize -= blk.Size()
+	} else {
+		blk = ic.popHotBlock()
+	}
+	if blk == nil {
+		err = ic.compactDb()
+	}
+	return blk, err
+}
+
+// compactDb is a hacky method of "compacting" the boltDB
+// this is clusterfuck bolt does not support compacting the file
+// so when we hit zero, delete the damn file...
+// its a hack, and I hate it... but it is what it is....
+func (ic *IngestCache) compactDb() error {
+	if err := ic.db.Sync(); err != nil {
+		return err
+	}
+	// Grab the tags before we go
+	ctags, err := getTagList(ic.db)
+	if err != nil {
+		return err
+	}
+
+	if err := ic.db.Close(); err != nil {
+		return err
+	}
+	if err := os.Remove(ic.storeLoc); err != nil {
+		return err
+	}
+	dbConfig := bolt.Options{
+		InitialMmapSize: dbMmapSize,
+		Timeout:         dbTimeout,
+	}
+
+	db, err := bolt.Open(ic.storeLoc, dbOpenMode, &dbConfig)
+	if err != nil {
+		return err
+	}
+	//create our bucket in case it doesn't exist
+	if err := db.Update(func(t *bolt.Tx) error {
+		if _, err := t.CreateBucketIfNotExists(dbBucketName); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	//also create the tag bucket if it doesn't exist
+	err = db.Update(func(t *bolt.Tx) error {
+		if _, err := t.CreateBucketIfNotExists(dbTagBucketName); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	ic.storedBlocks = 0
+	ic.count = 0
+	ic.storeSize = uint64(dbMmapSize)
+	ic.db = db
+	// Now write the tags back and call it good
+	return putTagList(db, ctags)
+}
+
+func (ic *IngestCache) popStoreBlock() (key entry.EntryKey, blk *entry.EntryBlock, err error) {
+	var tblk entry.EntryBlock
+	if err = ic.db.Update(func(tx *bolt.Tx) error {
+		bkt := tx.Bucket(dbBucketName)
+		if bkt == nil {
+			return ErrBucketMissing
+		}
+		c := bkt.Cursor()
+		for kb, vb := c.First(); kb != nil && vb != nil; kb, vb = c.Next() {
+			c.Delete() //removing, one way or another
+			key, err = getKey(kb)
+			if err != nil {
+				continue
+			}
+			//attempt to decode it
+			if err := tblk.Decode(append([]byte(nil), vb...)); err != nil {
+				continue
+			}
+			blk = &tblk
+			break //got it
+		}
+		return nil
+	}); err != nil {
+		blk = nil
+		return
+	}
+	return
+}
+
+func (ic *IngestCache) popAndMergeHotBlock(key entry.EntryKey, blk *entry.EntryBlock) *entry.EntryBlock {
+	b, ok := ic.hotBlocks[key]
+	if !ok {
+		return blk
+	}
+	b.Merge(blk)
+	return b
+}
+
+func (ic *IngestCache) popHotBlock() (blk *entry.EntryBlock) {
+	for k, v := range ic.hotBlocks {
+		if k == ic.currKey {
+			if len(ic.hotBlocks) == 1 {
+				ic.currKey = 0
+				ic.currBlock = nil
+			} else {
+				//skip the current block if there are others
+				continue
+			}
+		}
+		delete(ic.hotBlocks, k)
+		ic.count -= uint64(v.Count())
+		return v
+	}
+	return nil //nothing to pop
+}
+
+type iterator func([]byte, []byte) error
+
+func iterateEntries(db *bolt.DB, f iterator) error {
+	return db.View(func(tx *bolt.Tx) error {
+		bkt := tx.Bucket(dbBucketName)
+		if bkt == nil {
+			return ErrBucketMissing
+		}
+		return bkt.ForEach(f)
+	})
+}
+
+func deleteKeys(db *bolt.DB, keys [][]byte) error {
+	return db.Update(func(tx *bolt.Tx) error {
+		bkt := tx.Bucket(dbBucketName)
+		if bkt == nil {
+			return ErrBucketMissing
+		}
+		for _, k := range keys {
+			if err := bkt.Delete(k); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func getEntryCount(db *bolt.DB) (uint64, error) {
+	var deleteList [][]byte
+	var count uint64
+	if err := iterateEntries(db, func(k, v []byte) error {
+		var blk entry.EntryBlock
+		if _, err := getKey(k); err != nil {
+			//could not decode the key, just add to delete list and move on
+			deleteList = append(deleteList, k)
+			return nil
+		}
+		if err := blk.Decode(v); err != nil {
+			deleteList = append(deleteList, k)
+			return nil
+		}
+		count += uint64(blk.Count())
+		return nil
+	}); err != nil {
+		return 0, err
+	}
+	if err := deleteKeys(db, deleteList); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func makeKey(k entry.EntryKey) (v []byte) {
+	v = make([]byte, 8)
+	*(*entry.EntryKey)(unsafe.Pointer(&v[0])) = k
+	return
+}
+
+func getKey(v []byte) (k entry.EntryKey, err error) {
+	if len(v) != 8 {
+		err = ErrInvalidKey
+		return
+	}
+	k = *(*entry.EntryKey)(unsafe.Pointer(&v[0]))
+	return
+}

--- a/ingest/boltcache.go
+++ b/ingest/boltcache.go
@@ -90,7 +90,7 @@ func boltTransition(c MuxerConfig) error {
 
 	// We probably do. Create a temporary chancacher, read the bolt cache
 	// into it, and then shuffle the files around.
-	tmpd, err := ioutil.TempDir("", "ingestCacheTransition")
+	tmpd, err := ioutil.TempDir(filepath.Dir(c.CachePath), "ingestCacheTransition")
 	if err != nil {
 		return err
 	}

--- a/ingest/boltcache_test.go
+++ b/ingest/boltcache_test.go
@@ -1,0 +1,109 @@
+package ingest
+
+import (
+	"encoding/gob"
+	"io/ioutil"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gravwell/gravwell/v3/chancacher"
+	"github.com/gravwell/gravwell/v3/ingest/entry"
+)
+
+const (
+	tstLoc       string = `/tmp/cache_test.db`
+	memCacheSize uint64 = 1024 * 1024 //1MB
+)
+
+func TestTransition(t *testing.T) {
+	gob.Register(&entry.Entry{})
+
+	// build an old cache
+	echan := make(chan *entry.Entry, 8)
+	bchan := make(chan []*entry.Entry, 8)
+	ts := entry.Now()
+
+	tmp, err := ioutil.TempFile("", "bolttest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+	defer os.Remove(tmp.Name())
+
+	ic, err := NewIngestCache(IngestCacheConfig{
+		FileBackingLocation: tmp.Name(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// write out some fake tags
+	if err := ic.UpdateStoredTagList([]string{"a", "b", "c"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ic.Start(echan, bchan); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 10; i++ {
+		ent := &entry.Entry{
+			TS:   ts,
+			SRC:  net.ParseIP("127.0.0.1"),
+			Tag:  entry.EntryTag(0),
+			Data: []byte("test data"),
+		}
+		echan <- ent
+	}
+
+	if err := ic.Stop(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ic.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// build a MuxerConfig and transition
+	err = boltTransition(MuxerConfig{
+		CachePath: tmp.Name(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// tmp is now a directory bcause of the transition
+	defer os.RemoveAll(tmp.Name())
+
+	// read back data with chancacher
+	cc, err := chancacher.NewChanCacher(0, filepath.Join(tmp.Name(), "e"), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 10; i++ {
+		select {
+		case ee := <-cc.Out:
+			e := ee.(*entry.Entry)
+			if e.TS != ts || e.SRC.String() != "127.0.0.1" || e.Tag != entry.EntryTag(0) || string(e.Data) != "test data" {
+				t.Fatalf("mismatched entry: %v", e)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timeout!")
+		}
+	}
+	close(cc.In)
+
+	// verify tags
+	tagMap, err := readTagCache(tmp.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if tagMap["a"] != 0 || tagMap["b"] != 1 || tagMap["c"] != 2 {
+		t.Fatalf("invalid tagMap: %v", tagMap)
+	}
+}

--- a/ingest/muxer.go
+++ b/ingest/muxer.go
@@ -238,6 +238,15 @@ func newIngestMuxer(c MuxerConfig) (*IngestMuxer, error) {
 
 	var err error
 	if c.CachePath != "" {
+		//
+		// boltdb (old cache) transition stub. Delete this call, as
+		// well as boltcache.go when we no longer need this.
+		//
+		err = boltTransition(c)
+		if err != nil {
+			return nil, err
+		}
+
 		cache, err = chancacher.NewChanCacher(c.CacheDepth, filepath.Join(c.CachePath, "e"), mb*c.CacheSize)
 		if err != nil {
 			return nil, err

--- a/ingest/muxer.go
+++ b/ingest/muxer.go
@@ -240,7 +240,8 @@ func newIngestMuxer(c MuxerConfig) (*IngestMuxer, error) {
 	if c.CachePath != "" {
 		//
 		// boltdb (old cache) transition stub. Delete this call, as
-		// well as boltcache.go when we no longer need this.
+		// well as boltcache.go and boltcache_test.go when we no longer
+		// need this.
 		//
 		err = boltTransition(c)
 		if err != nil {


### PR DESCRIPTION
@floren the only code in boltcache.go that needs review is `boltTranstition()`, the rest of that file is the old cache. 

The idea here is to trigger on someone pointing neucache to a regular file, which we assume to be an old cache. We attempt to translate it to neucache in place, and just carry on. 