### PR TITLE
small fmt on client error and change to Template API

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -293,7 +293,7 @@ func (c *Client) RefreshLoginToken() (err error) {
 	defer c.mtx.Unlock()
 
 	if c.state != STATE_AUTHED {
-		return errors.New("not logged in")
+		return ErrNoLogin
 	}
 	//build up URL we are going to throw at
 	uri := fmt.Sprintf("%s://%s%s", c.httpScheme, c.server, REFRESH_TOKEN_URL)

--- a/client/templates.go
+++ b/client/templates.go
@@ -39,14 +39,14 @@ func (c *Client) ListAllTemplates() (templates []types.WireUserTemplate, err err
 
 // NewTemplate creates a new template with the given GUID, name, description, contents.
 // If guid is set to uuid.Nil, a random GUID will be chosen automatically.
-func (c *Client) NewTemplate(guid uuid.UUID, name, description string, contents types.RawObject) (storedGuid uuid.UUID, err error) {
+func (c *Client) NewTemplate(guid uuid.UUID, name, description string, contents types.RawObject) (details types.WireUserTemplate, err error) {
 	// Mash the content blob into an appropriate type
 	var ct types.TemplateContents
 	if err = json.Unmarshal(contents, &ct); err != nil {
 		return
 	}
 	template := types.UserTemplate{GUID: guid, Contents: ct, Name: name, Description: description}
-	err = c.methodStaticPushURL(http.MethodPost, templatesUrl(), template, &storedGuid)
+	err = c.methodStaticPushURL(http.MethodPost, templatesUrl(), template, &details)
 	return
 }
 


### PR DESCRIPTION
update error constant on client and change the templates API to get the entire wireTemplate back