### PR TITLE
Add ErrorNode field to FlowParseResponse

### DIFF
--- a/client/types/scheduledsearch.go
+++ b/client/types/scheduledsearch.go
@@ -108,6 +108,7 @@ type FlowParseRequest struct {
 type FlowParseResponse struct {
 	OK             bool
 	Error          string `json:",omitempty"`
+	ErrorNode      int    // the node which failed to parse (ignore if Error is empty)
 	OutputPayloads map[int]map[string]interface{}
 }
 


### PR DESCRIPTION
This indicates which node, if any, failed to parse