### PR TITLE
Add DebugEvent fields for flows.

### DIFF
--- a/client/types/alert.go
+++ b/client/types/alert.go
@@ -54,7 +54,7 @@ type AlertDefinition struct {
 	Name string `json:"Name"`
 
 	// A JSON schema describing the expected fields in the alerts.
-	Schema map[string]interface{} `json:"Schema"`
+	Schemas AlertSchemas `json:"Schemas"`
 
 	// The tag into which alerts will be ingested
 	TargetTag string `json:"TargetTag"`
@@ -77,4 +77,27 @@ type AlertDispatcher struct {
 	ID string `json:"ID"`
 
 	Type AlertDispatcherType `json:"Type"`
+}
+
+// AlertSchema - Contains schema definitions for an alert and selects which one is to be used.
+type AlertSchemas struct {
+
+	// The "simple" schema, if any is defined.
+	Simple map[string]interface{} `json:"Simple,omitempty"`
+
+	// A schema derived from an OCSF spec.
+	OCSF AlertSchemasOcsf `json:"OCSF,omitempty"`
+
+	// A user-provided JSON schema.
+	JSON map[string]interface{} `json:"JSON,omitempty"`
+
+	ActiveSchema string `json:"ActiveSchema"`
+}
+
+type AlertSchemasOcsf struct {
+	EventClass string `json:"EventClass"`
+
+	Extensions []string `json:"Extensions"`
+
+	Profiles []string `json:"Profiles"`
 }

--- a/client/types/scheduledsearch.go
+++ b/client/types/scheduledsearch.go
@@ -43,6 +43,7 @@ var (
 // ScheduledSearch represents a scheduled search, including rules, description,
 // etc.
 type ScheduledSearch struct {
+	Synced      bool
 	ID          int32
 	GUID        uuid.UUID
 	Groups      []int32
@@ -55,9 +56,11 @@ type ScheduledSearch struct {
 	Timezone    string // a location to use for the timezone, e.g. "America/New_York"
 	Updated     time.Time
 	Disabled    bool
-	OneShot     bool // Set this flag to 'true' to make the search fire ONCE
-	DebugMode   bool // set this to true to enable debug mode
-	Synced      bool
+
+	// These values are used for debug/testing runs
+	OneShot    bool                   // Set this flag to 'true' to make the search fire ONCE
+	DebugMode  bool                   // set this to true to enable debug mode
+	DebugEvent map[string]interface{} // If provided, this will be inserted as `event` into the flow payload.
 
 	// if true, search agent will attempt to "backfill" missed runs since
 	// the more recent of Updated or LastRun.
@@ -120,7 +123,8 @@ type ScheduledSearchParseResponse struct {
 }
 
 type FlowParseRequest struct {
-	Flow string
+	Flow       string
+	DebugEvent map[string]interface{} // If provided, this will be set as `event` in the flow payload for parsing.
 }
 
 type FlowParseResponse struct {


### PR DESCRIPTION
FlowParseRequest and ScheduledSearch types now have a DebugEvent type. If set, it will be injected into the incoming payloads of flows in the following cases:

- When parsing a flow via FlowParseRequest
- When running a flow in debug mode (DebugMode = true)

Also introduces the ParseReactiveFlow function on the client, to make it easier to validate flows as they are being built.

