### PR TITLE
try to knock down some code paths that MIGHT cause #582

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/crewjam/rfc5424 v0.1.0
 	github.com/dchest/safefile v0.0.0-20151022103144-855e8d98f185
 	github.com/eapache/go-resiliency v1.2.0 // indirect
-	github.com/elastic/beats v7.6.2+incompatible
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/gdamore/tcell/v2 v2.5.1
 	github.com/go-ole/go-ole v1.2.4 // indirect
@@ -61,6 +60,7 @@ require (
 	golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392 // indirect
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4
 	golang.org/x/sys v0.0.0-20220318055525-2edf467146b5
+	golang.org/x/text v0.3.7
 	golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1
 	google.golang.org/protobuf v1.22.0 // indirect
 	gopkg.in/jcmturner/gokrb5.v7 v7.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -120,14 +120,10 @@ github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 h1:YEetp8
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
-github.com/elastic/beats v7.6.2+incompatible h1:jHdLv83KURaqWUC6f55iMyVP6LYZrgElfeqxKWcskVE=
-github.com/elastic/beats v7.6.2+incompatible/go.mod h1:7cX7zGsOwJ01FLkZs9Tg5nBdnQi6XB3hYAyWekpKgeY=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/floren/go-msgraph v0.0.0-20200818171114-ec95909b54e3 h1:f0irndm+5FeJcUpPZVSul6Ic7zSO3ambfrv/shJ/9Lk=
-github.com/floren/go-msgraph v0.0.0-20200818171114-ec95909b54e3/go.mod h1:FQfGFirjPYyn2Y2iIEaAxwT6FY5pigmZVkIGhL1K2kI=
 github.com/floren/jsonparser v0.0.0-20210727191945-e5063027fceb h1:XRsoLQTeRindbOuSflYX5jAAsTjqhy09km3djCTiycQ=
 github.com/floren/jsonparser v0.0.0-20210727191945-e5063027fceb/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
@@ -226,10 +222,10 @@ github.com/inhies/go-bytesize v0.0.0-20201103132853-d0aed0d254f8/go.mod h1:KrtyD
 github.com/jcmturner/gofork v0.0.0-20190328161633-dc7c13fece03/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
 github.com/jcmturner/gofork v1.0.0 h1:J7uCkflzTEhUZ64xqKnkDxq3kzc96ajM1Gli5ktUem8=
 github.com/jcmturner/gofork v1.0.0/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
-github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
@@ -569,6 +565,7 @@ gopkg.in/jcmturner/rpc.v1 v1.1.0/go.mod h1:YIdkC4XfD6GXbzje11McwsDuOlZQSb9W4vfLv
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/winevent/wineventlog/README
+++ b/winevent/wineventlog/README
@@ -1,3 +1,6 @@
-This is a direct lift of the code at https://github.com/elastic/beats/tree/master/winlogbeat/sys/wineventlog
-which is governed by the Apache2.0 license.  We had to lift the code due to the vendoring that the elastic
-repository enforces.
+This code started its life as a direct lift of the code at https://github.com/elastic/beats/tree/master/winlogbeat/sys/wineventlog
+which is governed by the Apache2.0 license.  We had to lift the code due to the vendoring that the elastic respository enforces.
+
+But now it's so heavily modified it's basically its own beast, but still governed under the Apache2.0 license.
+
+Abandon hope all ye who enter here, the Windows eventlog system is a patchwork of hellfire, brimestone, UTF-16, and XML.

--- a/winevent/wineventlog/utils.go
+++ b/winevent/wineventlog/utils.go
@@ -1,0 +1,52 @@
+/*************************************************************************
+ * Copyright 2023 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
+package wineventlog
+
+import (
+	"io"
+	"unicode/utf16"
+	"unicode/utf8"
+
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
+)
+
+// UTF16LEBufferToUTF8Bytes takes UTF-16 in little endian encoding without a BOM and spits it back
+// out as UTF8.  Basically take the insanity of Windows native strings and turn it back
+// into nice clean UTF-8, just like the way mom used to make it.
+func UTF16LEBufferToUTF8Bytes(v []byte) (r []byte, err error) {
+	r, _, err = transform.Bytes(unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM).NewDecoder(), v)
+	return
+}
+
+func UTF16LEBufferToUTF8Writer(v []byte, out io.Writer) (err error) {
+	var bts []byte
+	if bts, err = UTF16LEBufferToUTF8Bytes(v); err == nil {
+		_, err = out.Write(bts)
+	}
+	return
+}
+
+// UTF16LEToUTF8 wraps UTF16LEToUTF8Bytes to return a string
+func UTF16LEToUTF8(v []byte) (s string, err error) {
+	if buff, lerr := UTF16LEBufferToUTF8Bytes(v); lerr == nil {
+		s = string(buff)
+	}
+	return
+}
+
+func UTF16LEToUTF8Bytes(v []uint16) (r []byte) {
+	runes := utf16.Decode(v)
+	for _, ru := range runes {
+		if utf8.ValidRune(ru) {
+			r = utf8.AppendRune(r, ru)
+		}
+	}
+	return
+}


### PR DESCRIPTION
This PR works on https://github.com/gravwell/gravwell/issues/582

I still can't replicate the behavior of that issue but I CAN see how if windows was letting NULLs slip into the XML formatting then the hand rolled implementation of UTF16->UTF8 would stop decoding. 

Its a shot in the dark, but also that hand rolled implementation is scary compared to `/x/text` libraries.