### PR TITLE
Add special ${_SRC_} sigil to regexextract preprocessor.

### DIFF
--- a/ingest/processors/regexextract_test.go
+++ b/ingest/processors/regexextract_test.go
@@ -9,6 +9,7 @@
 package processors
 
 import (
+	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -86,5 +87,35 @@ func TestRegexExtract(t *testing.T) {
 	}
 	if string(tent.Data) != `START STUFF	THINGS END` {
 		t.Fatal("Bad result")
+	}
+}
+
+func TestRegexExtractSRC(t *testing.T) {
+	cfg := RegexExtractConfig{
+		Template: "${_SRC_} ${stuff}",
+		Regex:    testRegex,
+	}
+	re, err := NewRegexExtractor(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ent := &entry.Entry{
+		Tag:  testTag,
+		SRC:  testIP,
+		TS:   testTime,
+		Data: []byte(`101 THINGS STUFF`),
+	}
+	ents, err := re.Process(ent)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(ents) != 1 {
+		t.Fatal("bad count", len(ents))
+	}
+	tent := ents[0]
+	if tent.Tag != ent.Tag || !tent.SRC.Equal(ent.SRC) || tent.TS != ent.TS {
+		t.Fatal("bad entry header data:", tent)
+	}
+	if string(tent.Data) != fmt.Sprintf("%v STUFF", testIP) {
+		t.Fatalf("Bad result: %v", string(tent.Data))
 	}
 }


### PR DESCRIPTION
If your regexextract Template contains `${_SRC_}`, it will be replaced with a string representation of the SRC field of the entry. Thus you can now do something like this:
```
[Preprocessor "srcextract"]
	Type=regexextract
	Regex="msg: (?P<msg>.+)$"
	Template=`{"srcip":"${_SRC_}", "msg":"${msg}"}`
```
and get entries which look like this:
```
{"srcip":"127.0.0.1", "msg":"foo bar baz"}
```