### PR TITLE
removing debug print

### DIFF
--- a/ingesters/PacketFleet/main.go
+++ b/ingesters/PacketFleet/main.go
@@ -137,7 +137,6 @@ func main() {
 	cfg, err := GetConfig(*confLoc)
 	if err != nil {
 		var tcfg cfgType
-		fmt.Printf("%+v\n", tcfg)
 		lg.FatalCode(0, "Failed to get configuration: %v\n", err)
 		return
 	}


### PR DESCRIPTION
there was a debug print when failing to load a config file.