### PR TITLE
addressing issue #343, its ok if the src is nil, so just pass it in

### DIFF
--- a/ingest/processors/srcrouter.go
+++ b/ingest/processors/srcrouter.go
@@ -123,7 +123,10 @@ func (sr *SrcRouter) processItem(ent *entry.Entry) *entry.Entry {
 
 func (sr *SrcRouter) handleExtract(v net.IP) (tag entry.EntryTag, drop, ok bool) {
 	//check if we have a tag
-	r, _ := sr.tree.FindCIDR(v.String())
+	var r interface{}
+	if v != nil {
+		r, _ = sr.tree.FindCIDR(v.String())
+	}
 	if r == nil {
 		drop = sr.Drop_Misses //straight not found
 	} else if _, ok = r.(bool); ok {

--- a/ingesters/fileFollow/main_linux.go
+++ b/ingesters/fileFollow/main_linux.go
@@ -178,8 +178,9 @@ func main() {
 		if src = net.ParseIP(cfg.Source_Override); src == nil {
 			lg.Fatal("Global Source-Override is invalid", log.KV("sourceoverride", cfg.Source_Override))
 		}
-	} else if src, err = igst.SourceIP(); err != nil {
-		lg.Fatal("failed to resolve source IP from muxer", log.KVErr(err))
+	} else {
+		//it is fine to set it to nil, it will be set by the ingest muxer, this can and WILL fail sometimes
+		src, _ = igst.SourceIP()
 	}
 
 	wtcher, err := filewatch.NewWatcher(cfg.StatePath())

--- a/ingesters/fileFollow/processing_windows.go
+++ b/ingesters/fileFollow/processing_windows.go
@@ -229,9 +229,9 @@ func (m *mainService) init(ctx context.Context) error {
 			errorout("Global Source-Override is invalid")
 			return err
 		}
-	} else if src, err = igst.SourceIP(); err != nil {
-		errorout("Failed to resolve source IP from muxer: %v", err)
-		return err
+	} else {
+		//it is ok to set src to nil, this can and will fail sometimes, ingest muxer will correct on ingest
+		src, _ = igst.SourceIP()
 	}
 
 	//build up the handlers


### PR DESCRIPTION
closes issue #343


ingest muxer will fixup nil SRC values, so don't bomb if we can't get it during startup.