### PR TITLE
Http fixup

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -208,6 +208,7 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024 h1:rBMNdl
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/k-sone/ipmigo v0.0.0-20190922011749-b22c7a70e949/go.mod h1:CixWBSPtPv3WFceEvubOBc8RhADaZr7t7Xk6j+hKOXU=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.8.2 h1:Bx0qjetmNjdFXASH02NSAREKpiaDwkO1DRZ3dV2KCcs=
 github.com/klauspost/compress v1.8.2/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=

--- a/ingesters/HttpIngester/auth.go
+++ b/ingesters/HttpIngester/auth.go
@@ -442,7 +442,7 @@ func (cah *cookieAuthHandler) AuthRequest(r *http.Request) (err error) {
 		return
 	}
 	if c == nil || c.Value == `` {
-		err = fmt.Errorf("invalid cookie")
+		err = errors.New("invalid cookie")
 		return
 	}
 	n := time.Now()
@@ -466,7 +466,7 @@ func getJWTToken(r *http.Request) (string, error) {
 
 func getAuthToken(r *http.Request, tokName string) (ret string, err error) {
 	if tokName == `` {
-		err = fmt.Errorf("Empty token name")
+		err = errors.New("Empty token name")
 		return
 	}
 	prefix := tokName + ` `
@@ -484,7 +484,7 @@ func getAuthToken(r *http.Request, tokName string) (ret string, err error) {
 
 func getParamToken(r *http.Request, tokName string) (ret string, err error) {
 	if tokName == `` {
-		err = fmt.Errorf("Empty token name")
+		err = errors.New("Empty token name")
 		return
 	}
 	keys, ok := r.URL.Query()[tokName]

--- a/ingesters/HttpIngester/gravwell_http_ingester.conf
+++ b/ingesters/HttpIngester/gravwell_http_ingester.conf
@@ -63,3 +63,10 @@ Health-Check-URL="/health/check"
 #	AuthType="preshared-parameter"
 #	TokenName=Gravwell
 #	TokenValue=Secret
+#
+#
+# Example that creates a listener that is API compatible with the Splunk HEC
+[HEC-Compatible-Listener "testing"]
+	#URL="/services/collector/event" #If URL is omitted, the default is set to /services/collector/event
+	TokenValue="thisisyourtoken" #set the access control token
+	Tag-Name=scythe

--- a/ingesters/HttpIngester/handlers.go
+++ b/ingesters/HttpIngester/handlers.go
@@ -10,9 +10,15 @@ package main
 
 import (
 	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
 	"io"
+	"io/ioutil"
+	"math"
 	"net"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/gravwell/gravwell/v3/ingest"
@@ -23,6 +29,7 @@ import (
 )
 
 type handlerConfig struct {
+	hecCompat bool
 	ignoreTs  bool
 	multiline bool
 	tag       entry.EntryTag
@@ -42,6 +49,8 @@ type handler struct {
 
 func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
+	debugout("REQUEST %s %v\n", r.Method, r.URL)
+	debugout("HEADERS %v\n", r.Header)
 
 	//check if its just a health check
 	if h.healthCheckURL == r.URL.Path {
@@ -73,12 +82,71 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if cfg.multiline {
+	if cfg.hecCompat {
+		h.handleHEC(cfg, r, w)
+	} else if cfg.multiline {
 		h.handleMulti(cfg, r, w)
 	} else {
 		h.handleSingle(cfg, r, w)
 	}
 	r.Body.Close()
+}
+
+type hecEvent struct {
+	Event json.RawMessage `json:"event"`
+	TS    custTime        `json:"time"`
+}
+
+type custTime time.Time
+
+func (c *custTime) UnmarshalJSON(v []byte) (err error) {
+	var f float64
+	v = bytes.Trim(v, `"`) //trim quotes if they are there
+	if f, err = strconv.ParseFloat(string(v), 64); err != nil {
+		return
+	} else if f < 0 || f > float64(0xffffffffff) {
+		err = errors.New("invalid timestamp value")
+	}
+	sec, dec := math.Modf(f)
+	*c = custTime(time.Unix(int64(sec), int64(dec*(1e9))))
+	return
+}
+
+func (h *handler) handleHEC(cfg handlerConfig, r *http.Request, w http.ResponseWriter) {
+	b, err := ioutil.ReadAll(io.LimitReader(r.Body, int64(maxBody+256))) //give some slack for the extra splunk garbage
+	if err != nil && err != io.EOF {
+		h.lgr.Info("Got bad request: %v", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	} else if len(b) > maxBody {
+		h.lgr.Error("Request too large, 4MB max")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if len(b) == 0 {
+		h.lgr.Info("Got an empty post from %s", r.RemoteAddr)
+		w.WriteHeader(http.StatusBadRequest)
+	}
+	var x hecEvent
+	if err = json.Unmarshal(b, &x); err == nil {
+		b = []byte(x.Event)
+	} //else means we just keep the entire raw thing
+
+	//if we couldn't get the timestmap, use now
+	if time.Time(x.TS).IsZero() {
+		x.TS = custTime(time.Now().UTC())
+	}
+	e := entry.Entry{
+		TS:   entry.FromStandard(time.Time(x.TS)),
+		SRC:  getRemoteIP(r),
+		Tag:  cfg.tag,
+		Data: b,
+	}
+	if err = cfg.pproc.Process(&e); err != nil {
+		h.lgr.Error("Failed to send entry: %v", err)
+		return
+	}
+	debugout("Sending entry %+v", e)
 }
 
 func (h *handler) handleMulti(cfg handlerConfig, r *http.Request, w http.ResponseWriter) {
@@ -99,18 +167,16 @@ func (h *handler) handleMulti(cfg handlerConfig, r *http.Request, w http.Respons
 }
 
 func (h *handler) handleSingle(cfg handlerConfig, r *http.Request, w http.ResponseWriter) {
-	b := make([]byte, maxBody)
-	n, err := readAll(r.Body, b)
+	b, err := ioutil.ReadAll(io.LimitReader(r.Body, int64(maxBody+1)))
 	if err != nil && err != io.EOF {
 		h.lgr.Info("Got bad request: %v", err)
 		w.WriteHeader(http.StatusBadRequest)
 		return
-	} else if n == maxBody {
+	} else if len(b) > maxBody {
 		h.lgr.Error("Request too large, 4MB max")
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	b = b[0:n]
 	if len(b) == 0 {
 		h.lgr.Info("Got an empty post from %s", r.RemoteAddr)
 		w.WriteHeader(http.StatusBadRequest)
@@ -146,8 +212,6 @@ func (h *handler) handleEntry(cfg handlerConfig, b []byte, ip net.IP) (err error
 		h.lgr.Error("Failed to send entry: %v", err)
 		return
 	}
-	if v {
-		h.lgr.Info("Sending entry %s %s", ts.String(), string(b))
-	}
+	debugout("Sending entry %+v", e)
 	return
 }


### PR DESCRIPTION
Cleaning up some debug functionality, removing some fmt usage, and adding a new listener type that should be fully compatible with the Splunk HEC system.

This way applications that have been designed against HEC can just point at our ingester and "just work"