### PR TITLE
Clean up some TLS min versions and default configs

### DIFF
--- a/ingesters/HttpIngester/gravwell_http_ingester.conf
+++ b/ingesters/HttpIngester/gravwell_http_ingester.conf
@@ -1,10 +1,10 @@
 [Global]
 Ingest-Secret = "IngestSecrets"
 Connection-Timeout = 0
-Insecure-Skip-TLS-Verify=true
 #Cleartext-Backend-Target=127.0.0.1:4023 #example of adding another cleartext connection
 #Cleartext-Backend-Target=172.17.0.2:4023 #example of adding a cleartext connection
 #Encrypted-Backend-Target=127.1.1.1:4024 #example of adding an encrypted connection
+#Insecure-Skip-TLS-Verify=true
 Pipe-Backend-Target=/opt/gravwell/comms/pipe #a named pipe connection, this should be used when ingester is on the same machine as a backend
 Log-Level=INFO #options are OFF INFO WARN ERROR
 Ingest-Cache-Path=/opt/gravwell/cache/http_ingester.cache

--- a/ingesters/HttpIngester/main.go
+++ b/ingesters/HttpIngester/main.go
@@ -10,6 +10,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	dlog "log"
@@ -166,6 +167,9 @@ func main() {
 		debugout("Binding to %v with TLS enabled using %s %s\n", cfg.Bind, cfg.TLS_Certificate_File, cfg.TLS_Key_File)
 		go func(dc chan error) {
 			defer close(dc)
+			srv.TLSConfig = &tls.Config{
+				MinVersion: tls.VersionTLS12,
+			}
 			if err := srv.ListenAndServeTLS(c, k); err != nil {
 				lg.Error("failed to serve HTTPS server", log.KVErr(err))
 			}

--- a/ingesters/networkLog/network_capture.conf
+++ b/ingesters/networkLog/network_capture.conf
@@ -1,10 +1,10 @@
 [Global]
 Ingest-Secret = "IngestSecrets"
 Connection-Timeout = 0
-Insecure-Skip-TLS-Verify=true
 #Cleartext-Backend-Target=127.0.0.1:4023 #example of adding a cleartext connection
 #Cleartext-Backend-Target=127.1.0.1:4023 #example of adding another cleartext connection
 #Encrypted-Backend-Target=127.1.1.1:4024 #example of adding an encrypted connection
+#Insecure-Skip-TLS-Verify=true
 Pipe-Backend-Target=/opt/gravwell/comms/pipe #a named pipe connection, this should be used when ingester is on the same machine as a backend
 Log-Level=INFO #options are OFF INFO WARN ERROR
 Log-File=/opt/gravwell/log/network_capture.log

--- a/migrate/splunkconn.go
+++ b/migrate/splunkconn.go
@@ -13,9 +13,8 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
-	"github.com/gravwell/gravwell/v3/ingest/config"
-	"github.com/gravwell/gravwell/v3/ingest/log"
 	"io"
 	"io/ioutil"
 	"math/rand"
@@ -23,6 +22,13 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/gravwell/gravwell/v3/ingest/config"
+	"github.com/gravwell/gravwell/v3/ingest/log"
+)
+
+var (
+	fInsecureSkipTlsVerify = flag.Bool("insecure-skip-tls-verify", false, "Skip TLS validation for HTTPS connections")
 )
 
 type splunkEntry struct {
@@ -73,7 +79,9 @@ type splunkConn struct {
 
 func newSplunkConn(server, token string) splunkConn {
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // ignore expired SSL certificates
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: *fInsecureSkipTlsVerify,
+		}, // ignore expired SSL certificates
 	}
 	client := &http.Client{Transport: tr}
 	return splunkConn{


### PR DESCRIPTION
Force TLS 1.2 or better for all servers, simple relay already did this, but now HTTP ingester does too

Also clean up some TLS related configs and bad settings.

This PR addresses https://github.com/gravwell/gravwell/issues/942