### PR TITLE
HTTP/HEC: we changed how URL works, so we need to treat it differently

### DIFF
--- a/ingesters/HttpIngester/hec_config.go
+++ b/ingesters/HttpIngester/hec_config.go
@@ -187,7 +187,7 @@ func includeHecListeners(hnd *handler, igst *ingest.IngestMuxer, cfg *cfgType, l
 			lg.Error("failed to generate HEC-Compatible-Listener auth", log.KVErr(err))
 			return
 		}
-		bp := path.Dir(v.URL)
+		bp := v.URL
 		//had the main handler for events
 		if err = hnd.addHandler(http.MethodPost, v.URL, hcfg); err != nil {
 			lg.Error("failed to add HEC-Compatible-Listener handler", log.KVErr(err))


### PR DESCRIPTION
We previously expected you to say `URL=/services/collector/event` and then we needed to get `/services/collector` from that to figure out other paths. Now we expect you to say `URL=/services/connector` and we build from that, but I forgot to change this line.

