### PR TITLE
make the ingest library build on macos, with or without m1

### DIFF
--- a/ingest/log/stderrlog_unix.go
+++ b/ingest/log/stderrlog_unix.go
@@ -38,7 +38,7 @@ func newStderrLogger(fileOverride string, cb StderrCallback) (lgr *Logger, err e
 		}
 
 		//dupe the output file onto stderr so that output goes there
-		if err = syscall.Dup3(int(fout.Fd()), int(os.Stderr.Fd()), 0); err != nil {
+		if err = syscall.Dup2(int(fout.Fd()), int(os.Stderr.Fd())); err != nil {
 			fout.Close()
 		}
 	}

--- a/ingest/processors/persistent_buffer.go
+++ b/ingest/processors/persistent_buffer.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build linux || darwin
+// +build linux darwin
 
 /*************************************************************************
  * Copyright 2018 Gravwell, Inc. All rights reserved.

--- a/ingest/processors/processors_darwin.go
+++ b/ingest/processors/processors_darwin.go
@@ -1,0 +1,57 @@
+/*************************************************************************
+ * Copyright 2018 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
+package processors
+
+import (
+	"strings"
+
+	"github.com/gravwell/gravwell/v3/ingest/config"
+)
+
+func checkProcessorOS(id string) error {
+	switch id {
+	case PersistentBufferProcessor:
+	default:
+		return ErrUnknownProcessor
+	}
+	return nil
+}
+
+func processorLoadConfigOS(vc *config.VariableConfig) (cfg interface{}, err error) {
+	var pb preprocessorBase
+	if err = vc.MapTo(&pb); err != nil {
+		return
+	}
+	switch strings.TrimSpace(strings.ToLower(pb.Type)) {
+	case PersistentBufferProcessor:
+		cfg, err = PersistentBufferLoadConfig(vc)
+	default:
+		err = ErrUnknownProcessor
+	}
+	return
+}
+
+func newProcessorOS(vc *config.VariableConfig, tgr Tagger) (p Processor, err error) {
+	var pb preprocessorBase
+	if err = vc.MapTo(&pb); err != nil {
+		return
+	}
+	id := strings.TrimSpace(strings.ToLower(pb.Type))
+	switch id {
+	case PersistentBufferProcessor:
+		var cfg PersistentBufferConfig
+		if err = vc.MapTo(&cfg); err != nil {
+			return
+		}
+		p, err = NewPersistentBuffer(cfg, tgr)
+	default:
+		err = ErrUnknownProcessor
+	}
+	return
+}


### PR DESCRIPTION
We don't actually use close on exec in Dup3, so Dup2 is fine, which macOS requires. The only other fix is a build constraint.