### PR TITLE
Add basic SNMP ingester

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/google/renameio v0.1.0
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/websocket v1.4.2
+	github.com/gosnmp/gosnmp v1.35.0 // indirect
 	github.com/gravwell/buffer v0.0.0-20220728204757-23339f4bab66
 	github.com/gravwell/gcfg v1.2.9-0.20221122204101-04b4a74a3018
 	github.com/gravwell/ipfix v1.4.3
@@ -53,7 +54,7 @@ require (
 	github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563 // indirect
 	github.com/rivo/tview v0.0.0-20220307222120-9994674d60a8
 	github.com/shirou/gopsutil v2.20.9+incompatible
-	github.com/stretchr/testify v1.6.1
+	github.com/stretchr/testify v1.7.1
 	github.com/tealeg/xlsx v1.0.5
 	github.com/turnage/graw v0.0.0-20191104042329-405cc3092119
 	github.com/turnage/redditproto v0.0.0-20151223012412-afedf1b6eddb // indirect

--- a/go.sum
+++ b/go.sum
@@ -165,6 +165,7 @@ github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
+github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -206,6 +207,8 @@ github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gosnmp/gosnmp v1.35.0 h1:EuWWNPxTCdAUx2/NbQcSa3WdNxjzpy4Phv57b4MWpJM=
+github.com/gosnmp/gosnmp v1.35.0/go.mod h1:2AvKZ3n9aEl5TJEo/fFmf/FGO4Nj4cVeEc5yuk88CYc=
 github.com/gravwell/buffer v0.0.0-20220728204757-23339f4bab66 h1:WY4eTW+ErqI0rbVrdM12pqey9eOYFQUSiFwejdGAOto=
 github.com/gravwell/buffer v0.0.0-20220728204757-23339f4bab66/go.mod h1:RUZts//u8V+P37LqSghbTYaMGDdTOJooQGHzbjfSIZA=
 github.com/gravwell/gcfg v1.2.9-0.20221122204101-04b4a74a3018 h1:yOl1BFerz+cq4FeeDVIHy11kOZAozTMKzbFd0PoJErA=
@@ -299,6 +302,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tealeg/xlsx v1.0.5 h1:+f8oFmvY8Gw1iUXzPk+kz+4GpbDZPK1FhPiQRd+ypgE=
 github.com/tealeg/xlsx v1.0.5/go.mod h1:btRS8dz54TDnvKNosuAqxrM1QgN1udgk9O34bDCnORM=
 github.com/traetox/fsnotify v1.5.2-0.20220310052716-a0d82fe7e596 h1:1YQS70QHOXTt5BdD1hVoH9IGDUQdBkIYbgPuhJKlS8k=
@@ -483,6 +487,7 @@ golang.org/x/tools v0.0.0-20200224181240-023911ca70b2/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200227222343-706bc42d1f0d/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200312045724-11d5b4c81c7d/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
+golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/ingesters/snmp/.gitignore
+++ b/ingesters/snmp/.gitignore
@@ -1,0 +1,2 @@
+test.conf
+snmp

--- a/ingesters/snmp/config.go
+++ b/ingesters/snmp/config.go
@@ -1,0 +1,214 @@
+/*************************************************************************
+ * Copyright 2020 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/gosnmp/gosnmp"
+	"github.com/gravwell/gravwell/v3/ingest"
+	"github.com/gravwell/gravwell/v3/ingest/config"
+	"github.com/gravwell/gravwell/v3/ingest/entry"
+	"github.com/gravwell/gravwell/v3/ingest/processors"
+)
+
+type listener struct {
+	v3auth
+	Tag_Name        string
+	Bind_String     string //IP port pair 127.0.0.1:1234
+	Version         string // SNMP version: 1, 2c, 3
+	Community       string // for SNMP v1 and v2
+	Source_Override string
+	Preprocessor    []string
+}
+
+type v3auth struct {
+	Username           string
+	Privacy_Passphrase string
+	Privacy_Protocol   string
+	Auth_Passphrase    string
+	Auth_Protocol      string
+}
+
+type global struct {
+	config.IngestConfig
+}
+
+type cfgReadType struct {
+	Global       global
+	Listener     map[string]*listener
+	Preprocessor processors.ProcessorConfig
+}
+
+type cfgType struct {
+	config.IngestConfig
+	Listener     map[string]*listener
+	Preprocessor processors.ProcessorConfig
+}
+
+func (a *v3auth) validate() error {
+	if a.Auth_Protocol != "" && a.Auth_Protocol != "MD5" && a.Auth_Protocol != "SHA" {
+		return fmt.Errorf("Invalid Auth-Protocol %v. Supported protocols: MD5, SHA")
+	}
+	if a.Privacy_Protocol != "" && a.Privacy_Protocol != "DES" {
+		return fmt.Errorf("Invalid Privacy-Protocol %v. Supported protocols: DES")
+	}
+	return nil
+}
+
+func (a *v3auth) getAuthProto() gosnmp.SnmpV3AuthProtocol {
+	switch a.Auth_Protocol {
+	case "MD5":
+		return gosnmp.MD5
+	case "SHA":
+		return gosnmp.SHA
+	}
+	return gosnmp.NoAuth
+}
+
+func (a *v3auth) getPrivacyProto() gosnmp.SnmpV3PrivProtocol {
+	switch a.Privacy_Protocol {
+	case "DES":
+		return gosnmp.DES
+	}
+	return gosnmp.NoPriv
+}
+
+func (a *v3auth) getMsgFlags() gosnmp.SnmpV3MsgFlags {
+	if a.Auth_Protocol != "" {
+		if a.Privacy_Protocol != "" {
+			return gosnmp.AuthPriv
+		}
+		return gosnmp.AuthNoPriv
+	}
+	return gosnmp.NoAuthNoPriv
+}
+
+func GetConfig(path, overlayPath string) (*cfgType, error) {
+	//read into the intermediary type to maintain backwards compatibility with the old system
+	var cr cfgReadType
+	if err := config.LoadConfigFile(&cr, path); err != nil {
+		return nil, err
+	} else if err = config.LoadConfigOverlays(&cr, overlayPath); err != nil {
+		return nil, err
+	}
+	c := &cfgType{
+		IngestConfig: cr.Global.IngestConfig,
+		Listener:     cr.Listener,
+		Preprocessor: cr.Preprocessor,
+	}
+
+	if err := verifyConfig(c); err != nil {
+		return nil, err
+	}
+
+	// Verify and set UUID
+	if _, ok := c.IngesterUUID(); !ok {
+		id := uuid.New()
+		if err := c.SetIngesterUUID(id, path); err != nil {
+			return nil, err
+		}
+		if id2, ok := c.IngesterUUID(); !ok || id != id2 {
+			return nil, errors.New("Failed to set a new ingester UUID")
+		}
+	}
+	return c, nil
+}
+
+func verifyConfig(c *cfgType) error {
+	//verify the global parameters
+	if err := c.Verify(); err != nil {
+		return err
+	}
+
+	if len(c.Listener) == 0 {
+		return errors.New("No listeners specified")
+	}
+
+	if err := c.Preprocessor.Validate(); err != nil {
+		return err
+	}
+
+	for k, v := range c.Listener {
+		if len(v.Tag_Name) == 0 {
+			v.Tag_Name = entry.DefaultTagName
+		}
+		if strings.ContainsAny(v.Tag_Name, ingest.FORBIDDEN_TAG_SET) {
+			return errors.New("Invalid characters in the Tag-Name for " + k)
+		}
+		if v.Source_Override != `` {
+			if net.ParseIP(v.Source_Override) == nil {
+				return fmt.Errorf("Source-Override %s is not a valid IP address", v.Source_Override)
+			}
+		}
+		switch v.Version {
+		case "2c":
+		case "3":
+		default:
+			return fmt.Errorf("Listener %v Invalid SNMP version %v, supported versions: 2c, 3", k, v.Version)
+		}
+
+		if err := v.v3auth.validate(); err != nil {
+			return fmt.Errorf("Listener %s SNMP v3 security config is invalid: %v", k, err)
+		}
+
+		if err := c.Preprocessor.CheckProcessors(v.Preprocessor); err != nil {
+			return fmt.Errorf("Listener %s preprocessor invalid: %v", k, err)
+		}
+	}
+
+	return nil
+}
+
+func (c *cfgType) Tags() ([]string, error) {
+	var tags []string
+	tagMp := make(map[string]bool, 1)
+
+	for _, v := range c.Listener {
+		if len(v.Tag_Name) == 0 {
+			continue
+		}
+		if _, ok := tagMp[v.Tag_Name]; !ok {
+			tags = append(tags, v.Tag_Name)
+			tagMp[v.Tag_Name] = true
+		}
+	}
+
+	if len(tags) == 0 {
+		return nil, errors.New("No tags specified")
+	}
+	sort.Strings(tags)
+	return tags, nil
+}
+
+func (c *cfgType) IngestBaseConfig() config.IngestConfig {
+	return c.IngestConfig
+}
+
+func (g *global) Verify() (err error) {
+	if err = g.IngestConfig.Verify(); err != nil {
+		return
+	}
+	return
+}
+
+func (l *listener) getSnmpVersion() gosnmp.SnmpVersion {
+	switch l.Version {
+	case "2c":
+		return gosnmp.Version2c
+	case "3":
+		return gosnmp.Version3
+	}
+	return gosnmp.Version2c
+}

--- a/ingesters/snmp/main.go
+++ b/ingesters/snmp/main.go
@@ -1,0 +1,184 @@
+/*************************************************************************
+ * Copyright 2023 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/gravwell/gravwell/v3/ingest/entry"
+	"github.com/gravwell/gravwell/v3/ingest/log"
+	"github.com/gravwell/gravwell/v3/ingest/processors"
+	"github.com/gravwell/gravwell/v3/ingesters/base"
+	"github.com/gravwell/gravwell/v3/ingesters/utils"
+)
+
+const (
+	defaultConfigLoc  = `/opt/gravwell/etc/s3.conf`
+	defaultConfigDLoc = `/opt/gravwell/etc/s3.conf.d`
+	defaultStateLoc   = `/opt/gravwell/etc/s3.state`
+	ingesterName      = `SNMP Ingester`
+	appName           = `snmp`
+
+	testTimeout time.Duration = 3 * time.Second
+)
+
+// TrapRecord gets built up from the received trap,
+// then encoded to JSON for ingest.
+type TrapRecord struct {
+	Sender          string
+	Community       string `json:",omitempty"`
+	ContextEngineID string `json:",omitempty"`
+	ContextName     string `json:",omitempty"`
+	TrapOID         string `json:",omitempty"`
+	Variables       []SnmpVariable
+}
+
+// SnmpVariable represents one OID->value mapping
+// from the trap. A trap may contain multiple
+// variables.
+type SnmpVariable struct {
+	OID        string
+	Value      interface{}
+	Type       gosnmp.Asn1BER
+	TypeString string
+}
+
+func main() {
+	var wg sync.WaitGroup
+	var cfg *cfgType
+	ibc := base.IngesterBaseConfig{
+		IngesterName:                 ingesterName,
+		AppName:                      appName,
+		DefaultConfigLocation:        defaultConfigLoc,
+		DefaultConfigOverlayLocation: defaultConfigDLoc,
+		GetConfigFunc:                GetConfig,
+	}
+	ib, err := base.Init(ibc)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get configuration %v\n", err)
+		return
+	} else if err = ib.AssignConfig(&cfg); err != nil || cfg == nil {
+		fmt.Fprintf(os.Stderr, "failed to assign configuration %v %v\n", err, cfg == nil)
+		return
+	}
+
+	igst, err := ib.GetMuxer()
+	if err != nil {
+		ib.Logger.FatalCode(0, "failed to get ingest connection", log.KVErr(err))
+		return
+	}
+	defer igst.Close()
+
+	var traps []*gosnmp.TrapListener
+	for name, lcfg := range cfg.Listener {
+		var tag entry.EntryTag
+		var proc *processors.ProcessorSet
+		if tag, err = igst.GetTag(lcfg.Tag_Name); err != nil {
+			ib.Logger.FatalCode(0, "failed to get established tag",
+				log.KV("tag", lcfg.Tag_Name),
+				log.KV("listener", name), log.KVErr(err))
+		} else if proc, err = cfg.Preprocessor.ProcessorSet(igst, lcfg.Preprocessor); err != nil {
+			ib.Logger.FatalCode(0, "preprocessor failure",
+				log.KV("listener", name), log.KVErr(err))
+		}
+
+		l := gosnmp.NewTrapListener()
+		l.Params = gosnmp.Default
+		l.Params.Community = lcfg.Community
+		//l.Params.Logger = gosnmp.NewLogger(glog.New(os.Stdout, "", 0))
+		if lcfg.getSnmpVersion() == gosnmp.Version3 {
+			l.Params.SecurityParameters = &gosnmp.UsmSecurityParameters{
+				UserName:                 lcfg.Username,
+				AuthenticationProtocol:   lcfg.getAuthProto(),
+				AuthenticationPassphrase: lcfg.Auth_Passphrase,
+				PrivacyProtocol:          lcfg.getPrivacyProto(),
+				PrivacyPassphrase:        lcfg.Privacy_Passphrase,
+				//Logger:                   gosnmp.NewLogger(glog.New(os.Stdout, "", 0)),
+			}
+			l.Params.MsgFlags = lcfg.getMsgFlags()
+			l.Params.SecurityModel = gosnmp.UserSecurityModel
+		}
+		l.Params.Version = lcfg.getSnmpVersion()
+		traps = append(traps, l)
+
+		// Set up the callback
+		cb := func(s *gosnmp.SnmpPacket, u *net.UDPAddr) {
+			if s == nil || u == nil {
+				return
+			}
+			if 0x3&s.MsgFlags != 0x3&l.Params.MsgFlags {
+				ib.Logger.Warn("dropping trap due to invalid msgflags",
+					log.KV("received-flags", 0x3&s.MsgFlags),
+					log.KV("expected-flags", 0x3&l.Params.MsgFlags),
+					log.KV("client", u.IP.String()))
+				return
+			}
+			ent := entry.Entry{
+				TS:  entry.Now(),
+				SRC: u.IP,
+				Tag: tag,
+			}
+			r := TrapRecord{
+				Sender:    u.IP.String(),
+				Community: s.Community,
+			}
+			for i := range s.Variables {
+				if s.Variables[i].Name == ".1.3.6.1.6.3.1.1.4.1.0" {
+					r.TrapOID, _ = s.Variables[i].Value.(string)
+				}
+				v := SnmpVariable{
+					OID:        s.Variables[i].Name,
+					Value:      s.Variables[i].Value,
+					Type:       s.Variables[i].Type,
+					TypeString: s.Variables[i].Type.String(),
+				}
+				r.Variables = append(r.Variables, v)
+			}
+			var err error
+			if ent.Data, err = json.Marshal(r); err != nil {
+				// Skip it, I guess
+				return
+			}
+			proc.Process(&ent)
+		}
+		l.OnNewTrap = cb
+
+		wg.Add(1)
+		go func(bind string) {
+			defer wg.Done()
+			l.Listen(bind)
+		}(lcfg.Bind_String)
+	}
+
+	ib.Debug("Running\n")
+
+	//listen for signals so we can close gracefully
+	utils.WaitForQuit()
+
+	// Close all the traps so goroutines exit
+	for i := range traps {
+		traps[i].Close()
+	}
+
+	// wait for graceful shutdown
+	wg.Wait()
+
+	if err := igst.Sync(time.Second); err != nil {
+		ib.Logger.Error("failed to sync", log.KVErr(err))
+	}
+	if err := igst.Close(); err != nil {
+		ib.Logger.Error("failed to close", log.KVErr(err))
+	}
+}

--- a/ingesters/snmp/snmp.conf
+++ b/ingesters/snmp/snmp.conf
@@ -1,0 +1,27 @@
+[Global]
+Ingest-Secret = IngestSecrets
+Connection-Timeout = 0
+Insecure-Skip-TLS-Verify=false
+#Cleartext-Backend-Target=127.0.0.1:4023 #example of adding a cleartext connection
+#Cleartext-Backend-Target=127.1.0.1:4023 #example of adding another cleartext connection
+#Encrypted-Backend-Target=127.1.1.1:4024 #example of adding an encrypted connection
+Pipe-Backend-Target=/opt/gravwell/comms/pipe #a named pipe connection, this should be used when ingester is on the same machine as a backend
+#Ingest-Cache-Path=/opt/gravwell/cache/simple_relay.cache #adding an ingest cache for local storage when uplinks fail
+#Max-Ingest-Cache=1024 #Number of MB to store, localcache will only store 1GB before stopping.  This is a safety net
+Log-Level=INFO
+Log-File=/opt/gravwell/log/snmp.log
+
+[Listener "default"]
+	Tag-Name=snmp
+	Bind-String="0.0.0.0:162"
+	Version=2c
+
+[Listener "v3"]
+	Tag-Name=snmp3
+	Bind-String="0.0.0.0:163"
+	Version=3
+	Username=myuser
+	Auth-Passphrase=mypassword
+	Auth-Protocol=MD5
+	Privacy-Passphrase=mypassword
+	Privacy-Protocol=DES


### PR DESCRIPTION
Per #564, implements an ingester which can accept SNMP Trap messages and ingests them as JSON. Supports SNMP versions 2c and 3.

For SNMPv3, supports MD5 and SHA auth protocols and DES privacy protocol. Messages with mis-matching auth/privacy settings will be dropped.

