### PR TITLE
Change default ipfix listener port.

### DIFF
--- a/ingesters/netflow/netflow_capture.conf
+++ b/ingesters/netflow/netflow_capture.conf
@@ -18,5 +18,5 @@ Log-File=/opt/gravwell/log/netflow_capture.log
 
 [Collector "ipfix"]
 	Tag-Name=ipfix
-	Bind-String="0.0.0.0:6343"
+	Bind-String="0.0.0.0:4739"
 	Flow-Type=ipfix


### PR DESCRIPTION
Port 6343 is more commonly used for s-flow, and it confuses some appliances to try and send ipfix there.