### PR TITLE
client: Do a sync in the Login function.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -282,7 +282,11 @@ func (c *Client) Login(user, pass string) error {
 	if err := json.NewDecoder(resp.Body).Decode(&loginResp); err != nil {
 		return err
 	}
-	return c.processLoginResponse(loginResp)
+	if err := c.processLoginResponse(loginResp); err != nil {
+		return err
+	}
+
+	return c.syncNoLock()
 }
 
 // RefreshLoginToken will ask the webserver to refresh the login state
@@ -458,7 +462,9 @@ func (c *Client) TestGet(path string) error {
 }
 
 // Sync fetches some useful information for local reference, such as user details.
-// In general, you should call Sync immediately after authenticating.
+// It is typically not necessary to call this function; in the past, you had to
+// call Sync immediately after authenticating, but the
+// Login function now fetches the same information automatically.
 func (c *Client) Sync() (err error) {
 	c.mtx.Lock()
 	err = c.syncNoLock()


### PR DESCRIPTION
Previously, we told users to call Login, then call Sync, which fetches information about the user. This tends to be a bit fraught in practice, because users reasonably assume that after calling NewClient and Login, you should be able to use the client -- but some calls *will* fail, because the client doesn't know the user's UID. This change just calls syncNoLock as the last step of Login.

Closes #474