### PR TITLE
packetfleet: don't leak jobs on invalid queries

### DIFF
--- a/ingesters/PacketFleet/main.go
+++ b/ingesters/PacketFleet/main.go
@@ -399,6 +399,7 @@ func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				resp.Body.Close()
 				lg.Error("invalid query")
 				w.WriteHeader(http.StatusBadRequest)
+				removeJob(j.ID)
 				return
 			}
 			wg.Add(1)


### PR DESCRIPTION
fixes #37 