### PR TITLE
Remove GetTags capability

### DIFF
--- a/client/types/cbac.go
+++ b/client/types/cbac.go
@@ -27,7 +27,7 @@ const (
 	SaveSearch         Capability = 2
 	AttachSearch       Capability = 3
 	BackgroundSearch   Capability = 4
-	GetTags            Capability = 5
+	_                  Capability = 5
 	SetSearchGroup     Capability = 6
 	SearchHistory      Capability = 7
 	SearchGroupHistory Capability = 8
@@ -231,8 +231,6 @@ func (c Capability) Name() string {
 		return `AttachSearch`
 	case BackgroundSearch:
 		return `BackgroundSearch`
-	case GetTags:
-		return `GetTags`
 	case SetSearchGroup:
 		return `SetSearchGroup`
 	case SearchHistory:
@@ -335,8 +333,6 @@ func (c Capability) Category() CapabilityCategory {
 	case AttachSearch:
 		return SearchCat
 	case BackgroundSearch:
-		return SearchCat
-	case GetTags:
 		return SearchCat
 	case SetSearchGroup:
 		return SearchCat
@@ -460,8 +456,6 @@ func (c *Capability) Parse(v string) (err error) {
 		*c = AttachSearch
 	case `backgroundsearch`:
 		*c = BackgroundSearch
-	case `gettags`:
-		*c = GetTags
 	case `setsearchgroup`:
 		*c = SetSearchGroup
 	case `searchhistory`:
@@ -567,8 +561,6 @@ func (c Capability) String() string {
 		return `Save Search`
 	case BackgroundSearch:
 		return `Background Search`
-	case GetTags:
-		return `Get Tags`
 	case SetSearchGroup:
 		return `Set Search Group`
 	case SearchHistory:
@@ -672,8 +664,6 @@ func (c Capability) Description() string {
 		return `User can save search results for later viewing`
 	case BackgroundSearch:
 		return `User can launch queries in the background`
-	case GetTags:
-		return `User can get a complete list of tags available`
 	case SetSearchGroup:
 		return `User can set the default search group`
 	case SearchHistory:

--- a/client/types/cbac_templates.go
+++ b/client/types/cbac_templates.go
@@ -29,7 +29,6 @@ var (
 		AttachSearch.CapabilityDesc(),
 		SaveSearch.CapabilityDesc(),
 		BackgroundSearch.CapabilityDesc(),
-		GetTags.CapabilityDesc(),
 		SetSearchGroup.CapabilityDesc(),
 		SearchHistory.CapabilityDesc(),
 		SearchGroupHistory.CapabilityDesc(),
@@ -79,7 +78,6 @@ var (
 		Search,
 		Download,
 		AttachSearch,
-		GetTags,
 		SetSearchGroup, //required to be able to search if default group is set
 		SearchHistory,
 		SearchGroupHistory,

--- a/client/types/cbac_test.go
+++ b/client/types/cbac_test.go
@@ -302,16 +302,16 @@ func TestCapabilityList(t *testing.T) {
 			GroupDetails{CBAC: CBACRules{Capabilities: testGetAllCaps()}},
 		},
 	}
-	if lst := ud.CapabilityList(); len(lst) != int(_maxCap) {
+	if lst := ud.CapabilityList(); len(lst) != len(fullCapList) {
 		t.Fatalf("wide open user does not have all capabilities: %d != %d", len(lst), _maxCap)
 	}
 
 	ud.Groups[1].CBAC.Capabilities = CapabilitySet{}
 	//allow a few explicite in the group
-	ud.Groups[1].CBAC.Capabilities.Set(GetTags)
+	ud.Groups[1].CBAC.Capabilities.Set(Download)
 	if lst := ud.CapabilityList(); len(lst) != 1 {
 		t.Fatalf("shut out user has capabilities: %d != 1", len(lst))
-	} else if lst[0].Name != GetTags.Name() {
+	} else if lst[0].Name != Download.Name() {
 		t.Fatalf("invalid allowed list: %v", lst)
 	}
 }


### PR DESCRIPTION
We control access to tags separately, and it doesn't make sense to hide the *list* of tags the user has access to -- they've been explicitly granted permission to use those tags!

