### PR TITLE
Issue 83 custom timestamp formats for ingesters

### DIFF
--- a/ingest/config/config.go
+++ b/ingest/config/config.go
@@ -52,6 +52,7 @@ import (
 	"github.com/google/go-write"
 	"github.com/google/uuid"
 	"github.com/gravwell/gravwell/v3/ingest/log"
+	"github.com/gravwell/gravwell/v3/timegrinder"
 )
 
 const (
@@ -118,6 +119,13 @@ type IngestConfig struct {
 type IngestStreamConfig struct {
 	Enable_Compression bool `json:",omitempty"`
 }
+
+type TimeFormat struct {
+	Format string
+	Regex  string
+}
+
+type CustomTimeFormat map[string]*TimeFormat
 
 func (ic *IngestConfig) loadDefaults() error {
 	//arrange the logic to be secure by default or when there is ambiguity
@@ -408,4 +416,49 @@ func writeFull(w io.Writer, b []byte) error {
 		}
 	}
 	return nil
+}
+
+func (ctf CustomTimeFormat) Validate() (err error) {
+	if len(ctf) == 0 {
+		return
+	}
+	for k, v := range ctf {
+		if v == nil {
+			continue
+		}
+		cf := timegrinder.CustomFormat {
+			Name: k,
+			Format: v.Format,
+			Regex:  v.Regex,
+		}
+		if err = cf.Validate(); err != nil {
+			return
+		}
+	}
+	return
+}
+
+func (ctf CustomTimeFormat) LoadFormats(tg *timegrinder.TimeGrinder) (err error) {
+	if len(ctf) == 0 {
+		return
+	} else if err = ctf.Validate(); err != nil {
+		return
+	}
+	for k, v := range ctf {
+		var p timegrinder.Processor
+		if v == nil {
+			continue
+		}
+		cf := timegrinder.CustomFormat {
+			Name: k,
+			Format: v.Format,
+			Regex:  v.Regex,
+		}
+		if p, err = timegrinder.NewCustomProcessor(cf); err != nil {
+			return
+		} else if _, err = tg.AddProcessor(p); err != nil {
+			return
+		}
+	}
+	return
 }

--- a/ingesters/HttpIngester/config.go
+++ b/ingesters/HttpIngester/config.go
@@ -44,6 +44,7 @@ type cfgReadType struct {
 	Global       gbl
 	Listener     map[string]*lst
 	Preprocessor processors.ProcessorConfig
+	TimeFormat   config.CustomTimeFormat
 }
 
 type lst struct {
@@ -51,6 +52,7 @@ type lst struct {
 	URL                       string //the URL we will listen to
 	Method                    string //method the listener expects
 	Tag_Name                  string //the tag to assign to the request
+	Multiline                 bool   //each request may have many entries
 	Ignore_Timestamps         bool   //Just apply the current timestamp to lines as we get them
 	Assume_Local_Timezone     bool
 	Timezone_Override         string
@@ -62,6 +64,7 @@ type cfgType struct {
 	gbl
 	Listener     map[string]*lst
 	Preprocessor processors.ProcessorConfig
+	TimeFormat   config.CustomTimeFormat
 }
 
 func GetConfig(path string) (*cfgType, error) {
@@ -73,6 +76,7 @@ func GetConfig(path string) (*cfgType, error) {
 		gbl:          cr.Global,
 		Listener:     cr.Listener,
 		Preprocessor: cr.Preprocessor,
+		TimeFormat:   cr.TimeFormat,
 	}
 	if err := verifyConfig(c); err != nil {
 		return nil, err
@@ -105,6 +109,8 @@ func verifyConfig(c *cfgType) error {
 		return errors.New("No Sniffers specified")
 	}
 	if err := c.Preprocessor.Validate(); err != nil {
+		return err
+	} else if err = c.TimeFormat.Validate(); err != nil {
 		return err
 	}
 	if hc, ok := c.HealthCheck(); ok {

--- a/ingesters/HttpIngester/main.go
+++ b/ingesters/HttpIngester/main.go
@@ -169,7 +169,9 @@ func main() {
 		hnd.healthCheckURL = hcurl
 	}
 	for _, v := range cfg.Listener {
-		var hcfg handlerConfig
+		hcfg := handlerConfig{
+			multiline: v.Multiline,
+		}
 		if hcfg.tag, err = igst.GetTag(v.Tag_Name); err != nil {
 			lg.Fatal("Failed to pull tag %v: %v", v.Tag_Name, err)
 		}
@@ -182,6 +184,8 @@ func main() {
 			}
 			if hcfg.tg, err = timegrinder.NewTimeGrinder(tcfg); err != nil {
 				lg.Fatal("Failed to generate new timegrinder: %v", err)
+			} else if cfg.TimeFormat.LoadFormats(hcfg.tg); err != nil {
+				lg.Fatal("Failed to load custom time formats: %v", err)
 			}
 			if v.Assume_Local_Timezone {
 				hcfg.tg.SetLocalTime()

--- a/ingesters/KinesisIngester/config.go
+++ b/ingesters/KinesisIngester/config.go
@@ -51,6 +51,7 @@ type cfgType struct {
 	Global        global
 	KinesisStream map[string]*streamDef
 	Preprocessor  processors.ProcessorConfig
+	TimeFormat    config.CustomTimeFormat
 }
 
 func GetConfig(path string) (*cfgType, error) {
@@ -104,6 +105,8 @@ func verifyConfig(c cfgType) error {
 		return errors.New("At least one Kinesis stream required.")
 	}
 	if err := c.Preprocessor.Validate(); err != nil {
+		return err
+	} else if err = c.TimeFormat.Validate(); err != nil {
 		return err
 	}
 	for k, v := range c.KinesisStream {

--- a/ingesters/MSGraphIngester/config.go
+++ b/ingesters/MSGraphIngester/config.go
@@ -50,6 +50,7 @@ type cfgType struct {
 	Global       global
 	ContentType  map[string]*contentType
 	Preprocessor processors.ProcessorConfig
+	TimeFormat   config.CustomTimeFormat
 }
 
 func GetConfig(path string) (*cfgType, error) {
@@ -94,6 +95,8 @@ func verifyConfig(c cfgType) error {
 		return errors.New("At least one content type required.")
 	}
 	if err := c.Preprocessor.Validate(); err != nil {
+		return err
+	} else if err = c.TimeFormat.Validate(); err != nil {
 		return err
 	}
 	for k, v := range c.ContentType {

--- a/ingesters/MSGraphIngester/main.go
+++ b/ingesters/MSGraphIngester/main.go
@@ -213,13 +213,15 @@ func main() {
 		tg, err := timegrinder.NewTimeGrinder(tcfg)
 		if err != nil {
 			ct.Ignore_Timestamps = true
+		} else if err = cfg.TimeFormat.LoadFormats(tg); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to set load custom time formats: %v\n", err)
+			return
 		}
 		if ct.Assume_Local_Timezone {
 			tg.SetLocalTime()
 		}
 		if ct.Timezone_Override != `` {
-			err = tg.SetTimezone(ct.Timezone_Override)
-			if err != nil {
+			if err = tg.SetTimezone(ct.Timezone_Override); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to set timezone to %v: %v\n", ct.Timezone_Override, err)
 				return
 			}

--- a/ingesters/O365Ingester/config.go
+++ b/ingesters/O365Ingester/config.go
@@ -50,6 +50,7 @@ type cfgType struct {
 	Global       global
 	ContentType  map[string]*contentType
 	Preprocessor processors.ProcessorConfig
+	TimeFormat   config.CustomTimeFormat
 }
 
 func GetConfig(path string) (*cfgType, error) {
@@ -94,6 +95,8 @@ func verifyConfig(c cfgType) error {
 		return errors.New("At least one content type required.")
 	}
 	if err := c.Preprocessor.Validate(); err != nil {
+		return err
+	} else if err = c.TimeFormat.Validate(); err != nil {
 		return err
 	}
 	for k, v := range c.ContentType {

--- a/ingesters/O365Ingester/main.go
+++ b/ingesters/O365Ingester/main.go
@@ -200,7 +200,29 @@ func main() {
 	// goroutine to read entries from Office 365 maintenance API
 	running := true
 	for k, v := range cfg.ContentType {
-		go func(name string, ct contentType) {
+		//get timegrinder stood up
+		tcfg := timegrinder.Config{
+			EnableLeftMostSeed: true,
+		}
+		tgr, err := timegrinder.NewTimeGrinder(tcfg)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to create timegrinder: %v\n", err)
+			return
+		} else if err := cfg.TimeFormat.LoadFormats(tgr); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to set load custom time formats: %v\n", err)
+			return
+		}
+		if v.Assume_Local_Timezone {
+			tgr.SetLocalTime()
+		}
+		if v.Timezone_Override != `` {
+			if err = tgr.SetTimezone(v.Timezone_Override); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to set timezone to %v: %v\n", v.Timezone_Override, err)
+				return
+			}
+		}
+
+		go func(name string, ct contentType, tg *timegrinder.TimeGrinder) {
 			debugout("Started reader for content type %v\n", ct.Content_Type)
 			wg.Add(1)
 			defer wg.Done()
@@ -214,25 +236,6 @@ func main() {
 			procset, err := cfg.Preprocessor.ProcessorSet(igst, ct.Preprocessor)
 			if err != nil {
 				lg.Fatal("Preprocessor construction error: %v", err)
-			}
-
-			// set up time extraction rules
-			tcfg := timegrinder.Config{
-				EnableLeftMostSeed: true,
-			}
-			tg, err := timegrinder.NewTimeGrinder(tcfg)
-			if err != nil {
-				ct.Ignore_Timestamps = true
-			}
-			if ct.Assume_Local_Timezone {
-				tg.SetLocalTime()
-			}
-			if ct.Timezone_Override != `` {
-				err = tg.SetTimezone(ct.Timezone_Override)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "Failed to set timezone to %v: %v\n", ct.Timezone_Override, err)
-					return
-				}
 			}
 
 			// we'll do a sliding window, they warn it can take a long time for some logs to show up
@@ -321,7 +324,7 @@ func main() {
 				lg.Error("Failed to close processor set: %v", err)
 			}
 
-		}(k, *v)
+		}(k, *v, tgr)
 	}
 
 	//register quit signals so we can die gracefully

--- a/ingesters/SimpleRelay/config.go
+++ b/ingesters/SimpleRelay/config.go
@@ -62,6 +62,7 @@ type cfgReadType struct {
 	Listener     map[string]*listener
 	JSONListener map[string]*jsonListener
 	Preprocessor processors.ProcessorConfig
+	TimeFormat   config.CustomTimeFormat
 }
 
 type cfgType struct {
@@ -69,6 +70,7 @@ type cfgType struct {
 	Listener     map[string]*listener
 	JSONListener map[string]*jsonListener
 	Preprocessor processors.ProcessorConfig
+	TimeFormat   config.CustomTimeFormat
 }
 
 func GetConfig(path string) (*cfgType, error) {
@@ -82,6 +84,7 @@ func GetConfig(path string) (*cfgType, error) {
 		Listener:     cr.Listener,
 		JSONListener: cr.JSONListener,
 		Preprocessor: cr.Preprocessor,
+		TimeFormat:   cr.TimeFormat,
 	}
 
 	if err := verifyConfig(c); err != nil {
@@ -109,6 +112,8 @@ func verifyConfig(c *cfgType) error {
 		return errors.New("No listeners specified")
 	}
 	if err := c.Preprocessor.Validate(); err != nil {
+		return err
+	} else if err = c.TimeFormat.Validate(); err != nil {
 		return err
 	}
 	bindMp := make(map[string]string, 1)

--- a/ingesters/SimpleRelay/lineHandlers.go
+++ b/ingesters/SimpleRelay/lineHandlers.go
@@ -52,6 +52,9 @@ func lineConnHandlerTCP(c net.Conn, cfg handlerConfig) {
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to get a handle on the timegrinder: %v\n", err)
 			return
+		} else if err = cfg.timeFormats.LoadFormats(tg); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to load custom time formats: %v\n", err)
+			return
 		}
 		if cfg.setLocalTime {
 			tg.SetLocalTime()
@@ -100,6 +103,9 @@ func lineConnHandlerUDP(c *net.UDPConn, cfg handlerConfig) {
 	tg, err := timegrinder.NewTimeGrinder(tcfg)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get a handle on the timegrinder: %v\n", err)
+		return
+	} else if err = cfg.timeFormats.LoadFormats(tg); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load custom time formats: %v\n", err)
 		return
 	}
 	if cfg.setLocalTime {

--- a/ingesters/SimpleRelay/rfc5424Handlers.go
+++ b/ingesters/SimpleRelay/rfc5424Handlers.go
@@ -53,6 +53,9 @@ func rfc5424ConnHandlerTCP(c net.Conn, cfg handlerConfig) {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get a handle on the timegrinder: %v\n", err)
 		return
+	} else if err = cfg.timeFormats.LoadFormats(tg); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load custom time formats: %v\n", err)
+		return
 	}
 
 	if cfg.setLocalTime {
@@ -123,6 +126,9 @@ func rfc5424ConnHandlerUDP(c *net.UDPConn, cfg handlerConfig) {
 	tg, err := timegrinder.NewTimeGrinder(tcfg)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get a handle on the timegrinder: %v\n", err)
+		return
+	} else if err = cfg.timeFormats.LoadFormats(tg); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load custom time formats: %v\n", err)
 		return
 	}
 

--- a/ingesters/SimpleRelay/simple.go
+++ b/ingesters/SimpleRelay/simple.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/gravwell/gravwell/v3/ingest"
+	"github.com/gravwell/gravwell/v3/ingest/config"
 	"github.com/gravwell/gravwell/v3/ingest/entry"
 	"github.com/gravwell/gravwell/v3/ingest/processors"
 	"github.com/gravwell/gravwell/v3/timegrinder"
@@ -45,6 +46,7 @@ type handlerConfig struct {
 	formatOverride   string
 	proc             *processors.ProcessorSet
 	ctx              context.Context
+	timeFormats      config.CustomTimeFormat
 }
 
 func startSimpleListeners(cfg *cfgType, igst *ingest.IngestMuxer, wg *sync.WaitGroup, f *flusher, ctx context.Context) error {
@@ -91,6 +93,7 @@ func startSimpleListeners(cfg *cfgType, igst *ingest.IngestMuxer, wg *sync.WaitG
 			wg:               wg,
 			formatOverride:   v.Timestamp_Format_Override,
 			ctx:              ctx,
+			timeFormats:      cfg.TimeFormat,
 		}
 		if hcfg.proc, err = cfg.Preprocessor.ProcessorSet(igst, v.Preprocessor); err != nil {
 			lg.Fatal("Preprocessor failure: %v", err)

--- a/ingesters/version/version.go
+++ b/ingesters/version/version.go
@@ -17,11 +17,11 @@ import (
 const (
 	MajorVersion = 4
 	MinorVersion = 1
-	PointVersion = 3
+	PointVersion = 4
 )
 
 var (
-	BuildDate time.Time = time.Date(2021, 01, 29, 0, 0, 0, 0, time.UTC)
+	BuildDate time.Time = time.Date(2021, 02, 15, 0, 0, 0, 0, time.UTC)
 )
 
 func PrintVersion(wtr io.Writer) {

--- a/timegrinder/custom.go
+++ b/timegrinder/custom.go
@@ -1,0 +1,122 @@
+/*************************************************************************
+ * Copyright 2017 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
+package timegrinder
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"time"
+)
+
+var (
+	ErrMissingName   = errors.New("Missing time extraction name")
+	ErrMissingRegex  = errors.New("Missing extraction regular expression")
+	ErrMissingFormat = errors.New("Missing extraction time format")
+	ErrInvalidFormat = errors.New("Invalid time format, could not format and extract current time")
+)
+
+var (
+	//this is so we can get a time structure that matches failed extractions
+	zeroTime, _ = time.Parse(``, ``)
+)
+
+type CustomFormat struct {
+	Name   string
+	Regex  string
+	Format string
+
+	dateMissing bool // indicates that the extraction only gets time, so add date
+}
+
+// Validate will check that the custom format is well formed and usable
+// we require a name, extraction regex, and time decoding format.
+// We will attempt to compile the regex and will also try to encode and decode
+// the timeformat.  The time format must be capable of encoding and decoding.
+// Validate will also detect if we are missing a date so that extractions will compensate
+func (cf *CustomFormat) Validate() (err error) {
+	//check that everything is specified
+	if cf.Name == `` {
+		return ErrMissingName
+	} else if cf.Regex == `` {
+		return ErrMissingRegex
+	} else if cf.Format == `` {
+		return ErrMissingFormat
+	}
+
+	//check that the regex compiles
+	if _, err = regexp.Compile(cf.Regex); err != nil {
+		return
+	}
+
+	//check that we can produce and consume a timestamp using the format
+	var t time.Time
+	if t, err = time.Parse(cf.Format, time.Now().Format(cf.Format)); err != nil {
+		err = fmt.Errorf("Invalid time format: %w", err)
+		return
+	} else if t.IsZero() || t.Equal(zeroTime) {
+		err = ErrInvalidFormat
+		return
+	} else if t.Year() == 0 && t.Month() == 1 && t.Day() == 1 {
+		//this is ok, but we need to add the date
+		cf.dateMissing = true
+	}
+	return
+}
+
+func (cf CustomFormat) ExtractionRegex() string {
+	return cf.Regex
+}
+
+type customProcessor struct {
+	CustomFormat
+	rx *regexp.Regexp
+}
+
+func NewCustomProcessor(cf CustomFormat) (p Processor, err error) {
+	if err = cf.Validate(); err != nil {
+		return
+	}
+	cp := &customProcessor{
+		CustomFormat: cf,
+	}
+	if cp.rx, err = regexp.Compile(cf.Regex); err != nil {
+		return
+	}
+	p = cp
+	return
+}
+
+func (cp *customProcessor) ToString(t time.Time) string {
+	return t.Format(cp.CustomFormat.Format)
+}
+
+func (cp *customProcessor) Match(d []byte) (int, int, bool) {
+	return match(cp.rx, nil, d)
+}
+
+func (cp *customProcessor) Extract(d []byte, loc *time.Location) (t time.Time, ok bool, offset int) {
+	if t, ok, offset = extract(cp.rx, nil, d, cp.CustomFormat.Format, loc); ok && cp.dateMissing {
+		t = addDate(t)
+	}
+	return
+}
+
+func (cp *customProcessor) Name() string {
+	return cp.CustomFormat.Name
+}
+
+func (cp *customProcessor) Format() string {
+	return cp.CustomFormat.Format
+}
+
+func addDate(t time.Time) time.Time {
+	now := time.Now().UTC().Truncate(24 * time.Hour)
+	return now.Add(t.Sub(zeroTime))
+}


### PR DESCRIPTION
adding the ability to specify custom time formats in config files for ingesters that use the timegrinder and a config.  Covers issue #83