### PR TITLE
Update google pubsub to limit needed privs

### DIFF
--- a/ingesters/GooglePubSubIngester/config.go
+++ b/ingesters/GooglePubSubIngester/config.go
@@ -34,6 +34,7 @@ type global struct {
 
 type pubsubconf struct {
 	Topic_Name            string
+	Subscription_Name     string
 	Tag_Name              string
 	Assume_Local_Timezone bool
 	Timezone_Override     string

--- a/ingesters/GooglePubSubIngester/main.go
+++ b/ingesters/GooglePubSubIngester/main.go
@@ -189,24 +189,30 @@ func main() {
 			lg.Fatal("preprocessor construction failed", log.KVErr(err))
 		}
 
-		// get the topic
-		topic := client.Topic(psv.Topic_Name)
-		ok, err := topic.Exists(ctx)
-		if err != nil {
-			lg.Fatal("error checking topic", log.KVErr(err))
-		}
-		if !ok {
-			lg.Fatal("topic does not exist", log.KV("topic", psv.Topic_Name))
-		}
-
 		// Get the subscription, creating if needed
-		subname := fmt.Sprintf("ingest_%s", psv.Topic_Name)
+		subname := psv.Subscription_Name
+		if subname == `` {
+			subname = fmt.Sprintf("ingest_%s", psv.Topic_Name)
+		}
 		sub := client.Subscription(subname)
 		ok, err = sub.Exists(ctx)
 		if err != nil {
 			lg.Fatal("error checking subscription", log.KVErr(err))
 		}
 		if !ok {
+			//Subscription does not exist, attempt to create it
+			// this may fail due to permissions
+
+			// get the topic
+			topic := client.Topic(psv.Topic_Name)
+			ok, err := topic.Exists(ctx)
+			if err != nil {
+				lg.Fatal("error checking topic", log.KVErr(err))
+			}
+			if !ok {
+				lg.Fatal("topic does not exist", log.KV("topic", psv.Topic_Name))
+			}
+
 			// doesn't exist, try creating it
 			sub, err = client.CreateSubscription(ctx, subname, pubsub.SubscriptionConfig{
 				Topic:       topic,

--- a/ingesters/GooglePubSubIngester/pubsub_ingest.conf
+++ b/ingesters/GooglePubSubIngester/pubsub_ingest.conf
@@ -15,7 +15,11 @@ Project-ID="myproject-127400"
 Google-Credentials-Path=/opt/gravwell/etc/google-compute-credentials.json
 
 [PubSub "gravwell"]
-	Topic-Name=mytopic	# the pubsub topic you want to ingest
+	Topic-Name=mytopic	# the pubsub topic you want to ingest from
+	# Optional Subscription name to ingest from
+	# If the subscription does not exist, the ingester will attempt to create one
+	# named ingest_<topic name>.  This will fail if permissions setup does not allow subscription creation
+	Subscription-Name=auditlogs
 	Tag-Name=gcp
 	Parse-Time=false
 	Assume-Local-Timezone=true


### PR DESCRIPTION
This updates the Google pubsub ingester so that it doesn't needs as aggressive privs.  It now walks a series of operations trying to get a handle on a subscription that require the least privs.

For example, if the subscription config is set, then it will try to use that, if it can't get what it needs it fails.

If it is NOT set then it tries to test it and create it (requiring more privs).  Using this escalating procedure its possible to configure a security token that doesn't really let the ingester do THAT much.

But if you DO give it a ton of privs it will set stuff up itself.