### PR TITLE
adding OSV TOML to announce invalid vuln reports

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,3 @@
+[[IgnoredVulns]]
+id = "GO-2022-0646"
+reason = "The Gravwell S3 ingester is a read only system and does not perform any KMS operations, nor should it be given write access to S3 buckets"


### PR DESCRIPTION
We don't use the S3 library in the way the vuln describes and don't want/need write permissions for S3 buckets.   We also don't support KMS in the ingester, so basically its not possible to trigger the Amazon library vulnerability using our ingester.