### PR TITLE
Implement the GetFullSecret API call.

### DIFF
--- a/client/secrets.go
+++ b/client/secrets.go
@@ -47,3 +47,13 @@ func (c *Client) UpdateSecret(id uuid.UUID, sc types.SecretCreate) (s types.Secr
 func (c *Client) DeleteSecret(id uuid.UUID) (err error) {
 	return c.methodStaticPushURL(http.MethodDelete, secretIdUrl(id), nil, nil, http.StatusNoContent)
 }
+
+// GetFullSecret fetches the entire Secret, including the value.
+// This can only be used if you have authenticated using the searchagent token.
+// The search agent knows how to set up the Client object correctly for this.
+// If you are not writing something which acts like the search agent, you don't
+// want this function, it won't work.
+func (c *Client) GetFullSecret(id uuid.UUID) (s types.SecretFull, err error) {
+	err = c.getStaticURL(secretIdFullUrl(id), &s)
+	return
+}

--- a/client/urls.go
+++ b/client/urls.go
@@ -160,6 +160,7 @@ const (
 	TOKENS_CAPABILITIES_URL          = `/api/tokens/capabilities`
 	SECRETS_URL                      = `/api/secrets`
 	SECRETS_ID_URL                   = `/api/secrets/%s`
+	SECRETS_ID_FULL_URL              = `/api/secrets/%s/full`
 	SETTINGS_URL                     = `/api/settings`
 
 	// Special APIs for installing licenses
@@ -587,4 +588,8 @@ func secretsUrl() string {
 
 func secretIdUrl(id uuid.UUID) string {
 	return fmt.Sprintf(SECRETS_ID_URL, id.String())
+}
+
+func secretIdFullUrl(id uuid.UUID) string {
+	return fmt.Sprintf(SECRETS_ID_FULL_URL, id.String())
 }


### PR DESCRIPTION
This endpoint is only accessible if you've done the full searchagent auth dance. This is how the searchagent will be able to fetch e.g. SSH keys from the secret store for use in automations. Regular users cannot touch this API.
