### PR TITLE
Add WordOffsets field to ExploreResult struct.

### DIFF
--- a/client/types/search.go
+++ b/client/types/search.go
@@ -83,9 +83,16 @@ type ExploreResult struct {
 	// This represents the module which generated the result, but
 	// individual Elements may have a different module set for
 	// purposes of filtering.
-	Module string
-	Tag    string
+	Module      string
+	Tag         string
+	WordOffsets []WordOffset `json:",omitempty"`
 }
+
+// A WordOffset contains two byte indexes into a string, denoting
+// the location of a "word" within that string. The usual substring
+// convention is followed, so the WordOffset of "foo" in "foo bar"
+// is WordOffset{0, 3}, or in standard notation [0, 3).
+type WordOffset [2]int
 
 type PingReq struct {
 	X error `json:",omitempty"`


### PR DESCRIPTION
The WordOffsets array contains [2]int arrays, each specifying the
absolute offsets of a word within the DATA field of the associated
entry. This can be used to provide clickable filters in the UI.