### PR TITLE
Add custom marshallers for some ABAC types.

### DIFF
--- a/client/types/abac.go
+++ b/client/types/abac.go
@@ -9,6 +9,7 @@
 package types
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 	"time"
@@ -131,6 +132,16 @@ type CapabilitySet struct {
 type CapabilityState struct {
 	Default   DefaultAccessRule
 	Overrides []string
+}
+
+func (cs CapabilityState) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Default   DefaultAccessRule
+		Overrides emptyStrings
+	}{
+		cs.Default,
+		cs.Overrides,
+	})
 }
 
 // CapabilityDesc is an enhanced structure containing a capability value, its name, and a brief description
@@ -778,6 +789,16 @@ type CapError struct {
 type TagAccess struct {
 	Default   DefaultAccessRule
 	Overrides []string //override sets an explicit allow or deny depending on Default state
+}
+
+func (ta TagAccess) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Default   DefaultAccessRule
+		Overrides emptyStrings
+	}{
+		ta.Default,
+		ta.Overrides,
+	})
 }
 
 // check returns two values:


### PR DESCRIPTION
Javascript really does not like to get a null when it expects an empty array, but that's what Go will send if your struct contains e.g. a []string and you don't explicitly initialize the slice. These custom marshallers make sure we send an empty array, making the frontend's life easier.

Go desperately needs some way to tell the JSON encoder that we want this behavior, see:

https://github.com/golang/go/issues/37711
https://github.com/golang/go/issues/27589
https://github.com/golang/go/pull/27813