### PR TITLE
Add Attach-Filename and Ignore-Glob to the migrate ingester

### DIFF
--- a/ingesters/utils/ignore_test.go
+++ b/ingesters/utils/ignore_test.go
@@ -6,7 +6,7 @@
  * BSD 2-clause license. See the LICENSE file for details.
  **************************************************************************/
 
-package filewatch
+package utils
 
 import (
 	"testing"
@@ -52,6 +52,24 @@ var ignoreTests = []ignoreTestConfig{
 			},
 		},
 	},
+	{
+		prefixes: []string{},
+		globs:    []string{"*foo*bar*"},
+		inputs: []ignoreInput{
+			{
+				input:      "foo blah",
+				shouldDrop: false,
+			},
+			{
+				input:      "some foo and some bar!",
+				shouldDrop: true,
+			},
+			{
+				input:      "foo and bar",
+				shouldDrop: true,
+			},
+		},
+	},
 }
 
 func TestIgnore(t *testing.T) {
@@ -62,7 +80,7 @@ func TestIgnore(t *testing.T) {
 		}
 		for _, input := range test.inputs {
 			if li.Ignore([]byte(input.input)) != input.shouldDrop {
-				t.Fatal("incorrect drop")
+				t.Fatalf("incorrect drop on: %+v", input)
 			}
 		}
 	}

--- a/ingesters/utils/lineignorer.go
+++ b/ingesters/utils/lineignorer.go
@@ -1,0 +1,54 @@
+/*************************************************************************
+ * Copyright 2023 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
+package utils
+
+import (
+	"bytes"
+
+	"github.com/gobwas/glob"
+)
+
+type LineIgnorer struct {
+	prefixes [][]byte
+	globs    []glob.Glob
+}
+
+func NewIgnorer(prefixes, globs []string) (*LineIgnorer, error) {
+	li := &LineIgnorer{}
+	for _, v := range prefixes {
+		li.prefixes = append(li.prefixes, []byte(v))
+	}
+	for _, v := range globs {
+		c, err := glob.Compile(v)
+		if err != nil {
+			return nil, err
+		}
+		li.globs = append(li.globs, c)
+	}
+	return li, nil
+}
+
+// Ignore returns true if the given byte slice matches any of the prefixes or
+// globs in the ignorer.
+func (l *LineIgnorer) Ignore(b []byte) bool {
+	for _, prefix := range l.prefixes {
+		if bytes.HasPrefix(b, prefix) {
+			return true
+		}
+	}
+
+	bString := string(b)
+	for _, glob := range l.globs {
+		if glob.Match(bString) {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Addresses #707.

Moved the LineIgnorer definition from filewatch to utils so we could apply it here.

