### PR TITLE
Fixing up preprocessors to maintain EVs

### DIFF
--- a/client/types/searchentry.go
+++ b/client/types/searchentry.go
@@ -110,6 +110,10 @@ func enumeratedEqual(a, b []EnumeratedPair) bool {
 			return false
 		} else if a[i].Value != b[i].Value {
 			return false
+		} else if a[i].RawValue.Type != b[i].RawValue.Type {
+			return false
+		} else if !bytes.Equal(a[i].RawValue.Data, b[i].RawValue.Data) {
+			return false
 		}
 	}
 	return true

--- a/generators/gravwellGenerator/regex.ax
+++ b/generators/gravwellGenerator/regex.ax
@@ -1,4 +1,3 @@
-# Extraction defintion for the regex generator with everything
 [[extraction]]
 	name="regex"
 	module="regex"

--- a/ingest/entry/entry.go
+++ b/ingest/entry/entry.go
@@ -88,6 +88,27 @@ func (ent *Entry) AddEnumeratedValueEx(name string, val interface{}) error {
 	return nil
 }
 
+// GetEnumeratedValue looks up an enumerated value by name and returns it as a native type
+// if the value is not present the function returns nil and false
+func (ent *Entry) GetEnumeratedValue(name string) (val interface{}, ok bool) {
+	var ev EnumeratedValue
+	if ent == nil {
+		return
+	}
+	if ev, ok = ent.evb.Get(name); ok {
+		val = ev.Value.Interface()
+		ok = (val != nil)
+	}
+	return
+}
+
+func (ent *Entry) CopyEnumeratedBlock(sent *Entry) {
+	if ent == nil || sent == nil || !sent.evb.Populated() {
+		return
+	}
+	ent.evb.Append(sent.evb)
+}
+
 // Size returns the size of an entry as if it were encoded.
 func (ent *Entry) Size() uint64 {
 	return uint64(len(ent.Data)) + uint64(ENTRY_HEADER_SIZE) + ent.evb.Size()

--- a/ingest/entry/enumeratedblock.go
+++ b/ingest/entry/enumeratedblock.go
@@ -100,6 +100,30 @@ func (eb evblock) Valid() error {
 	return nil
 }
 
+// Get retrieves an enumerated value from the set using a name
+// if the name does not exist an empty  EnumeratedValue and ok = false will be returned
+func (eb evblock) Get(name string) (ev EnumeratedValue, ok bool) {
+	for i := range eb.evs {
+		if eb.evs[i].Name == name {
+			ev = eb.evs[i]
+			ok = true
+			break
+		}
+	}
+	return
+}
+
+// Append appends one evblock to another.  This function DOES NOT de-duplicate enumerated values
+// if the src block already has foobar and so does the destination it will be duplicated
+func (eb *evblock) Append(seb evblock) {
+	for _, v := range seb.evs {
+		if v.Valid() {
+			eb.Add(v)
+		}
+	}
+	return
+}
+
 // Encode encodes an evblock into a byte buffer.
 func (eb evblock) Encode() (bts []byte, err error) {
 	// check if its valid

--- a/ingest/processors/corelight_test.go
+++ b/ingest/processors/corelight_test.go
@@ -105,6 +105,7 @@ func TestCorelightTransitions(t *testing.T) {
 	var ent entry.Entry
 	for i, v := range corelightTestData {
 		ent.Data = []byte(v.input)
+		ent.AddEnumeratedValueEx(`testing`, "foobar")
 		if ents, err := c.Process([]*entry.Entry{&ent}); err != nil {
 			t.Fatalf("failed to process %d: %v\n", i, err)
 		} else if len(ents) != 1 {
@@ -115,6 +116,12 @@ func TestCorelightTransitions(t *testing.T) {
 			t.Fatal("failed to lookup tag")
 		} else if tn != v.tag {
 			t.Fatalf("invalid tag: %v != %v", tn, v.tag)
+		} else {
+			for _, ent := range ents {
+				if x, ok := ent.GetEnumeratedValue(`testing`); !ok || x == nil {
+					t.Fatal("missing testing enumerated value")
+				}
+			}
 		}
 	}
 }

--- a/ingest/processors/jsonsplit.go
+++ b/ingest/processors/jsonsplit.go
@@ -166,14 +166,17 @@ func (je *JsonArraySplitter) processItem(ent *entry.Entry) (rset []*entry.Entry,
 				return
 			}
 			if data, cnt := je.bldr.render(); cnt > 0 {
-				rset = append(rset, &entry.Entry{
+				tent := &entry.Entry{
 					Tag:  ent.Tag,
 					SRC:  ent.SRC,
 					TS:   ent.TS,
 					Data: data,
-				})
+				}
+				tent.CopyEnumeratedBlock(ent)
+				rset = append(rset, tent)
 			}
 		} else if r, ok := je.genEntry(dt, ent, v); ok {
+			r.CopyEnumeratedBlock(ent)
 			rset = append(rset, r)
 		}
 		return

--- a/ingest/processors/jsonsplit_test.go
+++ b/ingest/processors/jsonsplit_test.go
@@ -167,6 +167,9 @@ func TestJsonArraySplit(t *testing.T) {
 				string(rset[i].Data), testJSONArrayValues[i])
 		}
 	}
+	if err := checkEntryEVs(rset); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestJsonArraySplitData(t *testing.T) {

--- a/ingest/processors/srcrouter_test.go
+++ b/ingest/processors/srcrouter_test.go
@@ -146,6 +146,12 @@ func TestSrcRouterProcess(t *testing.T) {
 			t.Fatalf("tagger didn't create tag %v", v.tag)
 		} else if tg != ent.Tag && !v.drop {
 			t.Fatalf("Invalid tag results for src %v: %v != %v", v.src, tg, ent.Tag)
+		} else {
+			for _, ent := range set {
+				if x, ok := ent.GetEnumeratedValue(`testing`); !ok || x == nil {
+					t.Fatal("failed to preserve testing EV")
+				}
+			}
 		}
 	}
 
@@ -164,10 +170,12 @@ func TestSrcRouterProcess(t *testing.T) {
 }
 
 func makeSrcTestEntry(ip string) *entry.Entry {
-	return &entry.Entry{
+	ent := &entry.Entry{
 		Tag:  0, //doesn't matter
 		SRC:  net.ParseIP(ip),
 		TS:   testTime,
 		Data: []byte(fmt.Sprintf(`foo bar and some other things`)),
 	}
+	ent.AddEnumeratedValueEx(`testing`, uint64(42))
+	return ent
 }

--- a/ingest/processors/vpc.go
+++ b/ingest/processors/vpc.go
@@ -166,6 +166,7 @@ func (p *Vpc) processItem(ent *entry.Entry) (rset []*entry.Entry, err error) {
 			Data: v,
 			TS:   entry.UnixTime(ts, 0),
 		}
+		r.CopyEnumeratedBlock(ent)
 		rset = append(rset, r)
 	}
 	return

--- a/ingest/processors/vpc_test.go
+++ b/ingest/processors/vpc_test.go
@@ -62,12 +62,20 @@ func TestVPCLoadConfig(t *testing.T) {
 		t.Fatal(err)
 	} else if len(set) != 4 {
 		t.Fatalf("Invalid cloud watch log count: %d != 4", len(set))
+	} else {
+		if err := checkEntryEVs(set); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	if set, err := p.Process(makeEntry(makeCloudWatchLog(4, true), 0)); err != nil {
 		t.Fatal(err)
 	} else if len(set) != 4 {
 		t.Fatalf("Invalid cloud watch log count: %d != 4", len(set))
+	} else {
+		if err := checkEntryEVs(set); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 }


### PR DESCRIPTION
This PR does the folllowing:
1. Adds a method on entry.Entry to copy enumerated values from one to another
2. Adds a method on entry.Entry to retrieve enumerated values
3. Updates the preprocessors that create wholly new entries (splitters, etc...) to preserve EVs from the original
4. Adds tests to ensure we don't have regressions


This PR addresses https://github.com/gravwell/backend/pull/584