### PR TITLE
Implement custom marshaller for types.Element 

### DIFF
--- a/client/types/marshallers_test.go
+++ b/client/types/marshallers_test.go
@@ -119,7 +119,7 @@ func TestSearchEntryEncodeDecodeRaw(t *testing.T) {
 }
 
 func TestElementNull(t *testing.T) {
-	// Test with an empty []byte
+	// Test with the field unset
 	s := Element{
 		Module:  "syslog",
 		Name:    "MsgID",
@@ -128,6 +128,25 @@ func TestElementNull(t *testing.T) {
 	}
 	var b []byte
 	var err error
+	if b, err = json.Marshal(s); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), "null") {
+		t.Fatalf("Found null in %v", string(b))
+	}
+
+	// Get a little trickier
+	type foo struct {
+		v []byte
+	}
+	var f foo
+	s = Element{
+		Module:  "syslog",
+		Name:    "MsgID",
+		Path:    "MsgID",
+		Value:   f.v,
+		Filters: []string{"=="},
+	}
 	if b, err = json.Marshal(s); err != nil {
 		t.Fatal(err)
 	}

--- a/client/types/marshallers_test.go
+++ b/client/types/marshallers_test.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -115,4 +116,38 @@ func TestSearchEntryEncodeDecodeRaw(t *testing.T) {
 	} else if !s.Equal(d) {
 		t.Fatalf("EncodeDecode failed:\n%+v\n%+v", s, d)
 	}
+}
+
+func TestElementNull(t *testing.T) {
+	// Test with an empty []byte
+	s := Element{
+		Module:  "syslog",
+		Name:    "MsgID",
+		Path:    "MsgID",
+		Filters: []string{"=="},
+	}
+	var b []byte
+	var err error
+	if b, err = json.Marshal(s); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), "null") {
+		t.Fatalf("Found null in %v", string(b))
+	}
+
+	// Test with an empty string to make sure we set Value in that case
+	s = Element{
+		Module:  "syslog",
+		Name:    "MsgID",
+		Path:    "MsgID",
+		Value:   "",
+		Filters: []string{"=="},
+	}
+	if b, err = json.Marshal(s); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "Value") {
+		t.Fatalf("No Value in %v", string(b))
+	}
+
 }

--- a/client/types/search.go
+++ b/client/types/search.go
@@ -49,6 +49,28 @@ type Element struct {
 	Filters     []string
 }
 
+// MarshalJSON implemented so we can avoid sending a "null" Value.
+func (e Element) MarshalJSON() ([]byte, error) {
+	// Handle the nil Value first
+	if e.Value == nil {
+		return json.Marshal(&struct {
+			Module      string
+			Name        string
+			Path        string
+			SubElements []Element `json:",omitempty"`
+			Filters     []string
+		}{
+			Module:      e.Module,
+			Name:        e.Name,
+			Path:        e.Path,
+			SubElements: e.SubElements,
+			Filters:     e.Filters,
+		})
+	}
+	type alias Element
+	return json.Marshal(alias(e))
+}
+
 // A GenerateAXRequest contains a tag name and a set of entries.
 // It is used by clients to request all possible extractions from the given entries.
 // All entries should have the same tag.

--- a/client/types/search.go
+++ b/client/types/search.go
@@ -52,7 +52,7 @@ type Element struct {
 // MarshalJSON implemented so we can avoid sending a "null" Value.
 func (e Element) MarshalJSON() ([]byte, error) {
 	// Handle the nil Value first
-	if e.Value == nil {
+	if vb, ok := e.Value.([]byte); e.Value == nil || (ok && len(vb) == 0) {
 		return json.Marshal(&struct {
 			Module      string
 			Name        string


### PR DESCRIPTION
We don't want to send a "null" value, so this implements a little bit of logic to get around that.