### PR TITLE
WIP: Rework how ingesters log.

### DIFF
--- a/ingest/gravwell_log.go
+++ b/ingest/gravwell_log.go
@@ -39,14 +39,14 @@ func (im *IngestMuxer) Errorf(format string, args ...interface{}) error {
 
 func (im *IngestMuxer) Warnf(format string, args ...interface{}) error {
 	if im.lgr != nil {
-		im.lgr.WarnfWithDepth(4, format, args...)
+		return im.lgr.WarnfWithDepth(4, format, args...)
 	}
 	return nil
 }
 
 func (im *IngestMuxer) Infof(format string, args ...interface{}) error {
 	if im.lgr != nil {
-		im.lgr.InfofWithDepth(4, format, args...)
+		return im.lgr.InfofWithDepth(4, format, args...)
 	}
 	return nil
 }
@@ -54,21 +54,21 @@ func (im *IngestMuxer) Infof(format string, args ...interface{}) error {
 // Error send an error entry down the line with the gravwell tag
 func (im *IngestMuxer) Error(msg string, args ...rfc5424.SDParam) error {
 	if im.lgr != nil {
-		im.lgr.ErrorWithDepth(4, msg, args...)
+		return im.lgr.ErrorWithDepth(4, msg, args...)
 	}
 	return nil
 }
 
 func (im *IngestMuxer) Warn(msg string, args ...rfc5424.SDParam) error {
 	if im.lgr != nil {
-		im.lgr.WarnWithDepth(4, msg, args...)
+		return im.lgr.WarnWithDepth(4, msg, args...)
 	}
 	return nil
 }
 
 func (im *IngestMuxer) Info(msg string, args ...rfc5424.SDParam) error {
 	if im.lgr != nil {
-		im.lgr.InfoWithDepth(4, msg, args...)
+		return im.lgr.InfoWithDepth(4, msg, args...)
 	}
 	return nil
 }

--- a/ingest/muxer.go
+++ b/ingest/muxer.go
@@ -110,7 +110,6 @@ type IngestMuxer struct {
 	errChan           chan error
 	wg                *sync.WaitGroup
 	state             muxState
-	logLevel          gll
 	hostname          string
 	appname           string
 	lgr               Logger
@@ -141,7 +140,7 @@ type UniformMuxerConfig struct {
 	CachePath         string
 	CacheSize         int
 	CacheMode         string
-	LogLevel          string
+	LogLevel          string // deprecated, no longer used
 	Logger            Logger
 	IngesterName      string
 	IngesterVersion   string
@@ -162,7 +161,7 @@ type MuxerConfig struct {
 	CachePath         string
 	CacheSize         int
 	CacheMode         string
-	LogLevel          string
+	LogLevel          string // deprecated, no longer used
 	Logger            Logger
 	IngesterName      string
 	IngesterVersion   string
@@ -370,7 +369,6 @@ func newIngestMuxer(c MuxerConfig) (*IngestMuxer, error) {
 		wg:                &sync.WaitGroup{},
 		state:             empty,
 		lgr:               c.Logger,
-		logLevel:          logLevel(c.LogLevel),
 		hostname:          c.Logger.Hostname(),
 		appname:           c.Logger.Appname(),
 		eChan:             cache.In,

--- a/ingesters/GooglePubSubIngester/main.go
+++ b/ingesters/GooglePubSubIngester/main.go
@@ -125,7 +125,6 @@ func main() {
 		Destinations:       conns,
 		Tags:               tags,
 		Auth:               cfg.Secret(),
-		LogLevel:           cfg.LogLevel(),
 		Logger:             lg,
 		IngesterName:       "GooglePubSub",
 		IngesterVersion:    version.GetVersion(),
@@ -144,6 +143,7 @@ func main() {
 	}
 	defer igst.Close()
 	debugout("Starting ingester muxer\n")
+	lg.AddRelay(igst)
 	if err := igst.Start(); err != nil {
 		lg.Fatal("failed start our ingest system", log.KVErr(err))
 	}

--- a/ingesters/HttpIngester/main.go
+++ b/ingesters/HttpIngester/main.go
@@ -129,7 +129,6 @@ func main() {
 		Destinations:       conns,
 		Tags:               tags,
 		Auth:               cfg.Secret(),
-		LogLevel:           cfg.LogLevel(),
 		VerifyCert:         !cfg.InsecureSkipTLSVerification(),
 		Logger:             lg,
 		IngesterName:       "httppost",
@@ -148,6 +147,7 @@ func main() {
 		lg.Fatal("failed to create new uniform muxer", log.KVErr(err))
 	}
 	debugout("Started ingester muxer\n")
+	lg.AddRelay(igst)
 	if err := igst.Start(); err != nil {
 		lg.Fatal("failed start our ingest system", log.KVErr(err))
 	}

--- a/ingesters/IPMIIngester/main.go
+++ b/ingesters/IPMIIngester/main.go
@@ -148,7 +148,6 @@ func main() {
 		Destinations:       conns,
 		Tags:               tags,
 		Auth:               cfg.Global.Secret(),
-		LogLevel:           cfg.Global.LogLevel(),
 		VerifyCert:         !cfg.Global.InsecureSkipTLSVerification(),
 		IngesterName:       ingesterName,
 		IngesterVersion:    version.GetVersion(),
@@ -167,8 +166,8 @@ func main() {
 		lg.Fatal("failed build our ingest system", log.KVErr(err))
 		return
 	}
-
 	defer igst.Close()
+	lg.AddRelay(igst)
 
 	if err := igst.Start(); err != nil {
 		lg.Fatal("failed start our ingest system", log.KVErr(err))

--- a/ingesters/KinesisIngester/main.go
+++ b/ingesters/KinesisIngester/main.go
@@ -167,7 +167,6 @@ func main() {
 		Destinations:       conns,
 		Tags:               tags,
 		Auth:               cfg.Secret(),
-		LogLevel:           cfg.LogLevel(),
 		Logger:             lg,
 		IngesterName:       appName,
 		IngesterVersion:    version.GetVersion(),
@@ -186,6 +185,8 @@ func main() {
 	}
 	defer igst.Close()
 	debugout("Starting ingester muxer\n")
+	// Henceforth, logs will also go out via the muxer to the gravwell tag
+	lg.AddRelay(igst)
 	if err := igst.Start(); err != nil {
 		lg.Fatal("failed start our ingest system", log.KVErr(err))
 		return
@@ -275,10 +276,10 @@ func main() {
 						if stream.JSON_Metrics {
 							jr, err := json.Marshal(report)
 							if err == nil {
-								igst.Infof("%v", string(jr))
+								lg.Infof("%v", string(jr))
 							}
 						} else {
-							igst.Info("stream stats",
+							lg.Info("stream stats",
 								log.KV("stream", stream.Stream_Name),
 								log.KV("shards", len(shards)),
 								log.KV("delay", report.AverageLag),

--- a/ingesters/MSGraphIngester/main.go
+++ b/ingesters/MSGraphIngester/main.go
@@ -133,7 +133,6 @@ func main() {
 		Destinations:       conns,
 		Tags:               tags,
 		Auth:               cfg.Secret(),
-		LogLevel:           cfg.LogLevel(),
 		Logger:             lg,
 		IngesterName:       "Microsoft Graph",
 		IngesterVersion:    version.GetVersion(),
@@ -144,6 +143,7 @@ func main() {
 		CachePath:          cfg.Global.Ingest_Cache_Path,
 		CacheSize:          cfg.Global.Max_Ingest_Cache,
 		CacheMode:          cfg.Global.Cache_Mode,
+		LogSourceOverride:  net.ParseIP(cfg.Global.Log_Source_Override),
 	}
 	igst, err := ingest.NewUniformMuxer(ingestConfig)
 	if err != nil {
@@ -151,6 +151,7 @@ func main() {
 	}
 	defer igst.Close()
 	debugout("Starting ingester muxer\n")
+	lg.AddRelay(igst)
 	if err := igst.Start(); err != nil {
 		lg.Fatal("failed start our ingest system", log.KVErr(err))
 		return

--- a/ingesters/O365Ingester/main.go
+++ b/ingesters/O365Ingester/main.go
@@ -133,7 +133,6 @@ func main() {
 		Destinations:       conns,
 		Tags:               tags,
 		Auth:               cfg.Secret(),
-		LogLevel:           cfg.LogLevel(),
 		Logger:             lg,
 		IngesterName:       "Office 365",
 		IngesterVersion:    version.GetVersion(),
@@ -152,6 +151,7 @@ func main() {
 	}
 	defer igst.Close()
 	debugout("Starting ingester muxer\n")
+	lg.AddRelay(igst)
 	if err := igst.Start(); err != nil {
 		lg.Fatal("failed start our ingest system", log.KVErr(err))
 		return

--- a/ingesters/PacketFleet/main.go
+++ b/ingesters/PacketFleet/main.go
@@ -191,7 +191,6 @@ func main() {
 		Destinations:       conns,
 		Tags:               tags,
 		Auth:               cfg.Global.Secret(),
-		LogLevel:           cfg.Global.LogLevel(),
 		VerifyCert:         !cfg.Global.InsecureSkipTLSVerification(),
 		IngesterName:       ingesterName,
 		IngesterVersion:    version.GetVersion(),
@@ -213,6 +212,7 @@ func main() {
 
 	defer igst.Close()
 	debugout("Started ingester muxer\n")
+	lg.AddRelay(igst)
 	if err := igst.Start(); err != nil {
 		lg.Fatal("failed start our ingest system", log.KVErr(err))
 		return

--- a/ingesters/SimpleRelay/json.go
+++ b/ingesters/SimpleRelay/json.go
@@ -175,7 +175,7 @@ func jsonAcceptor(lst net.Listener, id int, igst *ingest.IngestMuxer, cfg jsonHa
 			continue
 		}
 		debugout("Accepted %v connection from %s in json mode\n", tp.String(), conn.RemoteAddr())
-		igst.Info("accepted connection in json mode", log.KV("localaddress", tp.String()), log.KV("remoteaddress", conn.RemoteAddr()))
+		lg.Info("accepted connection in json mode", log.KV("localaddress", tp.String()), log.KV("remoteaddress", conn.RemoteAddr()))
 		failCount = 0
 		go jsonConnHandler(conn, cfg, igst)
 	}
@@ -197,11 +197,11 @@ func jsonConnHandler(c net.Conn, cfg jsonHandlerConfig, igst *ingest.IngestMuxer
 	if cfg.src == nil {
 		ipstr, _, err := net.SplitHostPort(c.RemoteAddr().String())
 		if err != nil {
-			igst.Error("failed to get host from remote addr", log.KV("remoteaddress", c.RemoteAddr().String()), log.KVErr(err))
+			lg.Error("failed to get host from remote addr", log.KV("remoteaddress", c.RemoteAddr().String()), log.KVErr(err))
 			return
 		}
 		if rip = net.ParseIP(ipstr); rip == nil {
-			igst.Error("failed to get remote address", log.KV("remoteaddress", ipstr))
+			lg.Error("failed to get remote address", log.KV("remoteaddress", ipstr))
 			return
 		}
 	} else {
@@ -216,10 +216,10 @@ func jsonConnHandler(c net.Conn, cfg jsonHandlerConfig, igst *ingest.IngestMuxer
 		}
 		tg, err = timegrinder.NewTimeGrinder(tcfg)
 		if err != nil {
-			igst.Error("failed to get a handle on the timegrinder", log.KVErr(err))
+			lg.Error("failed to get a handle on the timegrinder", log.KVErr(err))
 			return
 		} else if err = cfg.timeFormats.LoadFormats(tg); err != nil {
-			igst.Error("failed to load custom time formats", log.KVErr(err))
+			lg.Error("failed to load custom time formats", log.KVErr(err))
 			return
 		}
 		if cfg.setLocalTime {
@@ -228,7 +228,7 @@ func jsonConnHandler(c net.Conn, cfg jsonHandlerConfig, igst *ingest.IngestMuxer
 		if cfg.timezoneOverride != `` {
 			err = tg.SetTimezone(cfg.timezoneOverride)
 			if err != nil {
-				igst.Error("failed to set timezone", log.KV("timezone", cfg.timezoneOverride), log.KVErr(err))
+				lg.Error("failed to set timezone", log.KV("timezone", cfg.timezoneOverride), log.KVErr(err))
 				return
 			}
 		}
@@ -248,7 +248,7 @@ func jsonConnHandler(c net.Conn, cfg jsonHandlerConfig, igst *ingest.IngestMuxer
 			var extracted time.Time
 			extracted, ok, err = tg.Extract(data)
 			if err != nil {
-				igst.Error("catastrophic timegrinder failure", log.KVErr(err))
+				lg.Error("catastrophic timegrinder failure", log.KVErr(err))
 				return
 			} else if ok {
 				ts = entry.FromStandard(extracted)

--- a/ingesters/SimpleRelay/main.go
+++ b/ingesters/SimpleRelay/main.go
@@ -149,18 +149,17 @@ func main() {
 		Destinations:       conns,
 		Tags:               tags,
 		Auth:               cfg.Secret(),
-		LogLevel:           cfg.LogLevel(),
 		VerifyCert:         !cfg.InsecureSkipTLSVerification(),
 		IngesterName:       ingesterName,
 		IngesterVersion:    version.GetVersion(),
 		IngesterUUID:       id.String(),
 		IngesterLabel:      cfg.Label,
 		RateLimitBps:       lmt,
-		Logger:             lg,
 		CacheDepth:         cfg.Cache_Depth,
 		CachePath:          cfg.Ingest_Cache_Path,
 		CacheSize:          cfg.Max_Ingest_Cache,
 		CacheMode:          cfg.Cache_Mode,
+		Logger:             lg,
 		LogSourceOverride:  net.ParseIP(cfg.Log_Source_Override),
 	}
 	igst, err := ingest.NewUniformMuxer(igCfg)
@@ -170,11 +169,13 @@ func main() {
 	}
 	defer igst.Close()
 	debugout("Started ingester muxer\n")
-
+	// Henceforth, logs will also go out via the muxer to the gravwell tag
+	lg.AddRelay(igst)
 	if err := igst.Start(); err != nil {
 		lg.Fatal("failed start our ingest system", log.KVErr(err))
 		return
 	}
+
 	debugout("Waiting for connections to indexers ... ")
 	if err := igst.WaitForHot(cfg.Timeout()); err != nil {
 		lg.FatalCode(0, "timeout waiting for backend connections", log.KV("timeout", cfg.Timeout()), log.KVErr(err))
@@ -185,7 +186,7 @@ func main() {
 	// prepare the configuration we're going to send upstream
 	err = igst.SetRawConfiguration(cfg)
 	if err != nil {
-		lg.FatalCode(0, "failed to set configuration for ingester state messages", log.KVErr(err))
+		lg.FatalCode(0, "failed to set configuration for ingester state messages", log.KV("ingesteruuid", id), log.KVErr(err))
 	}
 
 	wg := &sync.WaitGroup{}
@@ -196,20 +197,21 @@ func main() {
 
 	//fire off our simple listeners
 	if err := startSimpleListeners(cfg, igst, wg, &flshr, ctx); err != nil {
-		lg.FatalCode(0, "Failed to start simple listeners", log.KVErr(err))
+		lg.FatalCode(0, "Failed to start simple listeners", log.KV("ingesteruuid", id), log.KVErr(err))
 		return
 	}
 	//fire off our json listeners
 	if err := startJSONListeners(cfg, igst, wg, &flshr, ctx); err != nil {
-		lg.FatalCode(0, "Failed to start json listeners", log.KVErr(err))
+		lg.FatalCode(0, "Failed to start json listeners", log.KV("ingesteruuid", id), log.KVErr(err))
 		return
 	}
 
-	debugout("Running\n")
+	lg.Info("Ingester running")
 
 	//listen for signals so we can close gracefully
 	utils.WaitForQuit()
 	debugout("Closing %d connections\n", connCount())
+	lg.Info("Closing active connections", log.KV("ingesteruuid", id), log.KV("active", connCount()))
 
 	go func() {
 		time.Sleep(time.Second)
@@ -237,7 +239,7 @@ func main() {
 	if err := flshr.Close(); err != nil {
 		lg.Error("failed to close preprocessors", log.KVErr(err))
 	}
-	lg.Info("simplerelay ingester exiting", log.KV("ingesteruuid", id))
+	lg.Info("Ingester exiting", log.KV("ingesteruuid", id))
 	if err := igst.Sync(time.Second); err != nil {
 		lg.Error("failed to sync", log.KVErr(err))
 	}

--- a/ingesters/SimpleRelay/simple.go
+++ b/ingesters/SimpleRelay/simple.go
@@ -167,14 +167,14 @@ func acceptor(lst net.Listener, id int, igst *ingest.IngestMuxer, cfg handlerCon
 				break
 			}
 			failCount++
-			igst.Warn("failed to accept TCP connection", log.KVErr(err))
+			lg.Warn("failed to accept TCP connection", log.KVErr(err))
 			if failCount > 3 {
 				break
 			}
 			continue
 		}
 		debugout("Accepted %v connection from %s in %v mode\n", conn.RemoteAddr(), cfg.lrt, tp.String())
-		igst.Info("accepted connection", log.KV("address", conn.RemoteAddr()), log.KV("readertype", cfg.lrt), log.KV("mode", tp))
+		lg.Info("accepted connection", log.KV("address", conn.RemoteAddr()), log.KV("readertype", cfg.lrt), log.KV("mode", tp))
 		failCount = 0
 		switch cfg.lrt {
 		case lineReader:
@@ -182,7 +182,7 @@ func acceptor(lst net.Listener, id int, igst *ingest.IngestMuxer, cfg handlerCon
 		case rfc5424Reader:
 			go rfc5424ConnHandlerTCP(conn, cfg)
 		default:
-			igst.Error("invalid reader type", log.KV("readertype", cfg.lrt))
+			lg.Error("invalid reader type", log.KV("readertype", cfg.lrt))
 			return
 		}
 	}
@@ -199,7 +199,7 @@ func acceptorUDP(conn *net.UDPConn, id int, cfg handlerConfig, igst *ingest.Inge
 	case rfc5424Reader:
 		rfc5424ConnHandlerUDP(conn, cfg)
 	default:
-		igst.Error("invalid reader type", log.KV("readertype", cfg.lrt))
+		lg.Error("invalid reader type", log.KV("readertype", cfg.lrt))
 		return
 	}
 }

--- a/ingesters/collectd/main.go
+++ b/ingesters/collectd/main.go
@@ -136,7 +136,6 @@ func main() {
 		Destinations:       conns,
 		Tags:               tags,
 		Auth:               cfg.Secret(),
-		LogLevel:           cfg.LogLevel(),
 		VerifyCert:         !cfg.InsecureSkipTLSVerification(),
 		IngesterName:       ingesterName,
 		IngesterVersion:    version.GetVersion(),
@@ -155,6 +154,7 @@ func main() {
 		lg.Fatal("failed build our ingest system", log.KVErr(err))
 	}
 	debugout("Started ingester muxer\n")
+	lg.AddRelay(igst)
 	if err := igst.Start(); err != nil {
 		lg.Fatal("failed start our ingest system", log.KVErr(err))
 	}

--- a/ingesters/fileFollow/main_linux.go
+++ b/ingesters/fileFollow/main_linux.go
@@ -131,7 +131,6 @@ func main() {
 		Destinations:       conns,
 		Tags:               tags,
 		Auth:               cfg.Secret(),
-		LogLevel:           cfg.LogLevel(),
 		IngesterName:       "filefollow",
 		IngesterVersion:    version.GetVersion(),
 		IngesterUUID:       id.String(),
@@ -151,6 +150,7 @@ func main() {
 	}
 	defer igst.Close()
 	debugout("Starting ingester muxer\n")
+	lg.AddRelay(igst)
 	if err := igst.Start(); err != nil {
 		lg.Fatal("failed start our ingest system", log.KVErr(err))
 		return

--- a/ingesters/kafka_consumer/main.go
+++ b/ingesters/kafka_consumer/main.go
@@ -149,7 +149,6 @@ func main() {
 		Destinations:       conns,
 		Tags:               ltags,
 		Auth:               cfg.Secret(),
-		LogLevel:           cfg.LogLevel(),
 		VerifyCert:         !cfg.InsecureSkipTLSVerification(),
 		IngesterName:       ingesterName,
 		RateLimitBps:       lmt,
@@ -169,6 +168,7 @@ func main() {
 
 	defer igst.Close()
 	debugout("Started ingester muxer\n")
+	lg.AddRelay(igst)
 	if err := igst.Start(); err != nil {
 		lg.Fatal("failed start our ingest system", log.KVErr(err))
 		return

--- a/ingesters/netflow/main.go
+++ b/ingesters/netflow/main.go
@@ -141,7 +141,6 @@ func main() {
 		Destinations:       conns,
 		Tags:               tags,
 		Auth:               cfg.Secret(),
-		LogLevel:           cfg.LogLevel(),
 		VerifyCert:         !cfg.InsecureSkipTLSVerification(),
 		IngesterName:       ingesterName,
 		IngesterVersion:    version.GetVersion(),
@@ -162,6 +161,7 @@ func main() {
 
 	defer igst.Close()
 	debugout("Started ingester muxer\n")
+	lg.AddRelay(igst)
 	if err := igst.Start(); err != nil {
 		lg.FatalCode(0, "failed start our ingest system", log.KVErr(err))
 	}
@@ -218,7 +218,7 @@ func main() {
 				return
 			}
 		case ipfixType:
-			if bh, err = NewIpfixHandler(bc, igst); err != nil {
+			if bh, err = NewIpfixHandler(bc); err != nil {
 				lg.FatalCode(0, "NewIpfixHandler failed", log.KVErr(err))
 				return
 			}

--- a/ingesters/networkLog/main.go
+++ b/ingesters/networkLog/main.go
@@ -167,18 +167,17 @@ func main() {
 		Destinations:       conns,
 		Tags:               tags,
 		Auth:               cfg.Secret(),
-		LogLevel:           cfg.LogLevel(),
 		IngesterName:       ingesterName,
 		IngesterVersion:    version.GetVersion(),
 		IngesterUUID:       id.String(),
 		IngesterLabel:      cfg.Label,
 		RateLimitBps:       lmt,
 		VerifyCert:         !cfg.InsecureSkipTLSVerification(),
-		Logger:             lg,
 		CacheDepth:         cfg.Cache_Depth,
 		CachePath:          cfg.Ingest_Cache_Path,
 		CacheSize:          cfg.Max_Ingest_Cache,
 		CacheMode:          cfg.Cache_Mode,
+		Logger:             lg,
 		LogSourceOverride:  net.ParseIP(cfg.Log_Source_Override),
 	}
 	igst, err := ingest.NewUniformMuxer(igCfg)
@@ -186,9 +185,12 @@ func main() {
 		lg.Fatal("failed build our ingest system", log.KVErr(err))
 	}
 	debugout("Started ingester muxer\n")
+	// Henceforth, logs will also go out via the muxer to the gravwell tag
+	lg.AddRelay(igst)
 	if err := igst.Start(); err != nil {
 		lg.Fatal("failed start our ingest system", log.KVErr(err))
 	}
+
 	debugout("Waiting for connections to indexers\n")
 	if err := igst.WaitForHot(cfg.Timeout()); err != nil {
 		lg.FatalCode(0, "timeout waiting for backend connections", log.KV("timeout", cfg.Timeout()), log.KVErr(err))
@@ -416,11 +418,11 @@ mainLoop:
 		case pkts, ok := <-ch: //get a packet
 			if !ok {
 				//Something bad happened, attempt to restart the pcap
-				igst.Error("failed to read next packet, attempting to rebuild packet source")
+				lg.Error("failed to read packet, attempting to rebuild packet source")
 				s.handle.Close()
 				s.handle, ok = rebuildPacketSource(s)
 				if !ok {
-					igst.Error("couldn't rebuild packet start")
+					lg.Error("couldn't rebuild packet source")
 					//Still failing, time to bail out
 					break mainLoop
 				}
@@ -428,7 +430,7 @@ mainLoop:
 				ch = make(chan []capPacket, 1024)
 				go packetExtractor(s.handle, ch)
 				debugout("Rebuilding packet source\n")
-				igst.Info("rebuilt packet source")
+				lg.Info("rebuilt packet source")
 				continue
 			}
 			staticSet := make([]entry.Entry, len(pkts))

--- a/ingesters/sqsIngester/main.go
+++ b/ingesters/sqsIngester/main.go
@@ -163,7 +163,6 @@ func main() {
 		Destinations:       conns,
 		Tags:               tags,
 		Auth:               cfg.Secret(),
-		LogLevel:           cfg.LogLevel(),
 		VerifyCert:         !cfg.InsecureSkipTLSVerification(),
 		IngesterName:       ingesterName,
 		IngesterVersion:    version.GetVersion(),
@@ -185,6 +184,7 @@ func main() {
 
 	defer igst.Close()
 	debugout("Started ingester muxer\n")
+	lg.AddRelay(igst)
 	if err := igst.Start(); err != nil {
 		lg.Fatal("failed start our ingest system", log.KVErr(err))
 		return


### PR DESCRIPTION
Instead of having a bunch of logic for the ingest muxer to send logs to the
gravwell tag, instead just provide convenience functions which write to
the Logger which was passed in the config. In turn, that logger can set
the ingest muxer as a *relay*, which writes the log messages to the gravwell
tag. This has the side effect of getting *all* log messages into the gravwell
tag, provided you don't fill up the (generous) buffer before finally connecting
to an indexer.

Note: This is not yet ready, the rest of the ingesters need to be walked to deal with things properly. networkLog and SimpleRelay demonstrate what needs doing, though.