### PR TITLE
updating raw results

### DIFF
--- a/client/searchCtrl.go
+++ b/client/searchCtrl.go
@@ -583,7 +583,16 @@ func (c *Client) GetPcapTsRange(s Search, start, end time.Time, first, last uint
 // GetRawResults queries a range of search results from the raw renderer. It returns
 // a types.TextResponse structure containing the results (see the Entries field).
 func (c *Client) GetRawResults(s Search, start, end uint64) (types.TextResponse, error) {
-	return c.GetTextResults(s, start, end)
+	req := types.TextRequest{
+		BaseRequest: types.BaseRequest{
+			ID: types.REQ_GET_RAW_ENTRIES,
+			EntryRange: &types.EntryRange{
+				First: start,
+				Last:  end,
+			},
+		},
+	}
+	return c.getTextResults(s, req)
 }
 
 // GetRawTsRange queries search results for a time range from the raw renderer. It returns

--- a/client/types/render.go
+++ b/client/types/render.go
@@ -23,9 +23,10 @@ import (
 
 const (
 	// base universal requests
-	REQ_GET_ENTRIES uint32 = 0x10
-	REQ_STREAMING   uint32 = 0x11
-	REQ_TS_RANGE    uint32 = 0x12
+	REQ_GET_ENTRIES     uint32 = 0x10
+	REQ_STREAMING       uint32 = 0x11
+	REQ_TS_RANGE        uint32 = 0x12
+	REQ_GET_RAW_ENTRIES uint32 = 0x13
 
 	// data exploration requests
 	REQ_GET_EXPLORE_ENTRIES uint32 = 0xf010
@@ -43,9 +44,10 @@ const (
 	REQ_SEARCH_METADATA uint32 = 0x10001
 
 	// base universal responses
-	RESP_GET_ENTRIES uint32 = 0x10
-	RESP_STREAMING   uint32 = 0x11
-	RESP_TS_RANGE    uint32 = 0x12
+	RESP_GET_ENTRIES     uint32 = 0x10
+	RESP_STREAMING       uint32 = 0x11
+	RESP_TS_RANGE        uint32 = 0x12
+	RESP_GET_RAW_ENTRIES uint32 = 0x13
 
 	// data exploration responses
 	RESP_GET_EXPLORE_ENTRIES uint32 = 0xf010


### PR DESCRIPTION
 request so that you can ask for unmutated entries from renderers like text, hex, and pcap.

This will have no affect on the raw renderer or general usage, but allows for getting un mutated entries from text, hex, and pcap.