### PR TITLE
Add ExternalAddr to GUISettings object

### DIFF
--- a/client/searchCtrl.go
+++ b/client/searchCtrl.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -320,7 +321,15 @@ func (c *Client) StartSearchEx(sr types.StartSearchRequest) (s Search, err error
 
 // SearchURL returns a URL string that points at an existing search.
 func (c *Client) SearchURL(id string) string {
-	u := c.serverURL
+	u := url.URL{Scheme: c.serverURL.Scheme, Host: c.serverURL.Host, User: c.serverURL.User}
+	// Try to get the ExternalAddr from the webserver, consider that authoritative
+	// from a user's point of view, since the client may be talking via 127.0.0.1
+	// or something (e.g. the searchagent)
+	if gs, err := c.GetGuiSettings(); err == nil {
+		if gs.ExternalAddr != "" {
+			u.Host = gs.ExternalAddr
+		}
+	}
 	u.Path = fmt.Sprintf("search/%s", id)
 	return u.String()
 }

--- a/client/types/api.go
+++ b/client/types/api.go
@@ -263,6 +263,11 @@ type GUISettings struct {
 
 	IngestAllowed bool // set to true if the user is allowed to use the ingest APIs
 	NonCommercial bool // set to true if the license is a non-commercial license
+
+	// The address the webserver considers "external". This can be explicitly set via
+	// the External-Addr field in the webserver's gravwell.conf, otherwise the server
+	// will pick one of its IP addresses.
+	ExternalAddr string
 }
 
 type SearchAgentConfig struct {


### PR DESCRIPTION
This allows the webserver to give its "canonical" address, the one it thinks users should be coming in through.

Also updates the SearchURL function to use that address if available.

