### PR TITLE
Improve the HEC listener.

### DIFF
--- a/ingesters/HttpIngester/gravwell_http_ingester.conf
+++ b/ingesters/HttpIngester/gravwell_http_ingester.conf
@@ -73,7 +73,7 @@ Health-Check-URL="/health/check"
 #
 # Example that creates a listener that is API compatible with the Splunk HEC
 #[HEC-Compatible-Listener "testing"]
-#	#URL="/services/collector/event" #If URL is omitted, the default is set to /services/collector/event
+#	#URL="/services/collector" #If URL is omitted, the default is set to /services/collector
 #	TokenValue="thisisyourtoken" #set the access control token
 #	Tag-Name=HECStuff
 #

--- a/ingesters/HttpIngester/hec.go
+++ b/ingesters/HttpIngester/hec.go
@@ -34,11 +34,11 @@ const (
 
 type hecHandler struct {
 	hecHealth
-	name      string
-	acking    bool
-	id        uint64
-	tagRouter map[string]entry.EntryTag
-	maxSize   uint
+	name           string
+	id             uint64
+	tagRouter      map[string]entry.EntryTag
+	rawLineBreaker string
+	maxSize        uint
 }
 
 type hecEvent struct {
@@ -81,8 +81,7 @@ func (c *custTime) UnmarshalJSON(v []byte) (err error) {
 	return
 }
 
-func (hh *hecHandler) handle(h *handler, cfg routeHandler, w http.ResponseWriter, rdr io.Reader, ip net.IP) {
-	var id uint64
+func (hh *hecHandler) handle(h *handler, cfg routeHandler, w http.ResponseWriter, r *http.Request, rdr io.Reader, ip net.IP) {
 	// get a local logger up that will always add some more info
 	ll := log.NewLoggerWithKV(h.lgr, log.KV("HEC-Listener", hh.name), log.KV("remoteaddress", ip.String()))
 	dec, err := utils.NewJsonLimitedDecoder(rdr, int64(maxBody+256)) //give some slack for the extra splunk garbage
@@ -166,18 +165,15 @@ loop:
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		if hh.acking {
-			id = atomic.AddUint64(&hh.id, 1)
-		}
 	}
-	if hh.acking {
+	if ackRequested(r) {
 		json.NewEncoder(w).Encode(ack{
-			ID: strconv.FormatUint(id, 10),
+			ID: strconv.FormatUint(atomic.AddUint64(&hh.id, 1), 10),
 		})
 	}
 }
 
-func (hh *hecHandler) handleRaw(h *handler, cfg routeHandler, w http.ResponseWriter, rdr io.Reader, ip net.IP) {
+func (hh *hecHandler) handleRaw(h *handler, cfg routeHandler, w http.ResponseWriter, r *http.Request, rdr io.Reader, ip net.IP) {
 	debugout("HEC RAW\n")
 	b, err := ioutil.ReadAll(io.LimitReader(rdr, int64(maxBody+1)))
 	if err != nil && err != io.EOF {
@@ -192,12 +188,16 @@ func (hh *hecHandler) handleRaw(h *handler, cfg routeHandler, w http.ResponseWri
 	if len(b) == 0 {
 		h.lgr.Info("got an empty post", log.KV("address", ip))
 		return
-	} else if err = h.handleEntry(cfg, b, ip); err != nil {
-		h.lgr.Error("failed to handle entry", log.KV("address", ip), log.KVErr(err))
-		w.WriteHeader(http.StatusInternalServerError)
-		return
+	} else {
+		for _, b := range bytes.Split(b, []byte(hh.rawLineBreaker)) {
+			if err = h.handleEntry(cfg, b, ip); err != nil {
+				h.lgr.Error("failed to handle entry", log.KV("address", ip), log.KVErr(err))
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+		}
 	}
-	if hh.acking {
+	if ackRequested(r) {
 		json.NewEncoder(w).Encode(ack{
 			ID: strconv.FormatUint(atomic.AddUint64(&hh.id, 1), 10),
 		})
@@ -254,4 +254,23 @@ func fixupMaxSize(v int) uint {
 		return uint(v)
 	}
 	return defaultMaxHECEventSize
+}
+
+// ackRequested returns true if we need to send an ackID for this request.
+// It is true if they set a Channel ID in either a header named
+// `X-Splunk-Request-Channel` or in a URL query parameter named `channel`.
+func ackRequested(r *http.Request) bool {
+	if r == nil {
+		// safeguard
+		return false
+	}
+	if q := r.URL.Query(); q != nil {
+		if _, ok := q["channel"]; ok {
+			return true
+		}
+	}
+	if r.Header != nil && r.Header.Get("X-Splunk-Request-Channel") != "" {
+		return true
+	}
+	return false
 }

--- a/ingesters/HttpIngester/kinesisdeliverystream.go
+++ b/ingesters/HttpIngester/kinesisdeliverystream.go
@@ -80,7 +80,7 @@ type record struct {
 	Data []byte `json:"data"`
 }
 
-func handleKDS(h *handler, cfg routeHandler, w http.ResponseWriter, rdr io.Reader, ip net.IP) {
+func handleKDS(h *handler, cfg routeHandler, w http.ResponseWriter, r *http.Request, rdr io.Reader, ip net.IP) {
 	var kr kinesisRequest
 	if err := json.NewDecoder(io.LimitReader(rdr, int64(maxBody+256))).Decode(&kr); err != nil {
 		h.lgr.Info("bad request", log.KV("address", ip), log.KVErr(err))


### PR DESCRIPTION
Change the URL parameter for HEC-Compatible-Listener to be the base (`/services/collector`) instead of the "event" path (`/services/collector/event`). This may be a breaking change for some setups, but I think we can make the following assumptions:

1. Most deployments with the HEC listener are using the default
2. Even if someone specified `URL=/services/collector/event`, it will still work ok because we'll listen on that endpoint with the same handler as on `/services/collector/event/event`. ACKs won't be quite right, but ACKs weren't quite right anyway.

The raw endpoint now splits on lines. You can specify a different line break string via e.g. `Raw-Line-Breaker=";"`

If an ACK is requested (by specifying a channel in the request) we will always send an ACK ID.

Also improves logging to the gravwell tag.