### PR TITLE
ingesters: add hostname to the ingest state object

### DIFF
--- a/ingest/api.go
+++ b/ingest/api.go
@@ -164,6 +164,7 @@ type IngesterState struct {
 	Version       string
 	Label         string
 	IP            net.IP        //child IP, won't be populated unless in child
+	Hostname      string        // whatever the ingester thinks its hostname is
 	Entries       uint64        // How many entries the ingester has written
 	Size          uint64        // How many bytes the ingester has written
 	Uptime        time.Duration // Nanoseconds since the ingest muxer was initialized

--- a/ingest/muxer.go
+++ b/ingest/muxer.go
@@ -340,11 +340,18 @@ func newIngestMuxer(c MuxerConfig) (*IngestMuxer, error) {
 		p = newParent(c.RateLimitBps, 0)
 	}
 
+	// figure out our hostname
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "(cannot determine hostname)"
+	}
+
 	// Initialize the state
 	state := IngesterState{
 		UUID:       c.IngesterUUID,
 		Name:       c.IngesterName,
 		Label:      c.IngesterLabel,
+		Hostname:   hostname,
 		Version:    c.IngesterVersion,
 		CacheState: c.CacheMode,
 		Children:   make(map[string]IngesterState),


### PR DESCRIPTION
Per #555, we now ship the hostname when we report ingest state.
