### PR TITLE
Revert "Change the URLs used for GetUserFile and GetUserFileDetails"

### DIFF
--- a/client/urls.go
+++ b/client/urls.go
@@ -141,7 +141,7 @@ const (
 	PIVOTS_ID_DETAILS_URL            = "/api/pivots/%s/details"
 	USER_FILES_URL                   = "/api/files"
 	USER_FILES_ID_URL                = "/api/files/%s"
-	USER_FILES_RAW_ID_URL            = "/api/files/%s/raw"
+	USER_FILES_DETAILS_ID_URL        = "/api/files/%s/details"
 	LIBRARY_URL                      = "/api/library"
 	LIBRARY_ID_URL                   = "/api/library/%s"
 	LIBS_URL                         = `/api/libs`
@@ -552,8 +552,8 @@ func userFilesIdUrl(id uuid.UUID) string {
 	return fmt.Sprintf(USER_FILES_ID_URL, id)
 }
 
-func userFilesRawIdUrl(id uuid.UUID) string {
-	return fmt.Sprintf(USER_FILES_RAW_ID_URL, id)
+func userFilesDetailsIdUrl(id uuid.UUID) string {
+	return fmt.Sprintf(USER_FILES_DETAILS_ID_URL, id)
 }
 
 func searchLibUrl() string {

--- a/client/userfiles.go
+++ b/client/userfiles.go
@@ -121,7 +121,7 @@ func (c *Client) UpdateUserFileMetadata(id uuid.UUID, uf types.UserFileDetails) 
 func (c *Client) GetUserFile(id uuid.UUID) (bts []byte, err error) {
 	bb := bytes.NewBuffer(nil)
 	var resp *http.Response
-	if resp, err = c.methodRequestURL(http.MethodGet, userFilesRawIdUrl(id), ``, nil); err != nil {
+	if resp, err = c.methodRequestURL(http.MethodGet, userFilesIdUrl(id), ``, nil); err != nil {
 		return
 	}
 	if _, err = io.CopyN(bb, resp.Body, maxFileSize); err != nil && err != io.EOF {
@@ -136,7 +136,7 @@ func (c *Client) GetUserFile(id uuid.UUID) (bts []byte, err error) {
 
 // GetUserFileDetails fetches the metadata (everything except the contents) about a given file.
 func (c *Client) GetUserFileDetails(id uuid.UUID) (meta types.UserFileDetails, err error) {
-	if err = c.getStaticURL(userFilesIdUrl(id), &meta); err != nil {
+	if err = c.getStaticURL(userFilesDetailsIdUrl(id), &meta); err != nil {
 		return
 	}
 


### PR DESCRIPTION
This reverts commit a67d1b5d71319dd0ec065cbf3344c2eb6ff47e61.

The change in URLs would have broken playbooks, and that's just not worth the squeeze.