### PR TITLE
Make timegrinder smarter in guessing the year.

### DIFF
--- a/timegrinder/custom.go
+++ b/timegrinder/custom.go
@@ -33,6 +33,7 @@ type CustomFormat struct {
 	Format string
 
 	dateMissing bool // indicates that the extraction only gets time, so add date
+	yearMissing bool // indicates that the extraction doesn't set the year
 }
 
 // Validate will check that the custom format is well formed and usable
@@ -66,6 +67,9 @@ func (cf *CustomFormat) Validate() (err error) {
 	} else if t.Year() == 0 && t.Month() == 1 && t.Day() == 1 {
 		//this is ok, but we need to add the date
 		cf.dateMissing = true
+	}
+	if t.Year() == 0 {
+		cf.yearMissing = true
 	}
 	return
 }
@@ -104,6 +108,10 @@ func (cp *customProcessor) Match(d []byte) (int, int, bool) {
 func (cp *customProcessor) Extract(d []byte, loc *time.Location) (t time.Time, ok bool, offset int) {
 	if t, ok, offset = extract(cp.rx, nil, d, cp.CustomFormat.Format, loc); ok && cp.dateMissing {
 		t = addDate(t)
+	}
+	//check if we need to set the year
+	if cp.yearMissing {
+		t = tweakYear(t)
 	}
 	return
 }

--- a/timegrinder/processors_extra.go
+++ b/timegrinder/processors_extra.go
@@ -499,10 +499,11 @@ func tweakYear(t time.Time) time.Time {
 		return t
 	}
 	now := time.Now()
+	year := now.Year()
 	// If setting the current year puts us too far in the future,
 	// more than 25 hours, we'll set the previous year instead.
-	if t.AddDate(now.Year(), 0, 0).Sub(now) > (25 * time.Hour) {
-		return t.AddDate(now.Year()-1, 0, 0)
+	if t.AddDate(year, 0, 0).Sub(now) > (25 * time.Hour) {
+		return t.AddDate(year-1, 0, 0)
 	}
-	return t.AddDate(time.Now().Year(), 0, 0)
+	return t.AddDate(year, 0, 0)
 }

--- a/timegrinder/timeGrinder_test.go
+++ b/timegrinder/timeGrinder_test.go
@@ -119,6 +119,81 @@ func TestGlobalMatcher(t *testing.T) {
 	}
 }
 
+// TestYearGuess validates timegrinder's year-guessing logic for
+// timestamps which don't include a year (e.g. SyslogFormat)
+func TestYearGuess(t *testing.T) {
+	tg, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Set to local time
+	tg.SetLocalTime()
+
+	// Define a custom format and add it
+	custom := CustomFormat{
+		Name:   `customfoo`,
+		Regex:  `\d{1,2}\.\d{1,2}_\d{1,2}\.\d{1,2}\.\d{1,2}(.\d+)?`, //example 2021.2.14_13:54:22.9
+		Format: `01.02_15.04.05.999999999`,
+	}
+	if err := custom.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if proc, err := NewCustomProcessor(custom); err != nil {
+		t.Fatal(err)
+	} else {
+		tg.AddProcessor(proc)
+	}
+
+	tester := func(name, format string, tg *TimeGrinder) {
+		// Grab the current time ("now")
+		now := time.Now()
+		// Subtract 24 hours from now, format it as syslog
+		// Attempt to extract with timegrinder
+		x := []byte(now.Add(-24 * time.Hour).Format(format))
+		out, ok, err := tg.Extract(x)
+		if !ok {
+			t.Fatalf("%v could not extract from %s", name, x)
+		} else if err != nil {
+			t.Fatalf("%v could not extract from %s: %v", name, x, err)
+		}
+		// The result should be in the past
+		if !out.Before(now) {
+			t.Fatalf("%v timestamp from 24 hours ago is not in the past", name)
+		}
+
+		// Add 24 hours to now, format it as syslog
+		// Attempt to extract with timegrinder
+		x = []byte(now.Add(24 * time.Hour).Format(format))
+		out, ok, err = tg.Extract(x)
+		if !ok {
+			t.Fatalf("%v could not extract from %s", name, x)
+		} else if err != nil {
+			t.Fatalf("%v could not extract from %s: %v", name, x, err)
+		}
+		// The result should be in the future
+		if !out.After(now) {
+			t.Fatalf("%v timestamp from 24 hours ahead is not in the future", name)
+		}
+
+		// Add 26 hours to now, format it as syslog
+		// Attempt to extract with timegrinder
+		x = []byte(now.Add(26 * time.Hour).Format(format))
+		out, ok, err = tg.Extract(x)
+		if !ok {
+			t.Fatalf("%v could not extract from %s", name, x)
+		} else if err != nil {
+			t.Fatalf("%v could not extract from %s: %v", name, x, err)
+		}
+		// The result should be in the past (threshold is 25 hours)
+		if !out.Before(now) {
+			t.Fatalf("%v timestamp from 26 hours ahead is not in the past", name)
+		}
+	}
+
+	tester("syslog", SyslogFormat, tg)
+	tester(custom.Name, custom.Format, tg)
+}
+
 func TestTooManyDigitsUnix(t *testing.T) {
 	tg, err := New(cfg)
 	if err != nil {


### PR DESCRIPTION
If it is January 30, and we read a syslog message that starts "Oct 5 13:00:00", the vast majority of the time that's coming from the *previous* year, not from 9 months into the *future*.

This change does the following for the Syslog timestamp format and for Custom formats which do not include the year:

* If setting the year of the timestamp to the current year places it more than 25 hours into the future, we instead set it to *last* year.
* If setting the year of the timestamp to the current year places it in the immediate future (<25 hours ahead), we use the current year, assuming clock drift or timezone issues.
* If using the current year places the timestamp in the past, we use the current year.
