### PR TITLE
migrate fixes

### DIFF
--- a/migrate/config.go
+++ b/migrate/config.go
@@ -150,7 +150,7 @@ func (c *cfgType) getSplunkPreprocessors(splunkName string, igst *ingest.IngestM
 	for k, vv := range c.Splunk {
 		if k == splunkName {
 			// get the ingester up and rolling
-			pproc, err = cfg.Preprocessor.ProcessorSet(igst, vv.Preprocessor)
+			pproc, err = c.Preprocessor.ProcessorSet(igst, vv.Preprocessor)
 			return
 		}
 	}

--- a/migrate/main.go
+++ b/migrate/main.go
@@ -1,6 +1,3 @@
-//go:build linux
-// +build linux
-
 /*************************************************************************
  * Copyright 2022 Gravwell, Inc. All rights reserved.
  * Contact: <legal@gravwell.io>


### PR DESCRIPTION
fixing typo in config type that was referencing the wrong config object and removing linux build constraints.

This should work just fine in windows