### PR TITLE
Change behavior of notification functions to handle random notificati…

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -79,8 +79,8 @@ type Client struct {
 // The ActiveSession structure represents a login session on the server. The
 // JWT field contains a negotiated authentication token (with expiration).
 type ActiveSession struct {
-	JWT                string
-	LastNotificationID uint64
+	JWT                  string
+	LastNotificationTime time.Time
 }
 
 func init() {


### PR DESCRIPTION
…on IDs

Notification IDs are now random instead of monotonically
increasing, so you can't say "give me all notifications
after #3". Instead, we set a timestamp in the request,
e.g. ?after=2006-01-02T15:04:05.999999999Z07. This change makes the
MyNewNotification* functions properly handle this.