### PR TITLE
if Community is unset, accept traps from any community

### DIFF
--- a/ingesters/snmp/main.go
+++ b/ingesters/snmp/main.go
@@ -129,7 +129,7 @@ func main() {
 					log.KV("expected-flags", 0x3&l.Params.MsgFlags),
 					log.KV("client", u.IP.String()))
 				return
-			} else if l.Params.Version == gosnmp.Version2c && s.Community != l.Params.Community {
+			} else if l.Params.Version == gosnmp.Version2c && l.Params.Community != "" && s.Community != l.Params.Community {
 				ib.Logger.Warn("dropping trap due to invalid community",
 					log.KV("received-community", s.Community),
 					log.KV("received-community", l.Params.Community),


### PR DESCRIPTION
This gives people a little more flexibility. You can set the  `Community` to require a community string on traps, or leave it blank to accept everything.