### PR TITLE
Change DebugPayloads and LastLogs into a single FlowResults map

### DIFF
--- a/client/types/scheduledsearch.go
+++ b/client/types/scheduledsearch.go
@@ -69,9 +69,8 @@ type ScheduledSearch struct {
 	ScriptLanguage ScriptLang // what script type is this: anko, go
 
 	// For scheduled flows
-	Flow          string                         // The flow specification itself
-	DebugPayloads map[int]map[string]interface{} // Outputs from each node
-	LastLogs      map[int]string                 // Logs from each node
+	Flow        string                 // The flow specification itself
+	FlowResults map[int]FlowNodeResult // results for each node in the flow
 
 	// These fields are updated by the search agent after it runs a search
 	PersistentMaps  map[string]map[string]interface{}
@@ -80,6 +79,14 @@ type ScheduledSearch struct {
 	LastSearchIDs   []string      // the IDs of the most recently performed searches
 	LastError       string        // any error from the last run of the scheduled search
 	DebugOutput     []byte        // output of the script if debugmode was enabled
+}
+
+type FlowNodeResult struct {
+	Payload map[string]interface{} // Only populated if the flow ran with the debug flag
+	Log     string
+	Error   error
+	Start   int64 // unix nanoseconds
+	End     int64 // unix nanoseconds
 }
 
 type ScheduledSearchParseRequest struct {


### PR DESCRIPTION
As we want to add more and more information about the execution of a flow, it makes sense to consolidate everything into a single struct per node of the flow