### PR TITLE
client: don't check if user is admin or not

### DIFF
--- a/client/admin.go
+++ b/client/admin.go
@@ -667,22 +667,16 @@ func (c *Client) Restore(rdr io.Reader) (err error) {
 
 // DistributedWebservers queries to determine if the webserver is in distributed mode
 // and therefore using the datastore.  This means that certain resource changes may take some
-// time to fully distribute.
+// time to fully distribute. This is an admin-only function.
 func (c *Client) DeploymentInfo() (di types.DeploymentInfo, err error) {
-	if !c.userDetails.Admin {
-		err = ErrNotAdmin
-	} else {
-		err = c.getStaticURL(deploymentUrl(), &di)
-	}
+	err = c.getStaticURL(deploymentUrl(), &di)
+
 	return
 }
 
 // PurgeUser will first enumerate every asset that is owned by the user and delete them
-// then it will delete the user
+// then it will delete the user. This is an admin-only function.
 func (c *Client) PurgeUser(id int32) error {
-	if !c.userDetails.Admin {
-		return ErrNotAdmin
-	}
 	//impersonate the user
 	nc, err := c.Impersonate(id)
 	if err != nil {

--- a/client/kit.go
+++ b/client/kit.go
@@ -185,13 +185,10 @@ func (c *Client) DeleteKitEx(id string) ([]types.SourcedKitItem, error) {
 // AdminDeleteKit is an admin-only function which can delete a kit owned by
 // any user.
 func (c *Client) AdminDeleteKit(id string) (err error) {
-	if !c.userDetails.Admin {
-		err = ErrNotAdmin
-	} else {
-		c.SetAdminMode()
-		err = c.deleteStaticURL(kitIdUrl(id), nil)
-		c.ClearAdminMode()
-	}
+	c.SetAdminMode()
+	err = c.deleteStaticURL(kitIdUrl(id), nil)
+	c.ClearAdminMode()
+
 	return
 }
 
@@ -228,16 +225,14 @@ func (c *Client) KitDownloadRequest(id string) (*http.Response, error) {
 }
 
 // AdminListKits is an admin-only function which lists all kits on the system.
+// Non-administrators will get the same list as returned by ListKits.
 func (c *Client) AdminListKits() (pkgs []types.IdKitState, err error) {
-	if !c.userDetails.Admin {
-		err = ErrNotAdmin
-	} else {
-		c.SetAdminMode()
-		if err = c.getStaticURL(kitUrl(), &pkgs); err != nil {
-			pkgs = nil
-		}
-		c.ClearAdminMode()
+	c.SetAdminMode()
+	if err = c.getStaticURL(kitUrl(), &pkgs); err != nil {
+		pkgs = nil
 	}
+	c.ClearAdminMode()
+
 	return
 }
 

--- a/client/library.go
+++ b/client/library.go
@@ -9,8 +9,9 @@
 package client
 
 import (
-	"github.com/gravwell/gravwell/v3/client/types"
 	"net/http"
+
+	"github.com/gravwell/gravwell/v3/client/types"
 
 	"github.com/google/uuid"
 )
@@ -28,18 +29,13 @@ func (c *Client) ListSearchLibrary() (wsl []types.WireSearchLibrary, err error) 
 }
 
 // ListAllSearchLibrary (admin-only) returns the list of all search library entries for all users.
+// Non-administrators will receive the same list as returned by ListSearchLibrary.
 func (c *Client) ListAllSearchLibrary() (wsl []types.WireSearchLibrary, err error) {
-	//check our status locally, server will kick it too, but no reason in even
-	//making the request if we know it will fail
-	if !c.userDetails.Admin {
-		err = ErrNotAdmin
-	} else {
-		c.SetAdminMode()
-		if err = c.getStaticURL(searchLibUrl(), &wsl); err != nil {
-			wsl = nil
-		}
-		c.ClearAdminMode()
+	c.SetAdminMode()
+	if err = c.getStaticURL(searchLibUrl(), &wsl); err != nil {
+		wsl = nil
 	}
+	c.ClearAdminMode()
 	return
 }
 

--- a/client/pivots.go
+++ b/client/pivots.go
@@ -9,8 +9,9 @@
 package client
 
 import (
-	"github.com/gravwell/gravwell/v3/client/types"
 	"net/http"
+
+	"github.com/gravwell/gravwell/v3/client/types"
 
 	"github.com/google/uuid"
 )
@@ -22,16 +23,14 @@ func (c *Client) ListPivots() (pivots []types.WirePivot, err error) {
 }
 
 // ListAllPivots returns the list of all pivots in the system
+// Non-administrators will receive the same list as returned by ListPivots.
 func (c *Client) ListAllPivots() (pivots []types.WirePivot, err error) {
-	if !c.userDetails.Admin {
-		err = ErrNotAdmin
-	} else {
-		c.SetAdminMode()
-		if err = c.getStaticURL(pivotsUrl(), &pivots); err != nil {
-			pivots = nil
-		}
-		c.ClearAdminMode()
+	c.SetAdminMode()
+	if err = c.getStaticURL(pivotsUrl(), &pivots); err != nil {
+		pivots = nil
 	}
+	c.ClearAdminMode()
+
 	return
 }
 

--- a/client/playbooks.go
+++ b/client/playbooks.go
@@ -52,6 +52,7 @@ func (c *Client) UpdatePlaybook(m types.Playbook) error {
 }
 
 // GetAllPlaybooks (admin-only) returns all playbooks for all users.
+// Non-administrators will receive the same list as returned by GetUserPlaybooks.
 func (c *Client) GetAllPlaybooks() (pbs []types.Playbook, err error) {
 	//check our status locally, server will kick it too, but no reason in even
 	//making the request if we know it will fail

--- a/client/resources.go
+++ b/client/resources.go
@@ -29,16 +29,14 @@ func (c *Client) GetResourceList() (rm []types.ResourceMetadata, err error) {
 }
 
 // GetAllResourceList is an admin-only API to pull back the entire resource list.
+// Non-administrators will receive the same list as returned by GetResourceList.
 func (c *Client) GetAllResourceList() (rm []types.ResourceMetadata, err error) {
-	if !c.userDetails.Admin {
-		err = ErrNotAdmin
-	} else {
-		c.SetAdminMode()
-		if err = c.getStaticURL(resourcesUrl(), &rm); err != nil {
-			rm = nil
-		}
-		c.ClearAdminMode()
+	c.SetAdminMode()
+	if err = c.getStaticURL(resourcesUrl(), &rm); err != nil {
+		rm = nil
 	}
+	c.ClearAdminMode()
+
 	return
 }
 

--- a/client/templates.go
+++ b/client/templates.go
@@ -23,17 +23,15 @@ func (c *Client) ListTemplates() (templates []types.WireUserTemplate, err error)
 	return
 }
 
-// ListAllTemplates returns the list of all templates in the system, admin only API
+// ListAllTemplates returns the list of all templates in the system.
+// Non-administrators will receive the same list as returned by ListTemplates.
 func (c *Client) ListAllTemplates() (templates []types.WireUserTemplate, err error) {
-	if !c.userDetails.Admin {
-		err = ErrNotAdmin
-	} else {
-		c.SetAdminMode()
-		if err = c.getStaticURL(templatesUrl(), &templates); err != nil {
-			templates = nil
-		}
-		c.ClearAdminMode()
+	c.SetAdminMode()
+	if err = c.getStaticURL(templatesUrl(), &templates); err != nil {
+		templates = nil
 	}
+	c.ClearAdminMode()
+
 	return
 }
 

--- a/client/userfiles.go
+++ b/client/userfiles.go
@@ -42,17 +42,13 @@ func (c *Client) UserFiles() (ufds []types.UserFileDetails, err error) {
 }
 
 // AllUserFiles pulls the complete list of all user files for the entire system.
-// Only administrators can use this API.
+// Non-administrators will receive the same list as returned by UserFiles.
 func (c *Client) AllUserFiles() (ufds []types.UserFileDetails, err error) {
-	if !c.userDetails.Admin {
-		err = ErrNotAdmin
-	} else {
-		c.SetAdminMode()
-		if err = c.getStaticURL(userFilesUrl(), &ufds); err != nil {
-			ufds = nil
-		}
-		c.ClearAdminMode()
+	c.SetAdminMode()
+	if err = c.getStaticURL(userFilesUrl(), &ufds); err != nil {
+		ufds = nil
 	}
+	c.ClearAdminMode()
 	return
 }
 


### PR DESCRIPTION
We decided in #473 that that client shouldn't be attempting to validate whether or not the user is an admin--the webserver will handle it! This strips out checks everywhere I could find them.

Closes #473.

