### PR TITLE
Make kitctl way more intelligent

### DIFF
--- a/client/templates.go
+++ b/client/templates.go
@@ -9,8 +9,10 @@
 package client
 
 import (
-	"github.com/gravwell/gravwell/v3/client/types"
+	"encoding/json"
 	"net/http"
+
+	"github.com/gravwell/gravwell/v3/client/types"
 
 	"github.com/google/uuid"
 )
@@ -38,7 +40,12 @@ func (c *Client) ListAllTemplates() (templates []types.WireUserTemplate, err err
 // NewTemplate creates a new template with the given GUID, name, description, contents.
 // If guid is set to uuid.Nil, a random GUID will be chosen automatically.
 func (c *Client) NewTemplate(guid uuid.UUID, name, description string, contents types.RawObject) (storedGuid uuid.UUID, err error) {
-	template := types.UserTemplate{GUID: guid, Contents: contents, Name: name, Description: description}
+	// Mash the content blob into an appropriate type
+	var ct types.TemplateContents
+	if err = json.Unmarshal(contents, &c); err != nil {
+		return
+	}
+	template := types.UserTemplate{GUID: guid, Contents: ct, Name: name, Description: description}
 	err = c.methodStaticPushURL(http.MethodPost, templatesUrl(), template, &storedGuid)
 	return
 }

--- a/client/types/autoextract.go
+++ b/client/types/autoextract.go
@@ -32,7 +32,7 @@ type AXDefinition struct {
 	Name        string    `toml:"name,omitempty" json:",omitempty"`
 	Desc        string    `toml:"desc,omitempty" json:",omitempty"`
 	Module      string    `toml:"module"`
-	Params      string    `toml:"params"`
+	Params      string    `toml:"params" json:",omitempty"`
 	Args        string    `toml:"args,omitempty" json:",omitempty"`
 	Tag         string    `toml:"tag"`
 	Labels      []string  `toml:"-"`

--- a/client/types/kits/types.go
+++ b/client/types/kits/types.go
@@ -23,7 +23,7 @@ import (
 type PackedMacro struct {
 	Name        string
 	Description string
-	Expansion   string
+	Expansion   string `json:",omitempty"`
 	Labels      []string
 }
 

--- a/client/types/playbooks.go
+++ b/client/types/playbooks.go
@@ -25,8 +25,8 @@ type Playbook struct {
 	Global      bool
 	Name        string
 	Desc        string
-	Body        []byte
-	Metadata    []byte
+	Body        []byte `json:",omitempty"`
+	Metadata    []byte `json:",omitempty"`
 	Labels      []string
 	LastUpdated time.Time
 	Author      AuthorInfo

--- a/client/types/things.go
+++ b/client/types/things.go
@@ -83,12 +83,28 @@ func (t *Thing) DecodeContents(obj interface{}) error {
 	return nil
 }
 
+// TemplateContents is what goes in the template's Contents field. This is entirely
+// the domain of the GUI.
+type TemplateContents struct {
+	Query     string             `json:"query,omitempty"`
+	Variables []TemplateVariable `json:"variables"`
+}
+
+type TemplateVariable struct {
+	Name         string `json:"name"`
+	Label        string `json:"label"`
+	Description  string `json:"description"`
+	Required     bool   `json:"required"`
+	DefaultValue string `json:"defaultValue"`
+	PreviewValue string `json:"previewValue"`
+}
+
 // UserTemplate is what is stored in the "thing" object, it is encoded into Contents
 type UserTemplate struct {
 	GUID        uuid.UUID
 	Name        string
 	Description string
-	Contents    RawObject
+	Contents    TemplateContents
 	Labels      []string
 }
 
@@ -111,7 +127,7 @@ type WireUserTemplate struct {
 	GUID        uuid.UUID
 	Name        string
 	Description string
-	Contents    RawObject
+	Contents    TemplateContents
 	Updated     time.Time
 	Labels      []string
 }
@@ -142,7 +158,7 @@ type PackedUserTemplate struct {
 	UUID        string
 	Name        string
 	Description string
-	Data        RawObject
+	Data        TemplateContents
 	Labels      []string
 }
 
@@ -270,7 +286,7 @@ type UserFile struct {
 	GUID     uuid.UUID
 	Name     string
 	Desc     string
-	Contents []byte
+	Contents []byte `json:",omitempty"`
 	Labels   []string
 }
 
@@ -361,7 +377,7 @@ func (wsl WireSearchLibrary) Thing() (t Thing, err error) {
 type SearchLibrary struct {
 	Name        string
 	Description string
-	Query       string
+	Query       string `json:",omitempty"`
 	GUID        uuid.UUID
 	Labels      []string  `json:",omitempty"`
 	Metadata    RawObject `json:",omitempty"`

--- a/kitctl/main.go
+++ b/kitctl/main.go
@@ -203,7 +203,7 @@ func packKit(args []string) {
 			}
 		case kits.Template:
 			var x types.PackedUserTemplate
-			if err := genericRead(wd, itm, &x); err != nil {
+			if x, err = readTemplate(wd, itm.Name); err != nil {
 				log.Fatalf("Could not read %v %v: %v", itm.Type.String(), itm.Name, err)
 			}
 			if err := marshallAdd(itm, x); err != nil {
@@ -220,7 +220,7 @@ func packKit(args []string) {
 		// Other types just ship as-is
 		case kits.Extractor:
 			var x types.AXDefinition
-			if err := genericRead(wd, itm, &x); err != nil {
+			if x, err = readExtractor(wd, itm.Name); err != nil {
 				log.Fatalf("Could not read %v %v: %v", itm.Type.String(), itm.Name, err)
 			}
 			if err := marshallAdd(itm, x); err != nil {
@@ -228,7 +228,7 @@ func packKit(args []string) {
 			}
 		case kits.File:
 			var x types.UserFile
-			if err := genericRead(wd, itm, &x); err != nil {
+			if x, err = readUserFile(wd, itm.Name); err != nil {
 				log.Fatalf("Could not read %v %v: %v", itm.Type.String(), itm.Name, err)
 			}
 			if err := marshallAdd(itm, x); err != nil {
@@ -236,7 +236,7 @@ func packKit(args []string) {
 			}
 		case kits.SearchLibrary:
 			var x types.WireSearchLibrary
-			if err := genericRead(wd, itm, &x); err != nil {
+			if x, err = readSearchLibrary(wd, itm.Name); err != nil {
 				log.Fatalf("Could not read %v %v: %v", itm.Type.String(), itm.Name, err)
 			}
 			if err := marshallAdd(itm, x); err != nil {
@@ -244,7 +244,7 @@ func packKit(args []string) {
 			}
 		case kits.Playbook:
 			var x types.Playbook
-			if err := genericRead(wd, itm, &x); err != nil {
+			if x, err = readPlaybook(wd, itm.Name); err != nil {
 				log.Fatalf("Could not read %v %v: %v", itm.Type.String(), itm.Name, err)
 			}
 			if err := marshallAdd(itm, x); err != nil {
@@ -370,7 +370,7 @@ func unpackKit(args []string) {
 			if err = json.NewDecoder(rdr).Decode(&p); err != nil {
 				return fmt.Errorf("Failed to decode %v %v: %v", tp.String(), name, err)
 			}
-			if err := genericWrite(wd, tp, name, p); err != nil {
+			if err := writeTemplate(wd, name, p); err != nil {
 				return fmt.Errorf("Failed to write out %v %v: %v", tp.String(), name, err)
 			}
 		case kits.Pivot:
@@ -390,7 +390,7 @@ func unpackKit(args []string) {
 			if err = p.Validate(); err != nil {
 				return fmt.Errorf("Failed to validate extractor %v: %v", name, err)
 			}
-			if err := genericWrite(wd, tp, name, p); err != nil {
+			if err := writeExtractor(wd, name, p); err != nil {
 				return fmt.Errorf("Failed to write out %v %v: %v", tp.String(), name, err)
 			}
 		case kits.File:
@@ -398,7 +398,7 @@ func unpackKit(args []string) {
 			if err = json.NewDecoder(rdr).Decode(&p); err != nil {
 				return fmt.Errorf("Failed to decode %v %v: %v", tp.String(), name, err)
 			}
-			if err := genericWrite(wd, tp, name, p); err != nil {
+			if err := writeUserFile(wd, name, p); err != nil {
 				return fmt.Errorf("Failed to write out %v %v: %v", tp.String(), name, err)
 			}
 		case kits.SearchLibrary:
@@ -406,7 +406,7 @@ func unpackKit(args []string) {
 			if err = json.NewDecoder(rdr).Decode(&p); err != nil {
 				return fmt.Errorf("Failed to decode %v %v: %v", tp.String(), name, err)
 			}
-			if err := genericWrite(wd, tp, name, p); err != nil {
+			if err := writeSearchLibrary(wd, name, p); err != nil {
 				return fmt.Errorf("Failed to write out %v %v: %v", tp.String(), name, err)
 			}
 		case kits.Playbook:
@@ -414,7 +414,7 @@ func unpackKit(args []string) {
 			if err = json.NewDecoder(rdr).Decode(&p); err != nil {
 				return fmt.Errorf("Failed to decode %v %v: %v", tp.String(), name, err)
 			}
-			if err := genericWrite(wd, tp, name, p); err != nil {
+			if err := writePlaybook(wd, name, p); err != nil {
 				return fmt.Errorf("Failed to write out %v %v: %v", tp.String(), name, err)
 			}
 		case kits.License:


### PR DESCRIPTION
Now breaks out far more fields when it unpacks. To properly deal with templates, we had to include the data type the GUI uses, so we can extract the query into its own file.