### PR TITLE
fix ingester stderr logger

### DIFF
--- a/ingest/log/logging_test.go
+++ b/ingest/log/logging_test.go
@@ -84,6 +84,30 @@ func TestValue(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	testOutputs(t, lgr)
+}
+
+func TestRawValue(t *testing.T) {
+	pth := filepath.Join(t.TempDir(), `testraw.log`)
+	lgr, err := NewFile(pth)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lgr.raw = true
+	testOutputs(t, lgr)
+	bts, err := ioutil.ReadFile(pth)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(bts)
+	if strings.Contains(s, "<") {
+		t.Fatal("raw contains RFC header", s)
+	}
+
+}
+
+func testOutputs(t *testing.T, lgr *Logger) {
+	var err error
 	if err = lgr.Warnf("ERROR test: %d", 99); err != nil {
 		t.Fatal(err)
 	}

--- a/ingest/log/stderrlog_unix.go
+++ b/ingest/log/stderrlog_unix.go
@@ -56,9 +56,13 @@ func (c critLevelRelay) WriteLog(l Level, ts time.Time, rfcline, rawline string)
 	if l >= ERROR {
 		if _, err = io.WriteString(os.Stderr, rawline); err != nil {
 			return
+		} else if _, err = os.Stderr.Write([]byte{'\n'}); err != nil {
+			return
 		}
 		for _, w := range c.wc {
 			if _, err = io.WriteString(w, rawline); err != nil {
+				return
+			} else if _, err = w.Write([]byte{'\n'}); err != nil {
 				return
 			}
 		}

--- a/ingest/log/stderrlog_unix.go
+++ b/ingest/log/stderrlog_unix.go
@@ -12,15 +12,17 @@
 package log
 
 import (
+	"io"
 	"os"
 	"syscall"
+	"time"
 )
 
 func newStderrLogger(fileOverride string, cb StderrCallback) (lgr *Logger, err error) {
-	var oldstderr int
-	var fout *os.File
-	lgr = New(os.Stderr)
+	var clr critLevelRelay
 	if len(fileOverride) > 0 {
+		var oldstderr int
+		var fout *os.File
 		//get a handle on the output file
 		if fout, err = os.Create(fileOverride); err != nil {
 			return
@@ -34,12 +36,40 @@ func newStderrLogger(fileOverride string, cb StderrCallback) (lgr *Logger, err e
 			fout.Close()
 			return
 		} else {
-			lgr.AddWriter(os.NewFile(uintptr(oldstderr), "oldstderr"))
+			clr.wc = []io.WriteCloser{os.NewFile(uintptr(oldstderr), "oldstderr")}
 		}
 
 		//dupe the output file onto stderr so that output goes there
 		if err = syscall.Dup3(int(fout.Fd()), int(os.Stderr.Fd()), 0); err != nil {
 			fout.Close()
+		}
+	}
+	lgr = NewLevelRelay(clr)
+	return
+}
+
+type critLevelRelay struct {
+	wc []io.WriteCloser
+}
+
+func (c critLevelRelay) WriteLog(l Level, ts time.Time, rfcline, rawline string) (err error) {
+	if l >= ERROR {
+		if _, err = io.WriteString(os.Stderr, rawline); err != nil {
+			return
+		}
+		for _, w := range c.wc {
+			if _, err = io.WriteString(w, rawline); err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+func (c critLevelRelay) Close() (err error) {
+	for _, wc := range c.wc {
+		if lerr := wc.Close(); err != nil {
+			err = lerr
 		}
 	}
 	return

--- a/ingest/log/stderrlog_windows.go
+++ b/ingest/log/stderrlog_windows.go
@@ -16,6 +16,6 @@ import (
 )
 
 func newStderrLogger(fileOverride string, cb StderrCallback) (lgr *Logger, err error) {
-	err = errors.New("stderr logger not avialable on windows or ARM")
+	err = errors.New("stderr logger not avialable on windows")
 	return
 }


### PR DESCRIPTION
This fixes the ingesters so that logs that go to stderr do NOT contain the RFC5424 error message, just the message and values.

Here is what happens now.

If you DO NOT redirect stderr:
1. logs come out to stderr as RFC5424
2. only error, critical, and fatal are emitted to stderr


If you DO redirect stderr:
1. logs going to the redirected stderr file are emitted as RFC5424
2. logs going to actual stderr (the journal) are emitted as raw with no timestamp (so the journal can handle it)
3. only error, critical, and fatal are emitted to stderr

This PR addresses #902 
This PR addresses #901 