### PR TITLE
fixing regex handler so that it can do TCP, UDP, or TLS

### DIFF
--- a/ingesters/SimpleRelay/json.go
+++ b/ingesters/SimpleRelay/json.go
@@ -124,7 +124,7 @@ func startJSONListeners(cfg *cfgType, igst *ingest.IngestMuxer, wg *sync.WaitGro
 
 		if tp.TCP() {
 			//get the socket
-			addr, err := net.ResolveTCPAddr("tcp", v.Bind_String)
+			addr, err := net.ResolveTCPAddr("tcp", str)
 			if err != nil {
 				return fmt.Errorf("%s Bind-String \"%s\" is invalid: %v\n", k, v.Bind_String, err)
 			}
@@ -159,6 +159,19 @@ func startJSONListeners(cfg *cfgType, igst *ingest.IngestMuxer, wg *sync.WaitGro
 			//start the acceptor
 			wg.Add(1)
 			go jsonAcceptor(l, connID, igst, jhc, tp)
+		} else if tp.UDP() {
+			addr, err := net.ResolveUDPAddr(tp.String(), str)
+			if err != nil {
+				lg.FatalCode(0, "invalid Bind-String", log.KV("bindstring", v.Bind_String), log.KV("listener", k), log.KVErr(err))
+			}
+			l, err := net.ListenUDP(tp.String(), addr)
+			if err != nil {
+				lg.FatalCode(0, "failed to listen via udp", log.KV("address", addr), log.KV("listener", k), log.KVErr(err))
+			}
+			connID := addConn(l)
+			wg.Add(1)
+			go jsonAcceptorUDP(l, connID, igst, jhc)
+
 		}
 
 	}
@@ -193,6 +206,66 @@ func jsonAcceptor(lst net.Listener, id int, igst *ingest.IngestMuxer, cfg jsonHa
 	return
 }
 
+func jsonAcceptorUDP(conn *net.UDPConn, id int, igst *ingest.IngestMuxer, cfg jsonHandlerConfig) {
+	defer cfg.wg.Done()
+	defer delConn(id)
+	defer conn.Close()
+
+	buff := make([]byte, 16*1024) //local buffer that should be big enough for even the largest UDP packets
+	tcfg := timegrinder.Config{
+		EnableLeftMostSeed: true,
+	}
+	tg, err := timegrinder.NewTimeGrinder(tcfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to get a handle on the timegrinder: %v\n", err)
+		return
+	} else if err = cfg.timeFormats.LoadFormats(tg); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load custom time formats: %v\n", err)
+		return
+	}
+	if cfg.setLocalTime {
+		tg.SetLocalTime()
+	}
+	if cfg.timezoneOverride != `` {
+		err = tg.SetTimezone(cfg.timezoneOverride)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to set timezone to %v: %v\n", cfg.timezoneOverride, err)
+			return
+		}
+	}
+	if cfg.formatOverride != `` {
+		if err = tg.SetFormatOverride(cfg.formatOverride); err != nil {
+			lg.Error("Failed to load format override", log.KV("override", cfg.formatOverride), log.KVErr(err))
+			return
+		}
+	}
+	for {
+		n, raddr, err := conn.ReadFromUDP(buff)
+		if err != nil {
+			break
+		}
+		if n == 0 {
+			continue
+		}
+		if raddr == nil {
+			continue
+		}
+		if n > len(buff) {
+			continue
+		}
+		var rip net.IP
+		if cfg.src == nil {
+			rip = raddr.IP
+		} else {
+			rip = cfg.src
+		}
+		// get a local logger up that will always add some more info
+		ll := log.NewLoggerWithKV(lg, log.KV("json-listener", cfg.name), log.KV("remoteaddress", rip.String()))
+		handleJSONStream(bytes.NewReader(buff[0:]), cfg, rip, tg, ll)
+	}
+
+}
+
 func jsonConnHandler(c net.Conn, cfg jsonHandlerConfig, igst *ingest.IngestMuxer) {
 	cfg.wg.Add(1)
 	id := addConn(c)
@@ -200,13 +273,8 @@ func jsonConnHandler(c net.Conn, cfg jsonHandlerConfig, igst *ingest.IngestMuxer
 	defer delConn(id)
 	defer c.Close()
 	var rip net.IP
-	var lip net.IP // just used for loggin
-	var ts entry.Timestamp
+	var lip net.IP // just used for logging
 	var tg *timegrinder.TimeGrinder
-	var ok bool
-
-	//initialize our tag to the default tag
-	tag := cfg.defTag
 
 	if ipstr, _, err := net.SplitHostPort(c.RemoteAddr().String()); err != nil {
 		lg.Error("failed to get host from remote addr", log.KV("remoteaddress", c.RemoteAddr().String()), log.KVErr(err))
@@ -254,11 +322,25 @@ func jsonConnHandler(c net.Conn, cfg jsonHandlerConfig, igst *ingest.IngestMuxer
 		}
 	}
 
-	dec, err := utils.NewJsonLimitedDecoder(c, cfg.maxObjectSize)
+	if err := handleJSONStream(c, cfg, rip, tg, ll); err != nil {
+		ll.Error("JSON Stream handler error", log.KVErr(err))
+	}
+	return
+}
+
+func handleJSONStream(rdr io.Reader, cfg jsonHandlerConfig, rip net.IP, tg *timegrinder.TimeGrinder, ll *log.KVLogger) error {
+	var ts entry.Timestamp
+	var ok bool
+
+	//initialize our tag to the default tag
+	tag := cfg.defTag
+
+	dec, err := utils.NewJsonLimitedDecoder(rdr, cfg.maxObjectSize)
 	if err != nil {
 		ll.Error("Failed to create limited json decoder", log.KVErr(err))
-		return
+		return err
 	}
+consumerLoop:
 	for {
 		var obj json.RawMessage
 		if err := dec.Decode(&obj); err != nil {
@@ -267,11 +349,12 @@ func jsonConnHandler(c net.Conn, cfg jsonHandlerConfig, igst *ingest.IngestMuxer
 				ll.Error("oversized json object", log.KV("max-size", cfg.maxObjectSize))
 			} else if errors.Is(err, io.EOF) {
 				ll.Info("client disconnected")
+				break consumerLoop //break out of the main loop
 			} else {
 				//just a plain old error
 				ll.Error("invalid json object", log.KV("max-size", cfg.maxObjectSize), log.KVErr(err))
 			}
-			return // we pretty much have to just hang up
+			return err // we pretty much have to just hang up
 		}
 		//we have a message, compact it
 		if cfg.disableCompact {
@@ -291,7 +374,7 @@ func jsonConnHandler(c net.Conn, cfg jsonHandlerConfig, igst *ingest.IngestMuxer
 		} else {
 			if extracted, ok, err := tg.Extract(data); err != nil {
 				ll.Error("catastrophic timegrinder failure", log.KVErr(err))
-				return
+				return err
 			} else if ok {
 				ts = entry.FromStandard(extracted)
 			} else {
@@ -315,6 +398,7 @@ func jsonConnHandler(c net.Conn, cfg jsonHandlerConfig, igst *ingest.IngestMuxer
 		}
 		cfg.proc.ProcessContext(ent, cfg.ctx)
 	}
+	return nil
 }
 
 func compactObject(obj json.RawMessage) (r json.RawMessage) {

--- a/ingesters/SimpleRelay/regexHandlers.go
+++ b/ingesters/SimpleRelay/regexHandlers.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -109,7 +110,7 @@ func startRegexListeners(cfg *cfgType, igst *ingest.IngestMuxer, wg *sync.WaitGr
 
 		if tp.TCP() {
 			//get the socket
-			addr, err := net.ResolveTCPAddr("tcp", v.Bind_String)
+			addr, err := net.ResolveTCPAddr("tcp", str)
 			if err != nil {
 				return fmt.Errorf("%s Bind-String \"%s\" is invalid: %v\n", k, v.Bind_String, err)
 			}
@@ -144,6 +145,18 @@ func startRegexListeners(cfg *cfgType, igst *ingest.IngestMuxer, wg *sync.WaitGr
 			//start the acceptor
 			wg.Add(1)
 			go regexAcceptor(l, connID, igst, rhc, tp)
+		} else if tp.UDP() {
+			addr, err := net.ResolveUDPAddr(tp.String(), str)
+			if err != nil {
+				lg.FatalCode(0, "invalid Bind-String", log.KV("bindstring", v.Bind_String), log.KV("listener", k), log.KVErr(err))
+			}
+			l, err := net.ListenUDP(tp.String(), addr)
+			if err != nil {
+				lg.FatalCode(0, "failed to listen via udp", log.KV("address", addr), log.KV("listener", k), log.KVErr(err))
+			}
+			connID := addConn(l)
+			wg.Add(1)
+			go regexAcceptorUDP(l, connID, rhc, igst)
 		}
 
 	}
@@ -178,6 +191,78 @@ func regexAcceptor(lst net.Listener, id int, igst *ingest.IngestMuxer, cfg regex
 	return
 }
 
+func regexAcceptorUDP(conn *net.UDPConn, id int, cfg regexHandlerConfig, igst *ingest.IngestMuxer) {
+	defer cfg.wg.Done()
+	defer delConn(id)
+	defer conn.Close()
+
+	buff := make([]byte, 16*1024) //local buffer that should be big enough for even the largest UDP packets
+	tcfg := timegrinder.Config{
+		EnableLeftMostSeed: true,
+	}
+	tg, err := timegrinder.NewTimeGrinder(tcfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to get a handle on the timegrinder: %v\n", err)
+		return
+	} else if err = cfg.timeFormats.LoadFormats(tg); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load custom time formats: %v\n", err)
+		return
+	}
+	if cfg.setLocalTime {
+		tg.SetLocalTime()
+	}
+	if cfg.timezoneOverride != `` {
+		err = tg.SetTimezone(cfg.timezoneOverride)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to set timezone to %v: %v\n", cfg.timezoneOverride, err)
+			return
+		}
+	}
+	if cfg.formatOverride != `` {
+		if err = tg.SetFormatOverride(cfg.formatOverride); err != nil {
+			lg.Error("Failed to load format override", log.KV("override", cfg.formatOverride), log.KVErr(err))
+			return
+		}
+	}
+	regex, err := regexp.Compile(cfg.regex)
+	if err != nil {
+		// will never happen (we always check the regex first)
+		return
+	}
+	rs := regexState{
+		rx:          regex,
+		prefixIndex: regex.SubexpIndex("prefix"),
+		suffixIndex: regex.SubexpIndex("suffix"),
+	}
+	if cfg.maxBuffer == 0 {
+		cfg.maxBuffer = DefaultMaxBuffer
+	}
+
+	for {
+		var rip net.IP
+		n, raddr, err := conn.ReadFromUDP(buff)
+		if err != nil {
+			break
+		}
+		if n == 0 {
+			continue
+		}
+		if raddr == nil {
+			continue
+		}
+		if n > len(buff) {
+			continue
+		}
+		if cfg.src == nil {
+			rip = raddr.IP
+		} else {
+			rip = cfg.src
+		}
+		regexLoop(bytes.NewReader(buff[0:]), cfg, rip, rs, tg)
+	}
+
+}
+
 func regexConnHandler(c net.Conn, cfg regexHandlerConfig, igst *ingest.IngestMuxer) {
 	cfg.wg.Add(1)
 	id := addConn(c)
@@ -200,32 +285,21 @@ func regexConnHandler(c net.Conn, cfg regexHandlerConfig, igst *ingest.IngestMux
 		rip = cfg.src
 	}
 
-	out := make(chan *entry.Entry, 128)
-	go regexLoop(c, cfg, rip, out)
-
-	for ent := range out {
-		cfg.proc.ProcessContext(ent, cfg.ctx)
-	}
-}
-
-func regexLoop(c io.Reader, cfg regexHandlerConfig, rip net.IP, out chan *entry.Entry) {
-	var tg *timegrinder.TimeGrinder
-	var ts entry.Timestamp
-	var regex *regexp.Regexp
-	var err error
-	var ok bool
-
-	if regex, err = regexp.Compile(cfg.regex); err != nil {
+	regex, err := regexp.Compile(cfg.regex)
+	if err != nil {
 		// will never happen (we always check the regex first)
 		return
 	}
-	prefixIndex := regex.SubexpIndex("prefix")
-	suffixIndex := regex.SubexpIndex("suffix")
-
+	rs := regexState{
+		rx:          regex,
+		prefixIndex: regex.SubexpIndex("prefix"),
+		suffixIndex: regex.SubexpIndex("suffix"),
+	}
 	if cfg.maxBuffer == 0 {
 		cfg.maxBuffer = DefaultMaxBuffer
 	}
 
+	var tg *timegrinder.TimeGrinder
 	if !cfg.ignoreTimestamps {
 		var err error
 		tcfg := timegrinder.Config{
@@ -257,14 +331,28 @@ func regexLoop(c io.Reader, cfg regexHandlerConfig, rip net.IP, out chan *entry.
 		}
 	}
 
-	defer close(out)
-	rd := make([]byte, 1024)
+	regexLoop(c, cfg, rip, rs, tg)
+}
+
+type regexState struct {
+	rx          *regexp.Regexp
+	prefixIndex int
+	suffixIndex int
+}
+
+func regexLoop(c io.Reader, cfg regexHandlerConfig, rip net.IP, rs regexState, tg *timegrinder.TimeGrinder) {
+	var ts entry.Timestamp
+	var err error
+	var ok bool
+
+	rd := make([]byte, 4096)
 	bio := bufio.NewReader(c)
 	var buf bytes.Buffer // we read from the connection into this buffer
 	var data []byte
 	var prefix, suffix []byte
 	var done bool
 	var n int
+readerLoop:
 	for !done {
 		// we build the entry data into this buffer.
 		// make a new one on each loop so we're safe to call Bytes() at the end
@@ -286,7 +374,7 @@ func regexLoop(c io.Reader, cfg regexHandlerConfig, rip net.IP, out chan *entry.
 			var entryData bytes.Buffer
 			entryData.Write(prefix)
 			b := buf.Bytes()
-			match := regex.FindIndex(b)
+			match := rs.rx.FindIndex(b)
 			// if there's no match, continue, *unless* we saw EOF in which case just send it
 			if match != nil {
 				// if there is a match, grab the bytes preceding it
@@ -294,14 +382,14 @@ func regexLoop(c io.Reader, cfg regexHandlerConfig, rip net.IP, out chan *entry.
 				// read the actual contents of the match
 				contents := buf.Next(match[1] - match[0])
 				// see if there's any prefix/suffix stuff
-				parts := regex.FindSubmatch(contents)
-				if prefixIndex >= 0 && len(parts) >= prefixIndex {
-					prefix = parts[prefixIndex]
+				parts := rs.rx.FindSubmatch(contents)
+				if rs.prefixIndex >= 0 && len(parts) >= rs.prefixIndex {
+					prefix = parts[rs.prefixIndex]
 				} else {
 					prefix = []byte{} // shouldn't happen
 				}
-				if suffixIndex >= 0 && len(parts) >= suffixIndex {
-					suffix = parts[suffixIndex]
+				if rs.suffixIndex >= 0 && len(parts) >= rs.suffixIndex {
+					suffix = parts[rs.suffixIndex]
 				} else {
 					suffix = []byte{} // shouldn't happen
 				}
@@ -325,7 +413,7 @@ func regexLoop(c io.Reader, cfg regexHandlerConfig, rip net.IP, out chan *entry.
 			// syslog messages by just matching on the priority + date part at the beginning, we're going to start out with an empty
 			// "entry" because the very first thing we see is the delimiter.
 			if entryData.Len() == 0 {
-				continue
+				continue readerLoop
 			}
 
 			data = entryData.Bytes()
@@ -352,8 +440,7 @@ func regexLoop(c io.Reader, cfg regexHandlerConfig, rip net.IP, out chan *entry.
 				Tag:  cfg.defTag,
 				Data: data,
 			}
-
-			out <- ent
+			cfg.proc.ProcessContext(ent, cfg.ctx)
 		}
 	}
 }

--- a/ingesters/SimpleRelay/regexHandlers.go
+++ b/ingesters/SimpleRelay/regexHandlers.go
@@ -146,11 +146,11 @@ func startRegexListeners(cfg *cfgType, igst *ingest.IngestMuxer, wg *sync.WaitGr
 			wg.Add(1)
 			go regexAcceptor(l, connID, igst, rhc, tp)
 		} else if tp.UDP() {
-			addr, err := net.ResolveUDPAddr(tp.String(), str)
+			addr, err := net.ResolveUDPAddr(`udp`, str)
 			if err != nil {
 				lg.FatalCode(0, "invalid Bind-String", log.KV("bindstring", v.Bind_String), log.KV("listener", k), log.KVErr(err))
 			}
-			l, err := net.ListenUDP(tp.String(), addr)
+			l, err := net.ListenUDP(`udp`, addr)
 			if err != nil {
 				lg.FatalCode(0, "failed to listen via udp", log.KV("address", addr), log.KV("listener", k), log.KVErr(err))
 			}
@@ -258,7 +258,7 @@ func regexAcceptorUDP(conn *net.UDPConn, id int, cfg regexHandlerConfig, igst *i
 		} else {
 			rip = cfg.src
 		}
-		regexLoop(bytes.NewReader(buff[0:]), cfg, rip, rs, tg)
+		regexLoop(bytes.NewReader(buff[:n]), cfg, rip, rs, tg)
 	}
 
 }


### PR DESCRIPTION
Updates the regexListener in simple relay so that we can do UDP, TCP, TLS.  UDP was missing.

I had to change some form and function a bit for regex loop so that i didn't have to duplicate a bunch of code for UDP.

This should remove some needless async too though, so maybe resource reduction.

This PR addresses https://github.com/gravwell/gravwell/issues/623