### PR TITLE
adding an additional operator on the jsonarraysplit preprocessor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/minio/highwayhash v1.0.0
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
 	github.com/pierrec/lz4 v2.3.0+incompatible // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563 // indirect
 	github.com/shirou/gopsutil v2.19.11+incompatible
 	github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -213,6 +213,8 @@ github.com/pierrec/lz4 v2.2.6+incompatible h1:6aCX4/YZ9v8q69hTyiR7dNLnTA3fgtKHVV
 github.com/pierrec/lz4 v2.2.6+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4 v2.3.0+incompatible h1:CZzRn4Ut9GbUkHlQ7jqBXeZQV41ZSKWFc302ZU6lUTk=
 github.com/pierrec/lz4 v2.3.0+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/ingest/processors/json_test.go
+++ b/ingest/processors/json_test.go
@@ -23,7 +23,7 @@ var (
 	testOutputJson  = `{"foo":99,"bar":"hello","baz":4.12}`
 	testExtractions = `foo,bar,foobar.baz`
 
-	testArrayInputJson  = []byte(`{"foo":{"bar":["a", "b", 1.4, {"stuff":"things"}]}}`)
+	testArrayInputJson  = []byte(`{"foo":{"bar":["a", "b", 1.4, {"stuff":"things"}]}, "foobar": "barbaz", "barbaz": 99}`)
 	testArrayExtraction = `foo.bar`
 	testJSONArrayValues = []string{
 		`{"bar":"a"}`,
@@ -31,6 +31,13 @@ var (
 		`{"bar":1.4}`,
 		`{"bar":{"stuff":"things"}}`,
 	}
+	testJSONArrayValuesExtra = []string{
+		`{"bar":"a","foobar":"barbaz","barbaz":99}`,
+		`{"bar":"b","foobar":"barbaz","barbaz":99}`,
+		`{"bar":1.4,"foobar":"barbaz","barbaz":99}`,
+		`{"bar":{"stuff":"things"},"foobar":"barbaz","barbaz":99}`,
+	}
+
 	testArrayValues = []string{`a`, `b`, `1.4`, `{"stuff":"things"}`}
 )
 
@@ -198,6 +205,70 @@ func TestJsonArraySplit(t *testing.T) {
 		if string(rset[i].Data) != testJSONArrayValues[i] {
 			t.Fatalf("%d invalid return value: %s != %s", i,
 				string(rset[i].Data), testJSONArrayValues[i])
+		}
+	}
+}
+
+func TestJsonArraySplitAdditional(t *testing.T) {
+	b := []byte(`
+	[global]
+	foo = "bar"
+	bar = 1337
+	baz = 1.337
+	foo-bar-baz="foo bar baz"
+
+	[item "A"]
+	name = "test A"
+	value = 0xA
+
+	[preprocessor "j2"]
+		type = jsonarraysplit
+		Passthrough-Misses=false
+		Extraction="` + testArrayExtraction + `"
+		Additional-Fields="foobar,barbaz"
+		Force-JSON-Object=true
+	`)
+	tc := struct {
+		Global struct {
+			Foo         string
+			Bar         uint16
+			Baz         float32
+			Foo_Bar_Baz string
+		}
+		Item map[string]*struct {
+			Name  string
+			Value int
+		}
+		Preprocessor ProcessorConfig
+	}{}
+	if err := config.LoadConfigBytes(&tc, b); err != nil {
+		t.Fatal(err)
+	}
+	var tt testTagger
+	if _, err := tc.Preprocessor.getProcessor(`j1`, &tt); err == nil {
+		t.Fatal("Failed to pickup missing processor")
+	}
+	p, err := tc.Preprocessor.getProcessor(`j2`, &tt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p == nil {
+		t.Fatal("no processor back")
+	}
+	rset, err := p.Process(makeEntry(testArrayInputJson, 123))
+	if err != nil {
+		t.Fatal(err)
+	} else if len(rset) != len(testJSONArrayValues) {
+		t.Fatalf("return count mismatch: %d != %d", len(rset), len(testJSONArrayValues))
+	}
+
+	for i := range rset {
+		if rset[i].Tag != 123 {
+			t.Fatalf("%d invalid return tag", rset[i].Tag)
+		}
+		if string(rset[i].Data) != testJSONArrayValuesExtra[i] {
+			t.Fatalf("%d invalid return value: %s != %s", i,
+				string(rset[i].Data), testJSONArrayValuesExtra[i])
 		}
 	}
 }

--- a/ingest/processors/processors.go
+++ b/ingest/processors/processors.go
@@ -46,8 +46,8 @@ type ProcessorConfig map[string]*config.VariableConfig
 
 // Processor is an interface that takes an entry and processes it, returning a new block
 type Processor interface {
-	Process(*entry.Entry) ([]*entry.Entry, error)                         //process an data item potentially setting a tag
-	Close() error                                                         //give the processor a chance to tide up
+	Process(*entry.Entry) ([]*entry.Entry, error) //process an data item potentially setting a tag
+	Close() error                                 //give the processor a chance to tide up
 }
 
 func CheckProcessor(id string) error {


### PR DESCRIPTION
JSONARRAY preprocessor now supports an `Additional-Fields` argument that lets you pack along some more stuff when cracking apart arrays.