### PR TITLE
adding new member to ingester stats

### DIFF
--- a/client/types/render.go
+++ b/client/types/render.go
@@ -229,6 +229,7 @@ type IngestStats struct {
 	LastDayCount uint64 //total entries in last 24 hours
 	LastDaySize  uint64 //total ingested in last 24 hours
 	Ingesters    []IngesterStats
+	Missing      []ingest.IngesterState `json:",omitempty"` //ingesters that have been seen before but not actively connected now
 }
 
 type IngesterStats struct {


### PR DESCRIPTION
 to also throw up the list if ingesters that an indexer has seen but hasn't seen lately

This is so we can inform the API about ingesters we saw before but aren't currently connected