### PR TITLE
this has some tests that show issues with how we do this conversion

### DIFF
--- a/ingest/processors/corelight.go
+++ b/ingest/processors/corelight.go
@@ -139,20 +139,7 @@ func (c *Corelight) processLine(s []byte) (tag string, ts time.Time, line []byte
 	return
 }
 
-func clean(ff map[string]interface{}) {
-	for k, v := range ff {
-		if len(k) == 0 {
-			continue
-		}
-		if bits := strings.Split(k, "."); len(bits) > 0 {
-			ff[bits[len(bits)-1]] = v
-		}
-	}
-	return
-}
-
 func (c *Corelight) process(mp map[string]interface{}, og []byte) (tag string, ts time.Time, line []byte) {
-	clean(mp)
 	var ok bool
 	var headers []string
 	if len(mp) == 0 {
@@ -185,7 +172,7 @@ func (c *Corelight) getTagTs(mp map[string]interface{}) (tag string, ts time.Tim
 		return
 	} else if tss, ok = tsv.(string); !ok {
 		return
-	} else if ts, err = time.Parse(time.RFC3339, tss); err != nil {
+	} else if ts, err = time.Parse(time.RFC3339Nano, tss); err != nil {
 		ok = false
 	} else {
 		tag = c.Prefix + tagval
@@ -217,36 +204,36 @@ func emitLine(ts time.Time, headers []string, mp map[string]interface{}) (line [
 }
 
 var tagHeaders = map[string]string{
-	"conn":        "ts,uid,orig_h,orig_p,resp_h,resp_p,proto,service,duration,orig_ip_bytes,resp_ip_bytes,conn_state,local_orig,local_resp,missed_bytes,history,orig_pkts,orig_ip_bytes,resp_pkts,resp_ip_bytes,tunnel_parents,vlan",
+	"conn":        "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,proto,service,duration,id.orig_ip_bytes,id.resp_ip_bytes,conn_state,local_orig,local_resp,missed_bytes,history,id.orig_pkts,id.orig_ip_bytes,id.resp_pkts,id.resp_ip_bytes,tunnel_parents,vlan",
 	"dhcp":        "ts,uids,client_addr,server_addr,mac,host_name,client_fqdn,domain,requested_addr,assigned_addr,lease_time,client_message,server_message,msg_types,duration",
-	"dns":         "ts,uid,orig_h,orig_p,resp_h,resp_p,proto,trans_id,rtt,query,qclass,qclass_name,qtype,qtype_name,rcode,rcode_name,AA,TC,RD,RA,Z,answers,TTLs,rejected",
+	"dns":         "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,proto,trans_id,rtt,query,qclass,qclass_name,qtype,qtype_name,rcode,rcode_name,AA,TC,RD,RA,Z,answers,TTLs,rejected",
 	"files":       "ts,fuid,tx_hosts,rx_hosts,conn_uids,source,depth,analyzers,mime_type,filename,duration,local_orig,is_orig,seen_bytes,total_bytes,missing_bytes,overflow_bytes,timedout,parent_fuid,md5,sha1,sha256,extracted,extracted_cutoff,extracted_size",
-	"http":        "ts,uid,orig_h,orig_p,resp_h,resp_p,trans_depth,method,host,uri,referrer,version,user_agent,origin,request_body_len,response_body_len,status_code,status_msg,info_code,info_msg,tags,username,password,proxied,orig_fuids,orig_filenames,orig_mime_types,resp_fuids,resp_filenames,resp_mime_types",
-	"ssl":         "ts,uid,orig_h,orig_p,resp_h,resp_p,version,cipher,curve,server_name,resumed,last_alert,next_protocol,established,cert_chain_fuids,client_cert_chain_fuids,subject,issuer,client_subject,client_issuer,validation_status",
-	"weird":       "ts,uid,orig_h,orig_p,resp_h,resp_p,name,addl,notice,peer",
+	"http":        "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,trans_depth,method,host,uri,referrer,version,user_agent,id.origin,request_body_len,id.response_body_len,status_code,status_msg,info_code,info_msg,tags,username,password,proxied,id.orig_fuids,id.orig_filenames,id.orig_mime_types,id.resp_fuids,id.resp_filenames,id.resp_mime_types",
+	"ssl":         "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,version,cipher,curve,server_name,resumed,last_alert,next_protocol,established,cert_chain_fuids,client_cert_chain_fuids,subject,issuer,client_subject,client_issuer,validation_status",
+	"weird":       "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,name,addl,notice,peer",
 	"x509":        "ts,uid,version,serial,subject,issuer,not_valid_before,not_valid_after,key_alg,sig_alg,key_type,key_length,exponent,curve,dns,uri,email,ip,ca,path_len",
-	"ssh":         "ts,uid,orig_h,orig_p,resp_h,resp_p,version,auth_success,auth_attempts,direction,client,server,cipher_alg,mac_alg,compression_alg,kex_alg,host_key_alg,host_key,inferences",
-	"sip":         "ts,uid,orig_h,orig_p,resp_h,resp_p,trans_depth,method,uri,date,request_fromrequest_to,response_from,response_to,reply_to,call_id,seq,subject,request_path,response_path,user_agent,status_code,status_msg,warning,request_body_len,response_body_len,content_type",
-	"dpd":         "ts,uid,orig_h,orig_p,resp_h,resp_p,proto,analyzer,failure_reason,packet_segment",
-	"snmp":        "ts,uid,orig_h,orig_p,resp_h,resp_p,duration,version,community,get_requests,get_bulk_requests,get_responses,set_requests,display_string,up_since",
-	"smtp":        "ts,uid,orig_h,orig_p,resp_h,resp_p,trans_depth,helo,mailfrom",
+	"ssh":         "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,version,auth_success,auth_attempts,direction,client,server,cipher_alg,mac_alg,compression_alg,kex_alg,host_key_alg,host_key,inferences",
+	"sip":         "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,trans_depth,method,uri,date,request_fromrequest_to,id.response_from,id.response_to,reply_to,call_id,seq,subject,request_path,id.response_path,user_agent,status_code,status_msg,warning,request_body_len,id.response_body_len,content_type",
+	"dpd":         "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,proto,analyzer,failure_reason,packet_segment",
+	"snmp":        "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,duration,version,community,get_requests,get_bulk_requests,get_responses,set_requests,display_string,up_since",
+	"smtp":        "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,trans_depth,helo,mailfrom",
 	"pe":          "ts,uid,machine,compile_ts,os,subsystem,is_exe,is_64bit,uses_aslr,uses_dep",
-	"tunnel":      "ts,uid,orig_h,orig_p,resp_h,resp_p,tunnel_type,action",
-	"socks":       "ts,uid,orig_h,orig_p,resp_h,resp_p,version,user,password,status,request,request_host,request_name,request_port,bound_host,bound_name",
+	"tunnel":      "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,tunnel_type,action",
+	"socks":       "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,version,user,password,status,request,request_host,request_name,request_port,bound_host,bound_name",
 	"software":    "ts,host,host_port,software_type,name,major,minor,minor2,minor3,addl,unparsed_version",
-	"syslog":      "ts,uid,orig_h,orig_p,resp_h,resp_p,proto,facility,severity,message",
-	"rfb":         "ts,uid,orig_h,orig_p,resp_h,resp_p,client_major_version,client_minor_version,server_major_version,server_minor_version,authentication_method,auth,share_flag,desktop_name,width,height",
-	"radius":      "ts,uid,orig_h,orig_p,resp_h,resp_p,username,mac,remote_ip,connect_info,result,logged",
-	"rdp":         "ts,uid,orig_h,orig_p,resp_h,resp_p,cookie,result,security_protocol,client_build,client_name,client_dig_product_id,desktop_width,desktop_height,requested_color_depth,cert_type,cert_count,cert_permanent,encryption_level,encryption_method",
-	"ftp":         "ts,uid,orig_h,orig_p,resp_h,resp_p,user,password,command,arg,mime_type,file_size,reply_code,reply_msg,data_channel_passive,data_channel_source_ip,data_channel_destination_ip,data_channel_destination_port",
-	"intel":       "ts,uid,orig_h,orig_p,resp_h,resp_p,indicator,indicator_type,seen_where,seen_node,matched,sources,fuid,file_mime_type,file_desc",
-	"irc":         "ts,uid,orig_h,orig_p,resp_h,resp_p,nick,user,command,value,additional_info,dcc_file_name,dcc_file_size,dcc_mime_type,fuid",
-	"kerberos":    "ts,uid,orig_h,orig_p,resp_h,resp_p,request_type,client,service,success,error_msg,from,till,cipher,forwardable,renewable,client_cert,client_cert_fuid,server_cert_subject,server_cert_fuid",
-	"mysql":       "ts,uid,orig_h,orig_p,resp_h,resp_p,cmd,arg,success,rows,response",
-	"modbus":      "ts,uid,orig_h,orig_p,resp_h,resp_p,func,exception",
-	"notice":      "ts,uid,orig_h,orig_p,resp_h,resp_p,fuid,mime,desc,proto,note,msg,sub,src,dst,p,n,peer_descr,actions,suppress_for,dropped,destination_country_code,destination_region,destination_city,destination_latitude,destination_longitude",
-	"signature":   "ts,uid,orig_h,orig_p,resp_h,resp_p,note,sig_id,event_msg,sub_msg,sig_count,host_count",
-	"smb_mapping": "ts,uid,orig_h,orig_p,resp_h,resp_p,path,service,native_file_system,share_type",
-	"smb_files":   "ts,uid,orig_h,orig_p,resp_h,resp_p,fuid,action,path,name,size,prev_name,modified,accessed,created,changed",
+	"syslog":      "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,proto,facility,severity,message",
+	"rfb":         "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,client_major_version,client_minor_version,server_major_version,server_minor_version,authentication_method,auth,share_flag,desktop_name,width,height",
+	"radius":      "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,username,mac,remote_ip,connect_info,result,logged",
+	"rdp":         "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,cookie,result,security_protocol,client_build,client_name,client_dig_product_id,desktop_width,desktop_height,requested_color_depth,cert_type,cert_count,cert_permanent,encryption_level,encryption_method",
+	"ftp":         "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,user,password,command,arg,mime_type,file_size,reply_code,reply_msg,data_channel.passive,data_channel.orig_h,data_channel.resp_h,data_channel.resp_p",
+	"intel":       "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,indicator,indicator_type,seen_where,seen_node,matched,sources,fuid,file_mime_type,file_desc",
+	"irc":         "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,nick,user,command,value,additional_info,dcc_file_name,dcc_file_size,dcc_mime_type,fuid",
+	"kerberos":    "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,request_type,client,service,success,error_msg,from,till,cipher,forwardable,renewable,client_cert,client_cert_fuid,server_cert_subject,server_cert_fuid",
+	"mysql":       "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,cmd,arg,success,rows,id.response",
+	"modbus":      "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,func,exception",
+	"notice":      "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,fuid,mime,desc,proto,note,msg,sub,src,dst,p,n,peer_descr,actions,suppress_for,dropped,destination_country_code,destination_region,destination_city,destination_latitude,destination_longitude",
+	"signature":   "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,note,sig_id,event_msg,sub_msg,sig_count,host_count",
+	"smb_mapping": "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,path,service,native_file_system,share_type",
+	"smb_files":   "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,fuid,action,path,name,size,prev_name,modified,accessed,created,changed",
 	"zeekdnp3":    "ts,uid,id,fc_request,fc_reply,iin",
 }

--- a/ingest/processors/corelight.go
+++ b/ingest/processors/corelight.go
@@ -154,7 +154,10 @@ func (c *Corelight) process(mp map[string]interface{}, og []byte) (tag string, t
 	} else if line, ok = emitLine(ts, headers, mp); !ok {
 		tag = defaultTag
 		line = og
+	} else {
+		line = bytes.TrimRight(line, "-\t\n")
 	}
+
 	return
 }
 
@@ -183,7 +186,7 @@ func (c *Corelight) getTagTs(mp map[string]interface{}) (tag string, ts time.Tim
 func emitLine(ts time.Time, headers []string, mp map[string]interface{}) (line []byte, ok bool) {
 	bb := bytes.NewBuffer(nil)
 	var f64 float64
-	fmt.Fprintf(bb, "%.3f", float64(ts.UnixNano())/1000000000.0)
+	fmt.Fprintf(bb, "%.5f", float64(ts.UnixNano())/1000000000.0)
 	for _, h := range headers[1:] { //always skip the TS
 		if v, ok := mp[h]; ok {
 			if f64, ok = v.(float64); ok {
@@ -225,7 +228,7 @@ var tagHeaders = map[string]string{
 	"rfb":         "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,client_major_version,client_minor_version,server_major_version,server_minor_version,authentication_method,auth,share_flag,desktop_name,width,height",
 	"radius":      "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,username,mac,remote_ip,connect_info,result,logged",
 	"rdp":         "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,cookie,result,security_protocol,client_build,client_name,client_dig_product_id,desktop_width,desktop_height,requested_color_depth,cert_type,cert_count,cert_permanent,encryption_level,encryption_method",
-	"ftp":         "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,user,password,command,arg,mime_type,file_size,reply_code,reply_msg,data_channel.passive,data_channel.orig_h,data_channel.resp_h,data_channel.resp_p",
+	"ftp":         "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,user,password,command,arg,mime_type,file_size,reply_code,reply_msg,data_channel.passive,data_channel.orig_h,data_channel.resp_h,data_channel.resp_p,fuid",
 	"intel":       "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,indicator,indicator_type,seen_where,seen_node,matched,sources,fuid,file_mime_type,file_desc",
 	"irc":         "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,nick,user,command,value,additional_info,dcc_file_name,dcc_file_size,dcc_mime_type,fuid",
 	"kerberos":    "ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,request_type,client,service,success,error_msg,from,till,cipher,forwardable,renewable,client_cert,client_cert_fuid,server_cert_subject,server_cert_fuid",

--- a/ingest/processors/corelight.go
+++ b/ingest/processors/corelight.go
@@ -25,7 +25,7 @@ const (
 )
 
 var (
-	defaultTag string
+	defaultTag    string
 	defaultPrefix = "zeek"
 )
 
@@ -48,15 +48,20 @@ type Corelight struct {
 }
 
 func CorelightLoadConfig(vc *config.VariableConfig) (c CorelightConfig, err error) {
-	err = vc.MapTo(&c)
-	if c.Prefix == "" {
+	if err = vc.MapTo(&c); err != nil {
+		return
+	}
+	if c.Prefix == `` {
 		c.Prefix = defaultPrefix
 	}
 	return
 }
 
 func NewCorelight(cfg CorelightConfig, tagger Tagger) (*Corelight, error) {
-	rr := &Corelight{tg: tagger}
+	rr := &Corelight{
+		CorelightConfig: cfg,
+		tg:              tagger,
+	}
 	if err := rr.init(cfg, tagger); err != nil {
 		return nil, err
 	}

--- a/ingest/processors/corelight.go
+++ b/ingest/processors/corelight.go
@@ -154,8 +154,6 @@ func (c *Corelight) process(mp map[string]interface{}, og []byte) (tag string, t
 	} else if line, ok = emitLine(ts, headers, mp); !ok {
 		tag = defaultTag
 		line = og
-	} else {
-		line = bytes.TrimRight(line, "-\t\n")
 	}
 
 	return
@@ -186,7 +184,7 @@ func (c *Corelight) getTagTs(mp map[string]interface{}) (tag string, ts time.Tim
 func emitLine(ts time.Time, headers []string, mp map[string]interface{}) (line []byte, ok bool) {
 	bb := bytes.NewBuffer(nil)
 	var f64 float64
-	fmt.Fprintf(bb, "%.5f", float64(ts.UnixNano())/1000000000.0)
+	fmt.Fprintf(bb, "%.6f", float64(ts.UnixNano())/1000000000.0)
 	for _, h := range headers[1:] { //always skip the TS
 		if v, ok := mp[h]; ok {
 			if f64, ok = v.(float64); ok {

--- a/ingest/processors/corelight_data_test.go
+++ b/ingest/processors/corelight_data_test.go
@@ -1,6 +1,6 @@
 package processors
 
-const ftp1_out = "1597559163.553\tCLkXf2CMo11hD8FQ5\t192.168.4.76\t53380\t196.216.2.24\t21\tanonymous\tftp@example.com\tEPSV\t-\t-\t-\t229\tEntering Extended Passive Mode (|||31746|).\ttrue\t192.168.4.76\t196.216.2.24\t31746"
+const ftp1_out = "1597559163.55329\tCLkXf2CMo11hD8FQ5\t192.168.4.76\t53380\t196.216.2.24\t21\tanonymous\tftp@example.com\tEPSV\t-\t-\t-\t229\tEntering Extended Passive Mode (|||31746|).\ttrue\t192.168.4.76\t196.216.2.24\t31746"
 const ftp1_in = `{
   "_path": "ftp",
   "_system_name": "ds61",
@@ -21,4 +21,26 @@ const ftp1_in = `{
   "data_channel.orig_h": "192.168.4.76",
   "data_channel.resp_h": "196.216.2.24",
   "data_channel.resp_p": 31746
+}`
+
+const ftp2_out = "1597559164.59729\tCLkXf2CMo11hD8FQ5\t192.168.4.76\t53380\t196.216.2.24\t21\tanonymous\tftp@example.com\tRETR\tftp://196.216.2.24/pub/stats/afrinic/delegated-afrinic-extended-latest.md5\t-\t74\t226\tTransfer complete.\t-\t-\t-\t-\tFueF95uKPrUuDnMc4"
+const ftp2_in = `{
+  "_path": "ftp",
+  "_system_name": "ds61",
+  "_write_ts": "2020-08-16T06:26:05.117287Z",
+  "_node": "worker-01",
+  "ts": "2020-08-16T06:26:04.597290Z",
+  "uid": "CLkXf2CMo11hD8FQ5",
+  "id.orig_h": "192.168.4.76",
+  "id.orig_p": 53380,
+  "id.resp_h": "196.216.2.24",
+  "id.resp_p": 21,
+  "user": "anonymous",
+  "password": "ftp@example.com",
+  "command": "RETR",
+  "arg": "ftp://196.216.2.24/pub/stats/afrinic/delegated-afrinic-extended-latest.md5",
+  "file_size": 74,
+  "reply_code": 226,
+  "reply_msg": "Transfer complete.",
+  "fuid": "FueF95uKPrUuDnMc4"
 }`

--- a/ingest/processors/corelight_data_test.go
+++ b/ingest/processors/corelight_data_test.go
@@ -1,0 +1,24 @@
+package processors
+
+const ftp1_out = "1597559163.553\tCLkXf2CMo11hD8FQ5\t192.168.4.76\t53380\t196.216.2.24\t21\tanonymous\tftp@example.com\tEPSV\t-\t-\t-\t229\tEntering Extended Passive Mode (|||31746|).\ttrue\t192.168.4.76\t196.216.2.24\t31746"
+const ftp1_in = `{
+  "_path": "ftp",
+  "_system_name": "ds61",
+  "_write_ts": "2020-08-16T06:26:04.077276Z",
+  "_node": "worker-01",
+  "ts": "2020-08-16T06:26:03.553287Z",
+  "uid": "CLkXf2CMo11hD8FQ5",
+  "id.orig_h": "192.168.4.76",
+  "id.orig_p": 53380,
+  "id.resp_h": "196.216.2.24",
+  "id.resp_p": 21,
+  "user": "anonymous",
+  "password": "ftp@example.com",
+  "command": "EPSV",
+  "reply_code": 229,
+  "reply_msg": "Entering Extended Passive Mode (|||31746|).",
+  "data_channel.passive": true,
+  "data_channel.orig_h": "192.168.4.76",
+  "data_channel.resp_h": "196.216.2.24",
+  "data_channel.resp_p": 31746
+}`

--- a/ingest/processors/corelight_test.go
+++ b/ingest/processors/corelight_test.go
@@ -80,28 +80,7 @@ type testCheck struct {
 var corelightTestData = []testCheck{
 	testCheck{
 		tag:    `zeekftp`,
-		output: "1597559163.553\tCLkXf2CMo11hD8FQ5\t192.168.4.76\t53380\t196.216.2.24\t21\tanonymous\tftp@example.com\tEPSV\t-\t-\t-\t229\tEntering Extended Passive Mode (|||31746|).\ttrue\t192.168.4.76\t196.216.2.24\t31746",
-		input: `
-{
-  "_path": "ftp",
-  "_system_name": "ds61",
-  "_write_ts": "2020-08-16T06:26:04.077276Z",
-  "_node": "worker-01",
-  "ts": "2020-08-16T06:26:03.553287Z",
-  "uid": "CLkXf2CMo11hD8FQ5",
-  "id.orig_h": "192.168.4.76",
-  "id.orig_p": 53380,
-  "id.resp_h": "196.216.2.24",
-  "id.resp_p": 21,
-  "user": "anonymous",
-  "password": "ftp@example.com",
-  "command": "EPSV",
-  "reply_code": 229,
-  "reply_msg": "Entering Extended Passive Mode (|||31746|).",
-  "data_channel.passive": true,
-  "data_channel.orig_h": "192.168.4.76",
-  "data_channel.resp_h": "196.216.2.24",
-  "data_channel.resp_p": 31746
-}`,
+		output: ftp1_out,
+		input:  ftp1_in,
 	},
 }

--- a/ingest/processors/corelight_test.go
+++ b/ingest/processors/corelight_test.go
@@ -1,0 +1,107 @@
+package processors
+
+import (
+	"testing"
+
+	"github.com/gravwell/gravwell/v3/ingest/entry"
+)
+
+func TestCorelightConfig(t *testing.T) {
+	b := `
+	[preprocessor "corelight"]
+		type = corelight
+	`
+	p, err := testLoadPreprocessor(b, `corelight`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	//cast to the corelight processor
+	if c, ok := p.(*Corelight); !ok {
+		t.Fatalf("preprocessor is the wrong type: %T != *Corelight", p)
+	} else {
+		if c.Prefix != defaultPrefix {
+			t.Fatalf("invalid prefix: %v %v", c.Prefix, defaultPrefix)
+		}
+	}
+
+	b = `
+	[preprocessor "corelight"]
+		type = corelight
+		Prefix="foobar"
+	`
+	p, err = testLoadPreprocessor(b, `corelight`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	//cast to the corelight processor
+	if c, ok := p.(*Corelight); !ok {
+		t.Fatalf("preprocessor is the wrong type: %T != *Corelight", p)
+	} else {
+		if c.Prefix != "foobar" {
+			t.Fatalf("invalid prefix: %v foobar", c.Prefix)
+		}
+	}
+
+}
+
+func TestCorelightTransitions(t *testing.T) {
+	b := `
+	[preprocessor "corelight"]
+		type = corelight
+	`
+	p, err := testLoadPreprocessor(b, `corelight`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	//cast to the corelight processor
+	c, ok := p.(*Corelight)
+	if !ok {
+		t.Fatalf("preprocessor is the wrong type: %T != *Corelight", p)
+	}
+	var ent entry.Entry
+	for i, v := range corelightTestData {
+		ent.Data = []byte(v.input)
+		if ents, err := c.Process([]*entry.Entry{&ent}); err != nil {
+			t.Fatalf("failed to process %d: %v\n", i, err)
+		} else if len(ents) != 1 {
+			t.Fatal(`too many entries came out`)
+		} else if string(ents[0].Data) != v.output {
+			t.Fatalf("Output mismatch %d:\n%s\n%s\n", i, string(ents[0].Data), v.output)
+		}
+	}
+}
+
+type testCheck struct {
+	tag    string
+	input  string
+	output string
+}
+
+var corelightTestData = []testCheck{
+	testCheck{
+		tag:    `zeekftp`,
+		output: "1597559164.077\tCLkXf2CMo11hD8FQ5\t192.168.4.76\t53380\t196.216.2.24\t21\tanonymous\tftp@example.com\tEPSV\t\t\t\t229\tEntering Extended Passive Mode (|||31746|).\ttrue\t192.168.4.76\t196.216.2.24\t31746",
+		input: `
+{
+  "_path": "ftp",
+  "_system_name": "ds61",
+  "_write_ts": "2020-08-16T06:26:04.077276Z",
+  "_node": "worker-01",
+  "ts": "2020-08-16T06:26:03.553287Z",
+  "uid": "CLkXf2CMo11hD8FQ5",
+  "id.orig_h": "192.168.4.76",
+  "id.orig_p": 53380,
+  "id.resp_h": "196.216.2.24",
+  "id.resp_p": 21,
+  "user": "anonymous",
+  "password": "ftp@example.com",
+  "command": "EPSV",
+  "reply_code": 229,
+  "reply_msg": "Entering Extended Passive Mode (|||31746|).",
+  "data_channel.passive": true,
+  "data_channel.orig_h": "192.168.4.76",
+  "data_channel.resp_h": "196.216.2.24",
+  "data_channel.resp_p": 31746
+}`,
+	},
+}

--- a/ingest/processors/corelight_test.go
+++ b/ingest/processors/corelight_test.go
@@ -67,6 +67,10 @@ func TestCorelightTransitions(t *testing.T) {
 			t.Fatal(`too many entries came out`)
 		} else if string(ents[0].Data) != v.output {
 			t.Fatalf("Output mismatch %d:\n%s\n%s\n", i, string(ents[0].Data), v.output)
+		} else if tn, ok := c.tg.LookupTag(ents[0].Tag); !ok {
+			t.Fatal("failed to lookup tag")
+		} else if tn != v.tag {
+			t.Fatalf("invalid tag: %v != %v", tn, v.tag)
 		}
 	}
 }
@@ -78,9 +82,6 @@ type testCheck struct {
 }
 
 var corelightTestData = []testCheck{
-	testCheck{
-		tag:    `zeekftp`,
-		output: ftp1_out,
-		input:  ftp1_in,
-	},
+	testCheck{tag: `zeekftp`, input: ftp1_in, output: ftp1_out},
+	testCheck{tag: `zeekftp`, input: ftp2_in, output: ftp2_out},
 }

--- a/ingest/processors/corelight_test.go
+++ b/ingest/processors/corelight_test.go
@@ -80,7 +80,7 @@ type testCheck struct {
 var corelightTestData = []testCheck{
 	testCheck{
 		tag:    `zeekftp`,
-		output: "1597559164.077\tCLkXf2CMo11hD8FQ5\t192.168.4.76\t53380\t196.216.2.24\t21\tanonymous\tftp@example.com\tEPSV\t\t\t\t229\tEntering Extended Passive Mode (|||31746|).\ttrue\t192.168.4.76\t196.216.2.24\t31746",
+		output: "1597559163.553\tCLkXf2CMo11hD8FQ5\t192.168.4.76\t53380\t196.216.2.24\t21\tanonymous\tftp@example.com\tEPSV\t-\t-\t-\t229\tEntering Extended Passive Mode (|||31746|).\ttrue\t192.168.4.76\t196.216.2.24\t31746",
 		input: `
 {
   "_path": "ftp",

--- a/ingest/processors/processors.go
+++ b/ingest/processors/processors.go
@@ -275,7 +275,7 @@ func newProcessor(vc *config.VariableConfig, tgr Tagger) (p Processor, err error
 		return
 	case CorelightProcessor:
 		var cfg CorelightConfig
-		if err = vc.MapTo(&cfg); err != nil {
+		if cfg, err = CorelightLoadConfig(vc); err != nil {
 			return
 		}
 		p, err = NewCorelight(cfg, tgr)


### PR DESCRIPTION
Basically because of the "clean" phase of the map fixup we introduce some ambiguity and failures.

I think we need to remove the clean phase and just specify the headers in the exact form that corelight throws them, we don't emit the headers anywhere, so its OK to keep them as is.

Test included.

example logs here: https://docs.zeek.org/en/master/logs/index.html