### PR TITLE
change alert validation functions to take UUIDs.

### DIFF
--- a/client/alerts.go
+++ b/client/alerts.go
@@ -9,7 +9,6 @@
 package client
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -60,12 +59,12 @@ func (c *Client) GetAlertSampleEvent(id uuid.UUID) (result types.Event, err erro
 
 // ValidateAlertScheduledSearchDispatcher validates an existing scheduled search against
 // a given schema.
-func (c *Client) ValidateAlertScheduledSearchDispatcher(ssearchID int32, schema types.AlertSchemas) (resp types.AlertDispatcherValidateResponse, err error) {
+func (c *Client) ValidateAlertScheduledSearchDispatcher(ssearchID uuid.UUID, schema types.AlertSchemas) (resp types.AlertDispatcherValidateResponse, err error) {
 	// build the request
 	req := types.AlertDispatcherValidateRequest{
 		Dispatcher: types.AlertDispatcher{
 			Type: types.ALERTDISPATCHERTYPE_SCHEDULEDSEARCH,
-			ID:   fmt.Sprintf("%d", ssearchID),
+			ID:   ssearchID.String(),
 		},
 		Schema: schema,
 	}
@@ -77,12 +76,12 @@ func (c *Client) ValidateAlertScheduledSearchDispatcher(ssearchID int32, schema 
 // ValidateAlertFlowConsumer validates an existing flow against
 // a given alert, making sure it does not consume any fields not
 // provided by the schema.
-func (c *Client) ValidateAlertFlowConsumer(flowID int32, alert types.AlertDefinition) (resp types.AlertConsumerValidateResponse, err error) {
+func (c *Client) ValidateAlertFlowConsumer(flowID uuid.UUID, alert types.AlertDefinition) (resp types.AlertConsumerValidateResponse, err error) {
 	// build the request
 	req := types.AlertConsumerValidateRequest{
 		Consumer: types.AlertConsumer{
 			Type: types.ALERTCONSUMERTYPE_FLOW,
-			ID:   fmt.Sprintf("%d", flowID),
+			ID:   flowID.String(),
 		},
 		Alert: alert,
 	}


### PR DESCRIPTION
they should not be using the int32 IDs

<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses [ISSUE_LINK]