### PR TITLE
Add Attach-Filename directive to file follower

### DIFF
--- a/filewatch/filewatch_test.go
+++ b/filewatch/filewatch_test.go
@@ -750,7 +750,7 @@ func newSafeTrackingLH() *safeTrackingLH {
 	}
 }
 
-func (h *safeTrackingLH) HandleLog(b []byte, ts time.Time) error {
+func (h *safeTrackingLH) HandleLog(b []byte, ts time.Time, fname string) error {
 	if h.mp == nil {
 		return errors.New("not ready")
 	}

--- a/filewatch/followers.go
+++ b/filewatch/followers.go
@@ -28,7 +28,7 @@ var (
 )
 
 type handler interface {
-	HandleLog([]byte, time.Time) error
+	HandleLog([]byte, time.Time, string) error
 	Tag() string
 }
 
@@ -148,7 +148,7 @@ func (f *follower) Sync(qc chan os.Signal) (bool, error) {
 		}
 		//actually handle the line
 		now := time.Now()
-		if err := f.lh.HandleLog(ln, now); err != nil {
+		if err := f.lh.HandleLog(ln, now, f.FilePath); err != nil {
 			return false, err
 		}
 		*f.state = f.lnr.Index()
@@ -260,7 +260,7 @@ func (f *follower) processLines(writeEvent bool) error {
 			break
 		}
 		//actually handle the line
-		if err := f.lh.HandleLog(ln, time.Now()); err != nil {
+		if err := f.lh.HandleLog(ln, time.Now(), f.FilePath); err != nil {
 			return err
 		}
 		*f.state = f.lnr.Index()

--- a/filewatch/followers_test.go
+++ b/filewatch/followers_test.go
@@ -230,7 +230,7 @@ type countingLH struct {
 	cnt int64
 }
 
-func (h *countingLH) HandleLog(b []byte, ts time.Time) error {
+func (h *countingLH) HandleLog(b []byte, ts time.Time, fname string) error {
 	if len(b) > 0 && !ts.IsZero() {
 		h.cnt++
 	}
@@ -242,7 +242,7 @@ type trackingLH struct {
 	mp map[string]time.Time
 }
 
-func (h *trackingLH) HandleLog(b []byte, ts time.Time) error {
+func (h *trackingLH) HandleLog(b []byte, ts time.Time, fname string) error {
 	if h.mp == nil {
 		h.mp = map[string]time.Time{}
 	}

--- a/filewatch/reader.go
+++ b/filewatch/reader.go
@@ -65,6 +65,13 @@ func newBaseReader(f *os.File, maxLine int, startIdx int64) (br baseReader, err 
 	return
 }
 
+func (br *baseReader) Name() string {
+	if br != nil && br.f != nil {
+		return br.f.Name()
+	}
+	return ``
+}
+
 func (br *baseReader) SeekFile(offset int64) error {
 	_, err := br.f.Seek(offset, 0)
 	br.idx = offset

--- a/ingest/entry/enumerated_test.go
+++ b/ingest/entry/enumerated_test.go
@@ -229,3 +229,12 @@ func testEVCycle(a interface{}) (err error) {
 
 	return
 }
+
+func TestEnumeratedStringTail(t *testing.T) {
+	tgt := strings.Repeat("A", MaxEvDataLength)
+	orig := strings.Repeat("FOOBAR", 100) + tgt
+	ed := StringEnumDataTail(orig)
+	if len(tgt) != len(ed.String()) {
+		t.Fatalf("bad return size: %d != %d", len(tgt), len(ed.String()))
+	}
+}

--- a/ingest/entry/enumerated_types.go
+++ b/ingest/entry/enumerated_types.go
@@ -16,6 +16,7 @@ import (
 	"net"
 	"strconv"
 	"time"
+	"unicode/utf8"
 )
 
 const (
@@ -221,6 +222,26 @@ func StringEnumData(v string) EnumeratedData {
 		data:   []byte(v),
 		evtype: typeUnicode,
 	}
+}
+
+// StringEnumDataTrimmed will create a Unicode enumerated value with leading characters trimmed off
+// if and only if the provided string is too long.  This function is commonly used in the file follower.
+// This function is UTF-8 aware and will respect entire unicode characters.
+func StringEnumDataTail(v string) EnumeratedData {
+	if len(v) < MaxEvDataLength {
+		//no need to do anything
+		return StringEnumData(v)
+	}
+	//trim it down
+	var size int
+	for len(v) > MaxEvDataLength {
+		// if we have an invalid UTF8 string then we just start cutting bytes hoping to find a valid char
+		if _, size = utf8.DecodeRuneInString(v); size <= 0 {
+			size = 1
+		}
+		v = v[size:]
+	}
+	return StringEnumData(v)
 }
 
 func SliceEnumData(v []byte) EnumeratedData {

--- a/ingesters/fileFollow/config.go
+++ b/ingesters/fileFollow/config.go
@@ -51,6 +51,7 @@ type follower struct {
 	Ignore_Timestamps         bool //Just apply the current timestamp to lines as we get them
 	Assume_Local_Timezone     bool
 	Recursive                 bool // Should we descend into child directories?
+	Attach_Filename           bool // attach the full path of the file to each entry
 	Ignore_Line_Prefix        []string
 	Ignore_Glob               []string
 	Timestamp_Format_Override string //override the timestamp format

--- a/ingesters/fileFollow/main_linux.go
+++ b/ingesters/fileFollow/main_linux.go
@@ -230,6 +230,7 @@ func main() {
 			TimezoneOverride:        val.Timezone_Override,
 			Ctx:                     wtcher.Context(),
 			TimeFormat:              cfg.TimeFormat,
+			AttachFilename:          val.Attach_Filename,
 		}
 		if v {
 			cfg.Debugger = debugout

--- a/ingesters/fileFollow/processing_windows.go
+++ b/ingesters/fileFollow/processing_windows.go
@@ -319,6 +319,7 @@ func (m *mainService) init(ctx context.Context) error {
 			UserTimeFormat:          val.Timestamp_Format_String,
 			Ctx:                     ctx,
 			TimeFormat:              m.timeFormats,
+			AttachFilename:          val.Attach_Filename,
 		}
 
 		lh, err := filewatch.NewLogHandler(cfg, pproc)


### PR DESCRIPTION
This adds the ability to attach a file name to entries as they are consumed in file follower.