### PR TITLE
fix the kinesis ingester config example

### DIFF
--- a/ingesters/HttpIngester/gravwell_http_ingester.conf
+++ b/ingesters/HttpIngester/gravwell_http_ingester.conf
@@ -78,8 +78,7 @@ Health-Check-URL="/health/check"
 #	Tag-Name=HECStuff
 #
 # Example that creates a listener that is API compatible with the Amazon Kinesis Delivery Stream
-#[Kinesis-Delivery-Stream "testing"]
+#[Kinesis-Delivery-Stream-Listener "testing"]
 #	URL="/kinesis/stream/foobar"
-#	TokenName="gravwell" #set this to your token name
 #	TokenValue="thisisyourtoken" #set the access control token
 #	Tag-Name=KDSStuff


### PR DESCRIPTION
example in config was wrong.

Kinesis delivery stream is unsupported, but the config snippets should still be right.