### PR TITLE
fixing up the file follower 

### DIFF
--- a/filewatch/filewatch.go
+++ b/filewatch/filewatch.go
@@ -39,6 +39,7 @@ var (
 	ErrInvalidStateFile = errors.New("State file exists and is not a regular file")
 	ErrAlreadyStarted   = errors.New("WatchManager already started")
 	ErrFailedSeek       = errors.New("Failed to seek to the start of the states file")
+	ErrFsNotifyOverflow = errors.New("FSNotify kernel event buffer overflow")
 )
 
 type WatchManager struct {
@@ -355,6 +356,8 @@ watchRoutine:
 					log.KVErr(err),
 					log.KV("max_queued_events", string(d)),
 					log.KV("help", "https://docs.gravwell.io/ingesters/file_follow.html#kernel-parameter-tuning"))
+			} else {
+				wm.logger.Error("fsnotify event queue error", log.KVErr(err)) //log it and continue
 			}
 			err = nil
 		case evt, ok := <-wm.watcher.Events:

--- a/filewatch/liner_linux.go
+++ b/filewatch/liner_linux.go
@@ -82,3 +82,15 @@ func (lr *LineReader) ReadEntry() (ln []byte, ok bool, wasEOF bool, err error) {
 	}
 	return
 }
+
+func (lr *LineReader) ReadRemaining() (ln []byte, err error) {
+	var ok bool
+	if ln, ok, _, err = lr.ReadEntry(); err != nil || ok == true {
+		// error or complete success
+		return
+	} else if len(lr.currLine) != 0 {
+		ln = lr.currLine
+		lr.currLine = nil
+	}
+	return
+}

--- a/filewatch/liner_windows.go
+++ b/filewatch/liner_windows.go
@@ -118,6 +118,18 @@ func (lr *LineReader) ReadEntry() (ln []byte, ok bool, sawEOF bool, err error) {
 	return
 }
 
+func (lr *LineReader) ReadRemaining() (ln []byte, err error) {
+	var ok bool
+	if ln, ok, _, err = lr.ReadEntry(); err != nil || ok == true {
+		// error or complete success
+		return
+	} else if len(lr.currLine) != 0 {
+		ln = lr.currLine
+		lr.currLine = nil
+	}
+	return
+}
+
 func (lr *LineReader) Index() int64 {
 	return lr.idx
 }

--- a/filewatch/reader.go
+++ b/filewatch/reader.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	maxLine       int = 8 * 1024 * 1024 //8MB
-	buffBlockSize int = 4096
+	maxLine          int = 8 * 1024 * 1024 //8MB
+	buffBlockSize    int = 4096
+	maxRemainingRead int = 1024 * 1024
 )
 
 const (
@@ -26,6 +27,7 @@ const (
 type Reader interface {
 	SeekFile(int64) error
 	ReadEntry() ([]byte, bool, bool, error)
+	ReadRemaining() ([]byte, error)
 	Index() int64
 	Close() error
 }

--- a/filewatch/reader_windows.go
+++ b/filewatch/reader_windows.go
@@ -125,6 +125,12 @@ func (evr *EvtxReader) Close() error {
 	return evr.Fin.Close()
 }
 
+// ReadRemaining is special on the EvtxReader, we won't ever have "dangling" stuff
+// so ReadRemaining makes no sense at all, just return A-OK!
+func (evr *EvtxReader) ReadRemaining() (ln []byte, err error) {
+	return
+}
+
 func (evr *EvtxReader) ReadEntry() (ln []byte, ok bool, wasEOF bool, err error) {
 	var evtHnds []wineventlog.EvtHandle
 	var id uint64

--- a/filewatch/regex.go
+++ b/filewatch/regex.go
@@ -96,6 +96,18 @@ func (rr *RegexReader) ReadEntry() (ln []byte, ok bool, wasEOF bool, err error) 
 	return
 }
 
+func (rr *RegexReader) ReadRemaining() (ln []byte, err error) {
+	var ok bool
+	if ln, ok, _, err = rr.ReadEntry(); err != nil || ok == true {
+		// error or complete success
+		return
+	} else if len(rr.currLine) != 0 {
+		ln = rr.currLine
+		rr.currLine = nil
+	}
+	return
+}
+
 func (rr *RegexReader) splitter(data []byte) (int, []byte, error) {
 	if len(data) == 0 {
 		return 0, nil, nil


### PR DESCRIPTION
so that if its been long enough and we don't have a trailing delimiter, we just consume the last entry.  This to deal with files that don't write a trailing newline

This PR addresses https://github.com/gravwell/gravwell/issues/668