### PR TITLE
Improve handling of filefollow pre-process

### DIFF
--- a/filewatch/filewatch.go
+++ b/filewatch/filewatch.go
@@ -401,6 +401,9 @@ func (wm *WatchManager) Catchup(qc chan os.Signal) (bool, error) {
 		return false, ErrAlreadyStarted
 	}
 
+	wm.logger.Info("beginning initial file catch-up")
+	defer wm.logger.Info("completed initial file catch-up")
+
 	//generate list of files that could be processed
 	//this could be MANNY files if people are doing some mass ingest
 	toProcess, err := wm.getWatchedFileList()

--- a/filewatch/filters.go
+++ b/filewatch/filters.go
@@ -695,7 +695,6 @@ func (f *FilterManager) CatchupFile(wf watchedFile, qc chan os.Signal) (bool, er
 			FilterID:             i,
 			Handler:              v.lh,
 		}
-		//this file needs to be caugh up
 		if quit, err := f.catchupFollower(fcfg, qc); err != nil || quit {
 			return quit, err
 		}
@@ -706,6 +705,7 @@ func (f *FilterManager) CatchupFile(wf watchedFile, qc chan os.Signal) (bool, er
 
 // catchupFollower is a linear operation to get outstanding files up to date.
 func (f *FilterManager) catchupFollower(fcfg FollowerConfig, qc chan os.Signal) (bool, error) {
+	f.logger.Info("performing initial catch-up preprocessing for file", log.KV("file", fcfg.FilePath))
 	if fl, err := NewFollower(fcfg); err != nil {
 		return false, err
 	} else if quit, err := fl.Sync(qc); err != nil || quit {


### PR DESCRIPTION
If a writer is writing really fast, we can sometimes get "stuck" chasing the tail of a given file during the initial sync. This change notes the size of the file when we begin the process and doesn't read past that size, even if the file has been written since then.

