### PR TITLE
Converting the main boiler plate code over to base

### DIFF
--- a/ingesters/IPMIIngester/config.go
+++ b/ingesters/IPMIIngester/config.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gravwell/gravwell/v3/ingest"
+	"github.com/gravwell/gravwell/v3/ingest/attach"
 	"github.com/gravwell/gravwell/v3/ingest/config"
 	"github.com/gravwell/gravwell/v3/ingest/entry"
 	"github.com/gravwell/gravwell/v3/ingest/processors"
@@ -33,6 +34,7 @@ type ipmi struct {
 
 type cfgType struct {
 	Global       config.IngestConfig
+	Attach       attach.AttachConfig
 	IPMI         map[string]*ipmi
 	Preprocessor processors.ProcessorConfig
 }
@@ -65,6 +67,8 @@ func GetConfig(path, overlayPath string) (*cfgType, error) {
 func verifyConfig(c *cfgType) error {
 	//verify the global parameters
 	if err := c.Global.Verify(); err != nil {
+		return err
+	} else if err = c.Attach.Verify(); err != nil {
 		return err
 	}
 
@@ -115,4 +119,12 @@ func (c *cfgType) Tags() ([]string, error) {
 	}
 	sort.Strings(tags)
 	return tags, nil
+}
+
+func (c *cfgType) IngestBaseConfig() config.IngestConfig {
+	return c.Global
+}
+
+func (c *cfgType) AttachConfig() attach.AttachConfig {
+	return c.Attach
 }

--- a/ingesters/IPMIIngester/main.go
+++ b/ingesters/IPMIIngester/main.go
@@ -13,23 +13,17 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"net"
 	"os"
-	"path/filepath"
-	"runtime/debug"
 	"sync"
-	"syscall"
 	"time"
 
-	"github.com/gravwell/gravwell/v3/ingest"
-	"github.com/gravwell/gravwell/v3/ingest/config/validate"
 	"github.com/gravwell/gravwell/v3/ingest/entry"
 	"github.com/gravwell/gravwell/v3/ingest/log"
 	"github.com/gravwell/gravwell/v3/ingest/processors"
+	"github.com/gravwell/gravwell/v3/ingesters/base"
 	"github.com/gravwell/gravwell/v3/ingesters/utils"
-	"github.com/gravwell/gravwell/v3/ingesters/version"
 
 	"github.com/gravwell/ipmigo"
 )
@@ -41,13 +35,7 @@ const (
 )
 
 var (
-	confLoc        = flag.String("config-file", defaultConfigLoc, "Location for configuration file")
-	confdLoc       = flag.String("config-overlays", defaultConfigDLoc, "Location for configuration overlay files")
-	stderrOverride = flag.String("stderr", "", "Redirect stderr to a shared memory file")
-	ver            = flag.Bool("version", false, "Print the version information and exit")
-
-	lg   *log.Logger
-	igst *ingest.IngestMuxer
+	lg *log.Logger
 
 	ipmiConns map[string]*handlerConfig
 )
@@ -69,116 +57,35 @@ type handlerConfig struct {
 	rate             int
 }
 
-func init() {
-	flag.Parse()
-	if *ver {
-		version.PrintVersion(os.Stdout)
-		ingest.PrintVersion(os.Stdout)
-		os.Exit(0)
-	}
-	validate.ValidateConfig(GetConfig, *confLoc, *confdLoc)
-
-	lg = log.New(os.Stderr) // DO NOT close this, it will prevent backtraces from firing
-	lg.SetAppname(ingesterName)
-	if *stderrOverride != `` {
-		if oldstderr, err := syscall.Dup(int(os.Stderr.Fd())); err != nil {
-			lg.Fatal("failed to dup stderr", log.KVErr(err))
-		} else {
-			lg.AddWriter(os.NewFile(uintptr(oldstderr), "oldstderr"))
-		}
-
-		fp := filepath.Join(`/dev/shm/`, *stderrOverride)
-		fout, err := os.Create(fp)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to create %s: %v\n", fp, err)
-		} else {
-			version.PrintVersion(fout)
-			ingest.PrintVersion(fout)
-			log.PrintOSInfo(fout)
-			//file created, dup it
-			if err := syscall.Dup3(int(fout.Fd()), int(os.Stderr.Fd()), 0); err != nil {
-				fout.Close()
-				lg.FatalCode(0, "failed to dup2 stderr", log.KVErr(err))
-			}
-		}
-	}
-}
-
 func main() {
-	debug.SetTraceback("all")
-
-	// config setup
-	cfg, err := GetConfig(*confLoc, *confdLoc)
+	var cfg *cfgType
+	ibc := base.IngesterBaseConfig{
+		IngesterName:                 ingesterName,
+		AppName:                      ingesterName,
+		DefaultConfigLocation:        defaultConfigLoc,
+		DefaultConfigOverlayLocation: defaultConfigDLoc,
+		GetConfigFunc:                GetConfig,
+	}
+	ib, err := base.Init(ibc)
 	if err != nil {
-		lg.FatalCode(0, "failed to get configuration", log.KVErr(err))
+		fmt.Fprintf(os.Stderr, "failed to get configuration %v\n", err)
+		return
+	} else if err = ib.AssignConfig(&cfg); err != nil || cfg == nil {
+		fmt.Fprintf(os.Stderr, "failed to assign configuration %v %v\n", err, cfg == nil)
 		return
 	}
+	lg = ib.Logger
 
-	cfg.Global.AddLocalLogging(lg)
-
-	tags, err := cfg.Tags()
-	if err != nil {
-		lg.FatalCode(0, "failed to get tags from configuration", log.KVErr(err))
-		return
-	}
-	conns, err := cfg.Global.Targets()
-	if err != nil {
-		lg.FatalCode(0, "failed to get backend targets from configuration", log.KVErr(err))
-		return
-	}
-
-	lmt, err := cfg.Global.RateLimit()
-	if err != nil {
-		lg.FatalCode(0, "failed to get rate limit from configuration", log.KVErr(err))
-		return
-	}
 	id, ok := cfg.Global.IngesterUUID()
 	if !ok {
-		lg.FatalCode(0, "Couldn't read ingester UUID")
+		ib.Logger.FatalCode(0, "could not read ingester UUID")
 	}
-	igCfg := ingest.UniformMuxerConfig{
-		IngestStreamConfig: cfg.Global.IngestStreamConfig,
-		Destinations:       conns,
-		Tags:               tags,
-		Auth:               cfg.Global.Secret(),
-		VerifyCert:         !cfg.Global.InsecureSkipTLSVerification(),
-		IngesterName:       ingesterName,
-		IngesterVersion:    version.GetVersion(),
-		IngesterUUID:       id.String(),
-		IngesterLabel:      cfg.Global.Label,
-		RateLimitBps:       lmt,
-		Logger:             lg,
-		CacheDepth:         cfg.Global.Cache_Depth,
-		CachePath:          cfg.Global.Ingest_Cache_Path,
-		CacheSize:          cfg.Global.Max_Ingest_Cache,
-		CacheMode:          cfg.Global.Cache_Mode,
-		LogSourceOverride:  net.ParseIP(cfg.Global.Log_Source_Override),
-	}
-	igst, err = ingest.NewUniformMuxer(igCfg)
+	igst, err := ib.GetMuxer()
 	if err != nil {
-		lg.Fatal("failed build our ingest system", log.KVErr(err))
+		ib.Logger.FatalCode(0, "failed to get ingest connection", log.KVErr(err))
 		return
 	}
 	defer igst.Close()
-	if cfg.Global.SelfIngest() {
-		lg.AddRelay(igst)
-	}
-
-	if err := igst.Start(); err != nil {
-		lg.Fatal("failed start our ingest system", log.KVErr(err))
-		return
-	}
-
-	if err := igst.WaitForHot(cfg.Global.Timeout()); err != nil {
-		lg.FatalCode(0, "timeout waiting for backend connections", log.KV("timeout", cfg.Global.Timeout()), log.KVErr(err))
-		return
-	}
-
-	// prepare the configuration we're going to send upstream
-	err = igst.SetRawConfiguration(cfg)
-	if err != nil {
-		lg.FatalCode(0, "failed to set configuration for ingester state messages", log.KVErr(err))
-	}
 
 	// fire up IPMI handlers
 	var wg sync.WaitGroup

--- a/ingesters/SimpleRelay/main.go
+++ b/ingesters/SimpleRelay/main.go
@@ -54,7 +54,6 @@ func main() {
 		fmt.Fprintf(os.Stderr, "failed to assign configuration %v %v\n", err, cfg == nil)
 		return
 	}
-	connClosers = make(map[int]closer, 1)
 	v = ib.Verbose
 	lg = ib.Logger
 	id, ok := cfg.IngesterUUID()
@@ -71,6 +70,7 @@ func main() {
 
 	debugout("Started ingester muxer\n")
 
+	connClosers = make(map[int]closer, 1)
 	//check capabilities so we can scream and throw a potential warning upstream
 	if !caps.Has(caps.NET_BIND_SERVICE) {
 		lg.Warn("missing capability", log.KV("capability", "NET_BIND_SERVICE"), log.KV("warning", "may not be able to bind to service ports"))

--- a/ingesters/networkLog/config.go
+++ b/ingesters/networkLog/config.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gravwell/gravwell/v3/ingest"
+	"github.com/gravwell/gravwell/v3/ingest/attach"
 	"github.com/gravwell/gravwell/v3/ingest/config"
 	"github.com/gravwell/gravwell/v3/ingest/entry"
 )
@@ -33,6 +34,7 @@ const (
 
 type cfgReadType struct {
 	Global  config.IngestConfig
+	Attach  attach.AttachConfig
 	Sniffer map[string]*snif
 }
 
@@ -47,6 +49,7 @@ type snif struct {
 
 type cfgType struct {
 	config.IngestConfig
+	Attach  attach.AttachConfig
 	Sniffer map[string]*snif
 }
 
@@ -60,6 +63,7 @@ func GetConfig(path, overlayPath string) (*cfgType, error) {
 	}
 	c := &cfgType{
 		IngestConfig: cr.Global,
+		Attach:       cr.Attach,
 		Sniffer:      cr.Sniffer,
 	}
 	if err := verifyConfig(c); err != nil {
@@ -80,6 +84,8 @@ func GetConfig(path, overlayPath string) (*cfgType, error) {
 
 func verifyConfig(c *cfgType) error {
 	if err := c.Verify(); err != nil {
+		return err
+	} else if err = c.Attach.Verify(); err != nil {
 		return err
 	}
 	if len(c.Sniffer) == 0 {
@@ -187,4 +193,12 @@ func getNonLoopbackInterface() (name string, err error) {
 	}
 	err = errors.New("No non-loopback interface found")
 	return
+}
+
+func (c *cfgType) IngestBaseConfig() config.IngestConfig {
+	return c.IngestConfig
+}
+
+func (c *cfgType) AttachConfig() attach.AttachConfig {
+	return c.Attach
 }

--- a/ingesters/sqsIngester/main.go
+++ b/ingesters/sqsIngester/main.go
@@ -10,24 +10,18 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
-	"io"
 	"net"
 	"os"
-	"path/filepath"
-	"runtime/debug"
 	"strconv"
 	"sync"
 	"time"
 
-	"github.com/gravwell/gravwell/v3/ingest"
-	"github.com/gravwell/gravwell/v3/ingest/config/validate"
 	"github.com/gravwell/gravwell/v3/ingest/entry"
 	"github.com/gravwell/gravwell/v3/ingest/log"
 	"github.com/gravwell/gravwell/v3/ingest/processors"
+	"github.com/gravwell/gravwell/v3/ingesters/base"
 	"github.com/gravwell/gravwell/v3/ingesters/utils"
-	"github.com/gravwell/gravwell/v3/ingesters/version"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -46,15 +40,8 @@ const (
 )
 
 var (
-	confLoc        = flag.String("config-file", defaultConfigLoc, "Location for configuration file")
-	confdLoc       = flag.String("config-overlays", defaultConfigDLoc, "Location for configuration overlay files")
-	verbose        = flag.Bool("v", false, "Display verbose status updates to stdout")
-	stderrOverride = flag.String("stderr", "", "Redirect stderr to a shared memory file")
-	ver            = flag.Bool("version", false, "Print the version information and exit")
-
-	v    bool
-	lg   *log.Logger
-	igst *ingest.IngestMuxer
+	v  bool
+	lg *log.Logger
 )
 
 type handlerConfig struct {
@@ -74,113 +61,34 @@ type handlerConfig struct {
 	ctx              context.Context
 }
 
-func init() {
-	flag.Parse()
-	if *ver {
-		version.PrintVersion(os.Stdout)
-		ingest.PrintVersion(os.Stdout)
-		os.Exit(0)
-	}
-	validate.ValidateConfig(GetConfig, *confLoc, *confdLoc)
-	var fp string
-	var err error
-	if *stderrOverride != `` {
-		fp = filepath.Join(`/dev/shm/`, *stderrOverride)
-	}
-	cb := func(w io.Writer) {
-		version.PrintVersion(w)
-		ingest.PrintVersion(w)
-		log.PrintOSInfo(w)
-	}
-	if lg, err = log.NewStderrLoggerEx(fp, cb); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to get stderr logger: %v\n", err)
-		os.Exit(-1)
-	}
-	lg.SetAppname(appName)
-
-	v = *verbose
-}
-
 func main() {
-	debug.SetTraceback("all")
-	cfg, err := GetConfig(*confLoc, *confdLoc)
+	var cfg *cfgType
+	ibc := base.IngesterBaseConfig{
+		IngesterName:                 ingesterName,
+		AppName:                      appName,
+		DefaultConfigLocation:        defaultConfigLoc,
+		DefaultConfigOverlayLocation: defaultConfigDLoc,
+		GetConfigFunc:                GetConfig,
+	}
+	ib, err := base.Init(ibc)
 	if err != nil {
-		lg.FatalCode(0, "failed to get configuration", log.KVErr(err))
+		fmt.Fprintf(os.Stderr, "failed to get configuration %v\n", err)
+		return
+	} else if err = ib.AssignConfig(&cfg); err != nil || cfg == nil {
+		fmt.Fprintf(os.Stderr, "failed to assign configuration %v %v\n", err, cfg == nil)
 		return
 	}
+	v = ib.Verbose
+	lg = ib.Logger
 
-	cfg.AddLocalLogging(lg)
-
-	tags, err := cfg.Tags()
+	igst, err := ib.GetMuxer()
 	if err != nil {
-		lg.FatalCode(0, "failed to get tags from configuration", log.KVErr(err))
+		ib.Logger.FatalCode(0, "failed to get ingest connection", log.KVErr(err))
 		return
 	}
-	conns, err := cfg.Targets()
-	if err != nil {
-		lg.FatalCode(0, "failed to get backend targets from configuration", log.KVErr(err))
-		return
-	}
-	debugout("Handling %d tags over %d targets\n", len(tags), len(conns))
-
-	lmt, err := cfg.RateLimit()
-	if err != nil {
-		lg.FatalCode(0, "failed to get rate limit from configuration", log.KVErr(err))
-		return
-	}
-	debugout("Rate limiting connection to %d bps\n", lmt)
-
-	//fire up the ingesters
-	debugout("INSECURE skip TLS certificate verification: %v\n", cfg.InsecureSkipTLSVerification())
-	id, ok := cfg.IngesterUUID()
-	if !ok {
-		lg.FatalCode(0, "could not read ingester UUID")
-	}
-	igCfg := ingest.UniformMuxerConfig{
-		IngestStreamConfig: cfg.IngestStreamConfig,
-		Destinations:       conns,
-		Tags:               tags,
-		Auth:               cfg.Secret(),
-		VerifyCert:         !cfg.InsecureSkipTLSVerification(),
-		IngesterName:       ingesterName,
-		IngesterVersion:    version.GetVersion(),
-		IngesterUUID:       id.String(),
-		IngesterLabel:      cfg.Label,
-		RateLimitBps:       lmt,
-		Logger:             lg,
-		CacheDepth:         cfg.Cache_Depth,
-		CachePath:          cfg.Ingest_Cache_Path,
-		CacheSize:          cfg.Max_Ingest_Cache,
-		CacheMode:          cfg.Cache_Mode,
-		LogSourceOverride:  net.ParseIP(cfg.Log_Source_Override),
-	}
-	igst, err = ingest.NewUniformMuxer(igCfg)
-	if err != nil {
-		lg.Fatal("failed build our ingest system", log.KVErr(err))
-		return
-	}
-
 	defer igst.Close()
-	debugout("Started ingester muxer\n")
-	if cfg.SelfIngest() {
-		lg.AddRelay(igst)
-	}
-	if err := igst.Start(); err != nil {
-		lg.Fatal("failed start our ingest system", log.KVErr(err))
-		return
-	}
-	debugout("Waiting for connections to indexers ... ")
-	if err := igst.WaitForHot(cfg.Timeout()); err != nil {
-		lg.FatalCode(0, "timeout waiting for backend connections", log.KV("timeout", cfg.Timeout()), log.KVErr(err))
-		return
-	}
-	debugout("Successfully connected to ingesters\n")
 
-	// prepare the configuration we're going to send upstream
-	err = igst.SetRawConfiguration(cfg)
-	if err != nil {
-		lg.FatalCode(0, "failed to set configuration for ingester state messages")
-	}
+	debugout("Started ingester muxer\n")
 
 	var wg sync.WaitGroup
 	done := make(chan bool)


### PR DESCRIPTION
This makes it easier to include attach stuff and any future changes to ingest muxer stuff

The following ingesters are converted in this PR:

- sqs
- packetfleet
- networklog
- ipmi