### PR TITLE
fixing config block structure that is thrown in the windows event ingester

### DIFF
--- a/ingesters/winevents/config.go
+++ b/ingesters/winevents/config.go
@@ -153,6 +153,28 @@ func (c *CfgType) AttachConfig() attach.AttachConfig {
 	return c.Attach
 }
 
+// RawConfig gets an object that is suitable for the ingestmuxer.SetRawConfiguration
+func (c *CfgType) RawConfig() interface{} {
+	if c == nil {
+		return nil
+	}
+	return struct {
+		config.IngestConfig
+		Bookmark_Location string
+		Ignore_Timestamps bool
+		Attach            attach.AttachConfig
+		EventChannel      map[string]*EventStreamConfig
+		Preprocessor      processors.ProcessorConfig
+	}{
+		IngestConfig:      c.Global.IngestConfig,
+		Bookmark_Location: c.Global.Bookmark_Location,
+		Ignore_Timestamps: c.Global.Ignore_Timestamps,
+		Attach:            c.Attach,
+		EventChannel:      c.EventChannel,
+		Preprocessor:      c.Preprocessor,
+	}
+}
+
 func (c *CfgType) VerifyRemote() bool {
 	return c.Global.Verify_Remote_Certificates
 }

--- a/ingesters/winevents/processing.go
+++ b/ingesters/winevents/processing.go
@@ -364,7 +364,7 @@ func (m *mainService) init() error {
 	}
 	// prepare the configuration we're going to send upstream
 	if m.cfg != nil {
-		if err = igst.SetRawConfiguration(*m.cfg); err != nil {
+		if err = igst.SetRawConfiguration(m.cfg.RawConfig()); err != nil {
 			lg.Error("failed to set configuration for ingester state messages", log.KVErr(err))
 			return err
 		}


### PR DESCRIPTION
This PR addresses #900 

![Screenshot from 2023-11-17 09-15-17](https://github.com/gravwell/gravwell/assets/108431167/1dbd4d75-f989-4678-bc61-6b8f212c8213)

