### PR TITLE
EV attach in ingesters

### DIFF
--- a/ingest/attach/attach.go
+++ b/ingest/attach/attach.go
@@ -1,0 +1,144 @@
+/*************************************************************************
+ * Copyright 2023 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
+package attach
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/google/uuid"
+	"github.com/gravwell/gcfg"
+	"github.com/gravwell/gravwell/v3/ingest/entry"
+)
+
+const (
+	nowId  = `$NOW`
+	uuidId = `$UUID`
+	hostId = `$HOSTNAME`
+)
+
+type AttachConfig struct {
+	gcfg.Idxer
+	Vals map[gcfg.Idx]*[]string
+}
+
+type attachItem struct {
+	key   string
+	value string
+}
+
+func (ac AttachConfig) Attachments() ([]attachItem, error) {
+	names := ac.Names()
+	if len(names) == 0 || len(ac.Vals) == 0 {
+		return nil, nil //nothing here
+	}
+	var ats []attachItem
+	for i, name := range names {
+		valptr, ok := ac.Vals[ac.Idx(name)]
+		if !ok || valptr == nil {
+			continue
+		}
+		if vals := *valptr; len(vals) > 1 {
+			return nil, fmt.Errorf("attach key of %q is duplicated %d times", name, len(vals))
+		} else if len(vals) == 1 {
+			if name == `` {
+				return nil, fmt.Errorf("Attach item %d has an empty name", i)
+			} else if vals[0] == `` {
+				return nil, fmt.Errorf("Attach item (%s)%d has an empty value", name, i)
+			}
+			ats = append(ats, attachItem{key: name, value: vals[0]})
+		}
+	}
+	return ats, nil
+}
+
+func (ac AttachConfig) Verify() (err error) {
+	if len(ac.Vals) == 0 {
+		return
+	}
+	_, err = ac.Attachments()
+	return
+}
+
+type dynamic interface {
+	run()
+}
+
+type Attacher struct {
+	active      bool
+	haveDynamic bool
+	evs         []entry.EnumeratedValue
+	dynamics    []dynamic
+}
+
+func NewAttacher(ac AttachConfig, id uuid.UUID) (a *Attacher, err error) {
+	var ats []attachItem
+	a = &Attacher{}
+	if ats, err = ac.Attachments(); err != nil {
+		return
+	} else if len(ats) == 0 {
+		return
+	}
+	a.evs = make([]entry.EnumeratedValue, len(ats))
+	for i, at := range ats {
+		a.evs[i].Name = at.key
+		switch at.value {
+		case hostId:
+			// we are not going to dynamically resolve the hostname every time
+			// do it once and treat it as a constant
+			var hostname string
+			if hostname, err = os.Hostname(); err != nil {
+				return nil, fmt.Errorf("Attach item %s(%d) failed to get hostname: %v", at.key, i, err)
+			}
+			a.evs[i].Value = entry.StringEnumData(hostname)
+		case uuidId:
+			a.evs[i].Value = entry.StringEnumData(id.String())
+		case nowId:
+			a.haveDynamic = true
+			nts := newTimeDynamic(&a.evs[i].Value)
+			a.dynamics = append(a.dynamics, nts)
+		default:
+			a.evs[i].Value = entry.StringEnumData(at.value)
+		}
+	}
+	a.active = len(a.evs) > 0
+	return
+}
+
+func (a *Attacher) Attach(ent *entry.Entry) {
+	if a == nil || a.active == false {
+		return
+	} else if a.haveDynamic {
+		for _, d := range a.dynamics {
+			d.run()
+		}
+	}
+	ent.AddEnumeratedValues(a.evs)
+}
+
+func (a *Attacher) Active() bool {
+	if a != nil && a.active {
+		return true
+	}
+	return false
+}
+
+type timeDynamic struct {
+	ed *entry.EnumeratedData
+}
+
+func newTimeDynamic(ed *entry.EnumeratedData) dynamic {
+	return &timeDynamic{
+		ed: ed,
+	}
+}
+
+func (t timeDynamic) run() {
+	*t.ed = entry.TSEnumData(entry.Now())
+}

--- a/ingest/attach/attach_test.go
+++ b/ingest/attach/attach_test.go
@@ -1,0 +1,209 @@
+/*************************************************************************
+ * Copyright 2023 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
+package attach
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gravwell/gravwell/v3/ingest/config"
+	"github.com/gravwell/gravwell/v3/ingest/entry"
+)
+
+type testConfigStruct struct {
+	Attach AttachConfig
+}
+
+func TestLoadConfig(t *testing.T) {
+	var cfg testConfigStruct
+	var its []attachItem
+	if err := config.LoadConfigBytes(&cfg, []byte(simpleConfig)); err != nil {
+		t.Fatal(err)
+	} else if its, err = cfg.Attach.Attachments(); err != nil {
+		t.Fatal(err)
+	} else if len(its) != len(simpleConfigItems) {
+		t.Fatalf("invalid attachment count: %d != %d", len(its), len(simpleConfigItems))
+	} else {
+		for i := range its {
+			if err = testKeys(its[i], simpleConfigItems); err != nil {
+				t.Fatalf("loaded attachment %d error %v", i, err)
+			}
+		}
+	}
+}
+
+func TestLoadBadConfig(t *testing.T) {
+	var cfg testConfigStruct
+	if err := config.LoadConfigBytes(&cfg, []byte(simpleConfig)); err != nil {
+		t.Fatal(err)
+	} else if err = cfg.Attach.Verify(); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg = testConfigStruct{}
+	if err := config.LoadConfigBytes(&cfg, []byte(badConfig)); err != nil {
+		t.Fatal(err)
+	} else if err = cfg.Attach.Verify(); err == nil {
+		t.Fatal(err)
+	}
+
+	cfg = testConfigStruct{}
+	if err := config.LoadConfigBytes(&cfg, []byte(badDupConfig)); err != nil {
+		t.Fatal(err)
+	} else if err = cfg.Attach.Verify(); err == nil {
+		t.Fatal(err)
+	}
+
+}
+
+func TestNewAttacher(t *testing.T) {
+	var cfg testConfigStruct
+	if err := config.LoadConfigBytes(&cfg, []byte(simpleConfig)); err != nil {
+		t.Fatal(err)
+	}
+	guid := uuid.New()
+	a, err := NewAttacher(cfg.Attach, guid)
+	if err != nil {
+		t.Fatal(err)
+	} else if a == nil {
+		t.Fatal("nil?")
+	} else if !a.active {
+		t.Fatal("not active")
+	} else if !a.haveDynamic {
+		t.Fatal("dynamics not set")
+	} else if len(a.evs) != len(simpleConfigItems) {
+		t.Fatalf("invalid ev count: %v != %v", len(a.evs), len(simpleConfigItems))
+	} else if len(a.dynamics) != 1 {
+		t.Fatalf("dynamics count is wrong: %d != 1", len(a.dynamics))
+	}
+
+	//do it again with an empty config
+	if a, err = NewAttacher(AttachConfig{}, guid); err != nil {
+		t.Fatal(err)
+	} else if a.active || a.haveDynamic || len(a.evs) > 0 || len(a.dynamics) > 0 {
+		t.Fatalf("attacher has stuff")
+	}
+}
+
+func TestAttach(t *testing.T) {
+	var cfg testConfigStruct
+	guid := uuid.New()
+	hostname, err := os.Hostname()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := config.LoadConfigBytes(&cfg, []byte(simpleConfig)); err != nil {
+		t.Fatal(err)
+	}
+	a, err := NewAttacher(cfg.Attach, guid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ents := make([]entry.Entry, 16)
+	for i := range ents {
+		a.Attach(&ents[i])
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	items := append([]attachItem{}, simpleConfigItems[0:3]...)
+	items = append(items, attachItem{key: `hostname`, value: hostname})
+	items = append(items, attachItem{key: `uuid`, value: guid.String()})
+
+	for _, ent := range ents {
+		if err := testEntConsts(ent, items); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	//now go swing through the timestamp items and make sure they are all native time types and unique
+	times := make(map[entry.Timestamp]bool, len(ents))
+	for _, ent := range ents {
+		if x, ok := ent.GetEnumeratedValue(`now`); !ok {
+			t.Fatal("could not find now value")
+		} else if ts, ok := x.(entry.Timestamp); !ok {
+			t.Fatalf("now is not a timestamp: %T", x)
+		} else if _, ok = times[ts]; ok {
+			t.Fatalf("NOW timestamp already exists: %v", ts)
+		} else {
+			times[ts] = true
+		}
+	}
+}
+
+func testEntConsts(ent entry.Entry, items []attachItem) (err error) {
+	for _, v := range items {
+		if ev, ok := ent.GetEnumeratedValue(v.key); !ok {
+			err = fmt.Errorf("Failed to find %v", v.key)
+			return
+		} else if ev == nil {
+			err = fmt.Errorf("ev for key %s is nil", v.key)
+			return
+		} else if s, ok := ev.(string); !ok {
+			err = fmt.Errorf("ev for key %s is not a string %T", v.key, ev)
+			return
+		} else if v.value != s {
+			err = fmt.Errorf("ev for key %s is wrong: %v != %v", v.key, v.value, s)
+			return
+		}
+	}
+	return
+}
+
+func testKeys(v attachItem, set []attachItem) (err error) {
+	//go find the value
+	for _, s := range set {
+		if s.key == v.key {
+			if s.value != v.value {
+				return fmt.Errorf("key %s value mismatch %v != %v", s.key, s.value, v.value)
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("failed to find key %v\n%v", v.key, set)
+}
+
+/* DATA BLOBS */
+var simpleConfigItems = []attachItem{
+	attachItem{key: `foo`, value: `bar`},
+	attachItem{key: `bar`, value: `baz`},
+	attachItem{key: `baz`, value: `foo`},
+	attachItem{key: `hostname`, value: `$HOSTNAME`},
+	attachItem{key: `uuid`, value: `$UUID`},
+	attachItem{key: `now`, value: `$NOW`},
+}
+
+const simpleConfig = `
+[Attach]
+	foo="bar"
+	bar="baz"
+	baz="foo"
+	hostname=$HOSTNAME
+	uuid=$UUID
+	now=$NOW
+`
+
+const badConfig = `
+[Attach]
+	foo="bar"
+	hostname=
+	uuid=$UUID
+	now=$NOW
+`
+
+const badDupConfig = `
+[Attach]
+	foo="bar"
+	foo="baz"
+	hostname=$HOSTNAME
+	uuid=$UUID
+	now=$NOW
+`

--- a/ingest/entry/entry.go
+++ b/ingest/entry/entry.go
@@ -75,6 +75,23 @@ func (ent *Entry) AddEnumeratedValue(ev EnumeratedValue) (err error) {
 	return
 }
 
+// AddEnumeratedValues will attach a slice of natively typed enumerated value to an entry.
+// An error is returned if the set of enumerated values contain an invalid enumerated value
+// or adding the set would would cause the entry to exceed the maximum entry size.
+func (ent *Entry) AddEnumeratedValues(evs []EnumeratedValue) (err error) {
+	if len(evs) == 0 {
+		return
+	}
+	for i := range evs {
+		if evs[i].Valid() == false {
+			err = ErrInvalid
+			return
+		}
+	}
+	ent.evb.AddSet(evs)
+	return
+}
+
 // AddEnumeratedValueEx will attach a natively typed enumerated value to an entry.
 // An error is returned if the enumerated value is invalid or adding it would cause
 // the entry to exceed the maximum entry size.  An error is also returned if the

--- a/ingest/entry/enumeratedblock.go
+++ b/ingest/entry/enumeratedblock.go
@@ -55,6 +55,18 @@ func (eb *evblock) Add(ev EnumeratedValue) {
 	eb.evs = append(eb.evs, ev)
 }
 
+// AddSet adds a slice of enumerated value to an evbloc, this function keeps a running tally of size for fast query.
+func (eb *evblock) AddSet(evs []EnumeratedValue) {
+	if eb.size == 0 {
+		eb.size = EVBlockHeaderLen
+		eb.evs = make([]EnumeratedValue, 0, len(evs))
+	}
+	for _, ev := range evs {
+		eb.size += uint64(ev.Size())
+		eb.evs = append(eb.evs, ev)
+	}
+}
+
 // Size is just a helper accessor to help with encoding efficiency.
 func (eb evblock) Size() uint64 {
 	return eb.size

--- a/ingest/entry/enumeratedblock_test.go
+++ b/ingest/entry/enumeratedblock_test.go
@@ -29,6 +29,8 @@ func TestEnumeratedValueBlockEncodeDecode(t *testing.T) {
 		t.Fatal("evb reported as not populated")
 	} else if err := evb.Valid(); err != nil {
 		t.Fatal("evb reported not valid", err)
+	} else if len(evb.evs) != 32 {
+		t.Fatalf("evb has wrong count: %d != 32", len(evb.evs))
 	}
 
 	//encode and decode
@@ -56,5 +58,69 @@ func TestEnumeratedValueBlockEncodeDecode(t *testing.T) {
 		t.Fatal(err)
 	} else if err = teb.Compare(evb); err != nil {
 		t.Fatal(err)
+	} else if len(teb.evs) != 32 {
+		t.Fatalf("invalid ev count: %d != 32", len(teb.evs))
+	}
+}
+
+func TestEnumeratedValueBlockDuplicateAdd(t *testing.T) {
+	var evs []EnumeratedValue
+	var evb evblock
+	for i := 0; i < 32; i++ {
+		if ev, err := NewEnumeratedValue(fmt.Sprintf("ev%d", i), int64(i)); err != nil {
+			t.Error(err)
+		} else {
+			evs = append(evs, ev)
+		}
+	}
+
+	evb.AddSet(evs)
+	if !evb.Populated() {
+		t.Fatal("evb reported as not populated")
+	} else if err := evb.Valid(); err != nil {
+		t.Fatal("evb reported not valid", err)
+	} else if evb.Count() != 32 {
+		t.Fatalf("evb has wrong count: %d != 32", evb.Count())
+	}
+
+	//add a whole new set
+	evs = []EnumeratedValue{}
+	for i := 0; i < 32; i++ {
+		if ev, err := NewEnumeratedValue(fmt.Sprintf("ev%d", i), fmt.Sprintf("stuff?%d", i)); err != nil {
+			t.Error(err)
+		} else {
+			evs = append(evs, ev)
+		}
+	}
+	evb.AddSet(evs)
+
+	//now add a single
+	if ev, err := NewEnumeratedValue(`ev0`, float64(3.14)); err != nil {
+		t.Error(err)
+	} else {
+		evb.Add(ev)
+		evs[0] = ev
+	}
+
+	//check the size
+	if !evb.Populated() {
+		t.Fatal("evb reported as not populated")
+	} else if err := evb.Valid(); err != nil {
+		t.Fatal("evb reported not valid", err)
+	} else if evb.Count() != 32 {
+		t.Fatalf("evb has wrong count: %d != 32", evb.Count())
+	}
+
+	//grab the set and check a few
+	evs2 := evb.Values()
+	if len(evs2) != evb.Count() {
+		t.Fatalf("Value count is wrong: %d != %d", len(evs2), evb.Count())
+	}
+	for i := range evs {
+		s1 := evs[i].String()
+		s2 := evs2[i].String()
+		if s1 != s2 {
+			t.Fatalf("enumerated value %d does not match: %s != %s", i, s1, s2)
+		}
 	}
 }

--- a/ingesters/SimpleRelay/config_test.go
+++ b/ingesters/SimpleRelay/config_test.go
@@ -38,7 +38,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestBasicConfig(t *testing.T) {
-	cfgPath, err := dropConfig(baseConfig)
+	cfgPath, err := dropConfig(testConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,7 +102,7 @@ func dropConfig(cfg string) (pth string, err error) {
 }
 
 const (
-	baseConfig string = `
+	testConfig string = `
 [Global]
 Ingest-Secret = IngestSecrets
 Connection-Timeout = 0

--- a/ingesters/SimpleRelay/jsonConfig.go
+++ b/ingesters/SimpleRelay/jsonConfig.go
@@ -33,7 +33,7 @@ var (
 )
 
 type jsonListener struct {
-	base
+	baseConfig
 	Max_Object_Size uint
 	Disable_Compact bool
 	Extractor       string
@@ -42,7 +42,7 @@ type jsonListener struct {
 }
 
 func (jl *jsonListener) Validate() error {
-	if err := jl.base.Validate(); err != nil {
+	if err := jl.baseConfig.Validate(); err != nil {
 		return err
 	}
 	jl.initDefaultTag() //make sure we resolve the Tag-Name and Default-Tag configs to do the right thing

--- a/ingesters/SimpleRelay/main.go
+++ b/ingesters/SimpleRelay/main.go
@@ -10,23 +10,16 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"io"
-	"net"
 	"os"
-	"path/filepath"
-	"runtime/debug"
 	"sync"
-	"syscall"
 	"time"
 
-	"github.com/gravwell/gravwell/v3/ingest"
-	"github.com/gravwell/gravwell/v3/ingest/config/validate"
 	"github.com/gravwell/gravwell/v3/ingest/log"
+	"github.com/gravwell/gravwell/v3/ingesters/base"
 	"github.com/gravwell/gravwell/v3/ingesters/utils"
 	"github.com/gravwell/gravwell/v3/ingesters/utils/caps"
-	"github.com/gravwell/gravwell/v3/ingesters/version"
 )
 
 const (
@@ -40,140 +33,48 @@ const (
 )
 
 var (
-	confLoc        = flag.String("config-file", defaultConfigLoc, "Location for configuration file")
-	confdLoc       = flag.String("config-overlays", defaultConfigDLoc, "Location for configuration overlay files")
-	verbose        = flag.Bool("v", false, "Display verbose status updates to stdout")
-	stderrOverride = flag.String("stderr", "", "Redirect stderr to a shared memory file")
-	ver            = flag.Bool("version", false, "Print the version information and exit")
-
 	v  bool
 	lg *log.Logger
 )
 
-func mainInit() {
-	flag.Parse()
-	if *ver {
-		version.PrintVersion(os.Stdout)
-		ingest.PrintVersion(os.Stdout)
-		os.Exit(0)
-	}
-	validate.ValidateConfig(GetConfig, *confLoc, *confdLoc)
-	lg = log.New(os.Stderr) // DO NOT close this, it will prevent backtraces from firing
-	lg.SetAppname(appName)
-	if *stderrOverride != `` {
-		if oldstderr, err := syscall.Dup(int(os.Stderr.Fd())); err != nil {
-			lg.Fatal("failed to dup stderr", log.KVErr(err))
-		} else {
-			lg.AddWriter(os.NewFile(uintptr(oldstderr), "oldstderr"))
-		}
-
-		fp := filepath.Join(`/dev/shm/`, *stderrOverride)
-		fout, err := os.Create(fp)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to create %s: %v\n", fp, err)
-		} else {
-			version.PrintVersion(fout)
-			ingest.PrintVersion(fout)
-			log.PrintOSInfo(fout)
-			//file created, dup it
-			if err := syscall.Dup3(int(fout.Fd()), int(os.Stderr.Fd()), 0); err != nil {
-				fout.Close()
-				lg.FatalCode(0, "failed to dup2 stderr", log.KVErr(err))
-			}
-		}
-	}
-
-	v = *verbose
-	connClosers = make(map[int]closer, 1)
-}
-
 func main() {
-	debug.SetTraceback("all")
-	mainInit()
-	cfg, err := GetConfig(*confLoc, *confdLoc)
+	var cfg *cfgType
+	ibc := base.IngesterBaseConfig{
+		IngesterName:                 ingesterName,
+		AppName:                      appName,
+		DefaultConfigLocation:        defaultConfigLoc,
+		DefaultConfigOverlayLocation: defaultConfigDLoc,
+		GetConfigFunc:                GetConfig,
+	}
+	ib, err := base.Init(ibc)
 	if err != nil {
-		lg.FatalCode(0, "failed to get configuration", log.KVErr(err))
+		fmt.Fprintf(os.Stderr, "failed to get configuration %v\n", err)
+		return
+	} else if err = ib.AssignConfig(&cfg); err != nil || cfg == nil {
+		fmt.Fprintf(os.Stderr, "failed to assign configuration %v %v\n", err, cfg == nil)
 		return
 	}
-
-	cfg.AddLocalLogging(lg)
-
-	tags, err := cfg.Tags()
-	if err != nil {
-		lg.FatalCode(0, "failed to get tags from configuration", log.KVErr(err))
-		return
-	}
-	conns, err := cfg.Targets()
-	if err != nil {
-		lg.FatalCode(0, "failed to get backend targets from configuration", log.KVErr(err))
-		return
-	}
-	debugout("Handling %d tags over %d targets\n", len(tags), len(conns))
-
-	lmt, err := cfg.RateLimit()
-	if err != nil {
-		lg.FatalCode(0, "failed to get rate limit from configuration", log.KVErr(err))
-		return
-	}
-	debugout("Rate limiting connection to %d bps\n", lmt)
-
-	//fire up the ingesters
-	debugout("INSECURE skip TLS certificate verification: %v\n", cfg.InsecureSkipTLSVerification())
+	connClosers = make(map[int]closer, 1)
+	v = ib.Verbose
+	lg = ib.Logger
 	id, ok := cfg.IngesterUUID()
 	if !ok {
-		lg.FatalCode(0, "Couldn't read ingester UUID")
+		ib.Logger.FatalCode(0, "could not read ingester UUID")
 	}
-	igCfg := ingest.UniformMuxerConfig{
-		IngestStreamConfig: cfg.IngestStreamConfig,
-		Destinations:       conns,
-		Tags:               tags,
-		Auth:               cfg.Secret(),
-		VerifyCert:         !cfg.InsecureSkipTLSVerification(),
-		IngesterName:       ingesterName,
-		IngesterVersion:    version.GetVersion(),
-		IngesterUUID:       id.String(),
-		IngesterLabel:      cfg.Label,
-		RateLimitBps:       lmt,
-		CacheDepth:         cfg.Cache_Depth,
-		CachePath:          cfg.Ingest_Cache_Path,
-		CacheSize:          cfg.Max_Ingest_Cache,
-		CacheMode:          cfg.Cache_Mode,
-		Logger:             lg,
-		LogSourceOverride:  net.ParseIP(cfg.Log_Source_Override),
-	}
-	igst, err := ingest.NewUniformMuxer(igCfg)
+
+	igst, err := ib.GetMuxer()
 	if err != nil {
-		lg.Fatal("failed build our ingest system", log.KVErr(err))
+		ib.Logger.FatalCode(0, "failed to get ingest connection", log.KVErr(err))
 		return
 	}
 	defer igst.Close()
-	debugout("Started ingester muxer\n")
-	// Henceforth, logs will also go out via the muxer to the gravwell tag
-	if cfg.SelfIngest() {
-		lg.AddRelay(igst)
-	}
-	if err := igst.Start(); err != nil {
-		lg.Fatal("failed start our ingest system", log.KVErr(err))
-		return
-	}
 
-	debugout("Waiting for connections to indexers ... ")
-	if err := igst.WaitForHot(cfg.Timeout()); err != nil {
-		lg.FatalCode(0, "timeout waiting for backend connections", log.KV("timeout", cfg.Timeout()), log.KVErr(err))
-		return
-	}
-	debugout("Successfully connected to ingesters\n")
+	debugout("Started ingester muxer\n")
 
 	//check capabilities so we can scream and throw a potential warning upstream
 	if !caps.Has(caps.NET_BIND_SERVICE) {
 		lg.Warn("missing capability", log.KV("capability", "NET_BIND_SERVICE"), log.KV("warning", "may not be able to bind to service ports"))
 		debugout("missing capability NET_BIND_SERVICE, may not be able to bind to service ports")
-	}
-
-	// prepare the configuration we're going to send upstream
-	err = igst.SetRawConfiguration(cfg)
-	if err != nil {
-		lg.FatalCode(0, "failed to set configuration for ingester state messages", log.KV("ingesteruuid", id), log.KVErr(err))
 	}
 
 	wg := &sync.WaitGroup{}

--- a/ingesters/SimpleRelay/regexConfig.go
+++ b/ingesters/SimpleRelay/regexConfig.go
@@ -17,14 +17,14 @@ import (
 )
 
 type regexListener struct {
-	base
+	baseConfig
 	Regex           string
 	Trim_Whitespace bool
 	Max_Buffer      int // maximum number of bytes to buffer without finding a regular expression
 }
 
 func (rl regexListener) Validate() error {
-	if err := rl.base.Validate(); err != nil {
+	if err := rl.baseConfig.Validate(); err != nil {
 		return err
 	}
 	//process the default tag

--- a/ingesters/base/base.go
+++ b/ingesters/base/base.go
@@ -21,6 +21,7 @@ import (
 	"runtime/debug"
 
 	"github.com/gravwell/gravwell/v3/ingest"
+	"github.com/gravwell/gravwell/v3/ingest/attach"
 	"github.com/gravwell/gravwell/v3/ingest/config"
 	"github.com/gravwell/gravwell/v3/ingest/config/validate"
 	"github.com/gravwell/gravwell/v3/ingest/log"
@@ -39,6 +40,7 @@ type getConfigFunc func(cfg, overlay string) (interface{}, error)
 type cfgHelper interface {
 	Tags() ([]string, error)
 	IngestBaseConfig() config.IngestConfig
+	AttachConfig() attach.AttachConfig
 }
 
 type IngesterBaseConfig struct {
@@ -194,6 +196,7 @@ func (ib *IngesterBase) GetMuxer() (igst *ingest.IngestMuxer, err error) {
 		CacheSize:          cfg.Max_Ingest_Cache,
 		CacheMode:          cfg.Cache_Mode,
 		LogSourceOverride:  net.ParseIP(cfg.Log_Source_Override),
+		Attach:             ch.AttachConfig(),
 	}
 	if igst, err = ingest.NewUniformMuxer(igCfg); err != nil {
 		ib.Logger.Fatal("failed build our ingest system", log.KVErr(err))

--- a/ingesters/s3Ingester/config.go
+++ b/ingesters/s3Ingester/config.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gravwell/gravwell/v3/ingest"
+	"github.com/gravwell/gravwell/v3/ingest/attach"
 	"github.com/gravwell/gravwell/v3/ingest/config"
 	"github.com/gravwell/gravwell/v3/ingest/entry"
 	"github.com/gravwell/gravwell/v3/ingest/processors"
@@ -48,6 +49,7 @@ type global struct {
 
 type cfgReadType struct {
 	Global       global
+	Attach       attach.AttachConfig
 	Bucket       map[string]*bucket
 	Preprocessor processors.ProcessorConfig
 	TimeFormat   config.CustomTimeFormat
@@ -55,6 +57,7 @@ type cfgReadType struct {
 
 type cfgType struct {
 	config.IngestConfig
+	Attach               attach.AttachConfig
 	State_Store_Location string
 	Bucket               map[string]*bucket
 	Preprocessor         processors.ProcessorConfig
@@ -71,6 +74,7 @@ func GetConfig(path, overlayPath string) (*cfgType, error) {
 	}
 	c := &cfgType{
 		IngestConfig:         cr.Global.IngestConfig,
+		Attach:               cr.Attach,
 		State_Store_Location: cr.Global.State_Store_Location,
 		Bucket:               cr.Bucket,
 		Preprocessor:         cr.Preprocessor,
@@ -100,6 +104,8 @@ func GetConfig(path, overlayPath string) (*cfgType, error) {
 func verifyConfig(c *cfgType) error {
 	//verify the global parameters
 	if err := c.Verify(); err != nil {
+		return err
+	} else if err = c.Attach.Verify(); err != nil {
 		return err
 	}
 
@@ -175,6 +181,10 @@ func (c *cfgType) Tags() ([]string, error) {
 
 func (c *cfgType) IngestBaseConfig() config.IngestConfig {
 	return c.IngestConfig
+}
+
+func (c *cfgType) AttachConfig() attach.AttachConfig {
+	return c.Attach
 }
 
 func (c *cfgType) newTimeGrinder(tc TimeConfig) (tg *timegrinder.TimeGrinder, err error) {

--- a/ingesters/snmp/config.go
+++ b/ingesters/snmp/config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gosnmp/gosnmp"
 	"github.com/gravwell/gravwell/v3/ingest"
+	"github.com/gravwell/gravwell/v3/ingest/attach"
 	"github.com/gravwell/gravwell/v3/ingest/config"
 	"github.com/gravwell/gravwell/v3/ingest/entry"
 	"github.com/gravwell/gravwell/v3/ingest/processors"
@@ -46,12 +47,14 @@ type global struct {
 
 type cfgReadType struct {
 	Global       global
+	Attach       attach.AttachConfig
 	Listener     map[string]*listener
 	Preprocessor processors.ProcessorConfig
 }
 
 type cfgType struct {
 	config.IngestConfig
+	Attach       attach.AttachConfig
 	Listener     map[string]*listener
 	Preprocessor processors.ProcessorConfig
 }
@@ -104,6 +107,7 @@ func GetConfig(path, overlayPath string) (*cfgType, error) {
 	}
 	c := &cfgType{
 		IngestConfig: cr.Global.IngestConfig,
+		Attach:       cr.Attach,
 		Listener:     cr.Listener,
 		Preprocessor: cr.Preprocessor,
 	}
@@ -128,6 +132,8 @@ func GetConfig(path, overlayPath string) (*cfgType, error) {
 func verifyConfig(c *cfgType) error {
 	//verify the global parameters
 	if err := c.Verify(); err != nil {
+		return err
+	} else if err = c.Attach.Verify(); err != nil {
 		return err
 	}
 
@@ -193,6 +199,10 @@ func (c *cfgType) Tags() ([]string, error) {
 
 func (c *cfgType) IngestBaseConfig() config.IngestConfig {
 	return c.IngestConfig
+}
+
+func (c *cfgType) AttachConfig() attach.AttachConfig {
+	return c.Attach
 }
 
 func (g *global) Verify() (err error) {


### PR DESCRIPTION
This implements the "attach" thing so that any ingester can slap a global config and the ingester will attach stuff.

It allows for attaching arbitrary strings as well as some keywords:

Here is an example config for Simple Relay:

```
Log-Level=INFO
Log-File=/opt/gravwell/log/simple_relay.log

[Attach]
        host="$HOSTNAME"
        foobar="foo to the bar"
        ingested="$NOW"
        ingester="$UUID"


#basic default logger, all entries will go to the default tag
# this is useful for sending generic line-delimited
# data to Gravwell, for example if you have an old log file sitting around:
#       cat logfile | nc gravwell-host 7777
#no Tag-Name means use the default tag
[Listener "default"]
        Bind-String="0.0.0.0:7777" #we are binding to all interfaces, with TCP implied
        Tag-Name=default4
```


This will attach the ingester UUID, timestamp at point of ingestion, and the derived hostname.  It also attaches arbitrary string `foo to the bar`