### PR TITLE
Use the reingest API for IngestEntries

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -74,6 +74,7 @@ type Client struct {
 	userAgent   string
 	tlsConfig   *tls.Config
 	transport   *http.Transport
+	guiSettings types.GUISettings
 }
 
 // The ActiveSession structure represents a login session on the server. The
@@ -473,7 +474,9 @@ func (c *Client) syncNoLock() error {
 		return err
 	}
 	c.userDetails = userDets
-	return nil
+	// pull down "GUI settings"
+	c.guiSettings, err = c.getGuiSettings()
+	return err
 }
 
 // Close shuts down the client and cleans up connections. It does NOT terminate sessions.

--- a/client/info.go
+++ b/client/info.go
@@ -43,6 +43,19 @@ func (v VersionStruct) String() string {
 	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Revision)
 }
 
+func (c *Client) GetGuiSettings() (types.GUISettings, error) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	return c.getGuiSettings()
+}
+
+func (c *Client) getGuiSettings() (types.GUISettings, error) {
+	settings := types.GUISettings{}
+	err := c.getStaticURL(SETTINGS_URL, &settings)
+	return settings, err
+
+}
+
 // MySessions returns an array of the current user's sessions.
 func (c *Client) MySessions() ([]types.Session, error) {
 	if c.userDetails.UID == 0 {

--- a/client/types/api.go
+++ b/client/types/api.go
@@ -253,8 +253,9 @@ type GUISettings struct {
 	ServerTimezone       string
 	ServerTimezoneOffset int
 
-	MaxFileSize     uint64 // the maximum size allowed for user file uploads
-	MaxResourceSize uint64 // the largest resource you're allowed to make
+	MaxFileSize        uint64 // the maximum size allowed for user file uploads
+	MaxResourceSize    uint64 // the largest resource you're allowed to make
+	MaxJsonRequestSize uint64 // the largest object you're allowed to send in a JSON request body
 
 	IngestAllowed bool // set to true if the user is allowed to use the ingest APIs
 	NonCommercial bool // set to true if the license is a non-commercial license

--- a/client/urls.go
+++ b/client/urls.go
@@ -157,6 +157,7 @@ const (
 	TOKENS_URL                       = `/api/tokens`
 	TOKENS_ID_URL                    = `/api/tokens/%s`
 	TOKENS_CAPABILITIES_URL          = `/api/tokens/capabilities`
+	SETTINGS_URL                     = `/api/settings`
 
 	// Special APIs for installing licenses
 	LICENSE_INIT_UPLOAD = `/license`


### PR DESCRIPTION
IngestEntries previously used /api/ingest/json, which has a 24MB
default limit.  This means you could only ingest 24MB of entries at
a time or else you'd get an error from the webserver. This change
instead uses the reimport API, which can also handle search entries,
but does it via a streaming multipart request and goes around the
size limits.

Also adds a function to fetch the GUI Settings object.