### PR TITLE
Add Pre-extractions to CustomTime Formats

### DIFF
--- a/client/types/alert.go
+++ b/client/types/alert.go
@@ -56,7 +56,7 @@ type AlertDefinition struct {
 
 	LastUpdated time.Time `json:"LastUpdated"`
 
-	SaveSearchDuraton time.Duaration `json:"SaveSearchDuration"`
+	SaveSearchDuration time.Duaration `json:"SaveSearchDuration"`
 
 	// Maximum number of events allowed per firing of the alert. This is
 	// intended as a safety valve to avoid thousands of emails. If zero,

--- a/client/types/alert.go
+++ b/client/types/alert.go
@@ -21,6 +21,8 @@ type AlertConsumerType string
 // List of AlertConsumerType
 const (
 	ALERTCONSUMERTYPE_FLOW AlertConsumerType = "flow"
+
+	DefaultAlertSaveSearchDuration = time.Hour * 24 * 7 // alerts save search results for 7 days by default
 )
 
 // AlertDispatcherType : Possible types for an Alert Dispatcher
@@ -53,6 +55,8 @@ type AlertDefinition struct {
 	Labels []string `json:"Labels"`
 
 	LastUpdated time.Time `json:"LastUpdated"`
+
+	SaveSearchDuraton time.Duaration `json:"SaveSearchDuration"`
 
 	// Maximum number of events allowed per firing of the alert. This is
 	// intended as a safety valve to avoid thousands of emails. If zero,


### PR DESCRIPTION
Timegrinder currently has a hard time with unix seconds, or unix nano, or whatever when its embedded deep in some other structure.  This is because.. its just a number.

It also struggles when there are multiple timestamps.

This PR introduces Custom `Extraction-Regex` that can be applied to custom timestamps.

Consider the following data:
```
{"key1": "foobar", "TS": 1700874050}
{"key1": "foobar", "TS": 1700874051}
{"key1": "foobar", "TS": 1700874052}
```

Before we could not capture that, but with this `CustomTime` specification:

```
[TimeFormat "foo"]
	Format="UnixSeconds"
	Extraction-Regex=`"TS":\s*(?P<ts>\d+)`
```

We can now.

### See the before and after in a query
![Screenshot from 2023-11-24 18-17-15](https://github.com/gravwell/gravwell/assets/108431167/5a9e98a5-abdd-4165-bb24-2821a05dd20d)
