### PR TITLE
fix unsafe usage of scanner Bytes() method

### DIFF
--- a/generators/gravwellGenerator/jsongen.go
+++ b/generators/gravwellGenerator/jsongen.go
@@ -28,12 +28,12 @@ type datum struct {
 }
 
 type megaDatum struct {
-	TS        string         `json:"time"`
 	Account   Account        `json:"account"`
 	Class     int            `json:"class"`
 	Groups    []ComplexGroup `json:"groups,omitempty"`
 	UserAgent string         `json:"user_agent"`
 	IP        string         `json:"ip"`
+	TS        int64          `json:"time"` //bury the timestamp somewhere dumb, its also encoded unix timestamp
 	Records   []megaRecord   `json:"records"`
 	Data      string         `json:"data,escape"`
 }
@@ -76,7 +76,7 @@ func genDataJSON(ts time.Time) (r []byte) {
 // these will vary from 32KB to 128KB
 func genDataMegaJSON(ts time.Time) (r []byte) {
 	var d megaDatum
-	d.TS = ts.UTC().Format(time.RFC3339)
+	d.TS = ts.UTC().Unix()
 	d.Class = rand.Int() % 0xffff
 	d.Groups = getComplexGroups()
 	d.Account = getUser()

--- a/ingesters/HttpIngester/config.go
+++ b/ingesters/HttpIngester/config.go
@@ -372,17 +372,22 @@ func (pa *paramAttacher) processAll(vals url.Values) {
 		if len(k) > 0 && len(v) > 0 {
 			// ignore tag override parameter
 			if k != parameterTag {
-				// loop over values and find one that has something
+				// initialize our string value, it will be empty by default
+				// then scan the values looking for something that is NOT empty
+				// if we find something, set the string value and break
+				// if not, then it's an empty string and we use the initialized zero value
+				var sval string
+				// loop over values and find one that has something, potentially overriding the zero value
 				for _, vv := range v {
 					if len(vv) > 0 {
-						// got one, add it and break
-						pa.exts = append(pa.exts, entry.EnumeratedValue{
-							Name:  k,
-							Value: entry.StringEnumData(vv),
-						})
+						sval = vv
 						break
 					}
 				}
+				pa.exts = append(pa.exts, entry.EnumeratedValue{
+					Name:  k,
+					Value: entry.StringEnumData(sval),
+				})
 			}
 		}
 	}

--- a/ingesters/SimpleRelay/rfc5424Handlers.go
+++ b/ingesters/SimpleRelay/rfc5424Handlers.go
@@ -109,13 +109,14 @@ func rfc5424ConnHandlerTCP(c net.Conn, cfg handlerConfig) {
 	}
 	s.Split(splitter)
 	for s.Scan() {
-		data := bytes.Trim(s.Bytes(), "\n\r\t ")
+		data := bytes.TrimSpace(s.Bytes())
 		if cfg.dropPriority {
 			data = dropPriority(data)
 		}
 		if len(data) == 0 {
 			continue
 		}
+		data = bytes.Clone(data) // the scanner re-uses bytes, so we have to clone
 		if ent, err := handleLog(data, rip, cfg.ignoreTimestamps, cfg.tag, tg); err != nil {
 			return
 		} else if err = cfg.proc.ProcessContext(ent, cfg.ctx); err != nil {

--- a/ingesters/SimpleRelay/rfc6587Handlers.go
+++ b/ingesters/SimpleRelay/rfc6587Handlers.go
@@ -169,6 +169,7 @@ func rfc6587ConnHandlerTCP(c net.Conn, cfg handlerConfig) {
 		if len(data) == 0 {
 			continue
 		}
+		data = bytes.Clone(data) // we have to copy due to the scanner reusing its underlying buffer
 		if ent, err := handleLog(data, rip, cfg.ignoreTimestamps, cfg.tag, tg); err != nil {
 			return
 		} else if err = cfg.proc.ProcessContext(ent, cfg.ctx); err != nil {

--- a/ingesters/massFile/processing.go
+++ b/ingesters/massFile/processing.go
@@ -10,6 +10,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -101,7 +102,7 @@ func groupLargeLogs(src, wrk string, totalSize int64) error {
 			if !ok {
 				ts = lastTS
 			}
-			if err := fm.writeLine(int64(ts.Second()), v); err != nil {
+			if err := fm.writeLine(int64(ts.Second()), bytes.Clone(v)); err != nil {
 				return err
 			}
 			ud.update(fm.total)
@@ -319,7 +320,7 @@ func walkAndReadFiles(dir string, totalSize int64, iv *ingestVars, f entsFunc) e
 			}
 			ents = append(ents, ent{
 				ts:   entry.FromStandard(ts),
-				data: append(nilbs, v...),
+				data: bytes.Clone(v),
 			})
 		}
 		if err := fin.Close(); err != nil {

--- a/ingesters/multiFile/main.go
+++ b/ingesters/multiFile/main.go
@@ -286,11 +286,11 @@ func ingestFile(fin io.Reader, igst *ingest.IngestMuxer, tag entry.EntryTag, tg 
 			ts = time.Now()
 		}
 		ent := &entry.Entry{
-			TS:  entry.FromStandard(ts),
-			Tag: tag,
-			SRC: src,
+			TS:   entry.FromStandard(ts),
+			Tag:  tag,
+			SRC:  src,
+			Data: bytes.Clone(bts), // force a copy due to scanner
 		}
-		ent.Data = append(ent.Data, bts...) //force reallocation due to the scanner
 		if bsize == 0 {
 			if err = igst.WriteEntry(ent); err != nil {
 				return err

--- a/ingesters/regexFile/main.go
+++ b/ingesters/regexFile/main.go
@@ -208,11 +208,11 @@ func ingestFile(fin io.Reader, igst *ingest.IngestMuxer, tag entry.EntryTag, tso
 			}
 		}
 		ent := &entry.Entry{
-			TS:  entry.FromStandard(ts),
-			Tag: tag,
-			SRC: src,
+			TS:   entry.FromStandard(ts),
+			Tag:  tag,
+			SRC:  src,
+			Data: bytes.Clone(bts), //force copy due to the scanner
 		}
-		ent.Data = append(ent.Data, bts...) //force reallocation due to the scanner
 		if err = igst.WriteEntry(ent); err != nil {
 			return err
 		}

--- a/ingesters/s3Ingester/utils.go
+++ b/ingesters/s3Ingester/utils.go
@@ -316,9 +316,9 @@ func processLinesContext(ctx context.Context, rdr io.Reader, maxLineSize int, tg
 		}
 		ent := entry.Entry{
 			TS:   entry.FromStandard(ts),
-			SRC:  src,                         //may be nil, ingest muxer will handle if it is
-			Data: append([]byte(nil), bts...), //scanner re-uses the buffer
+			SRC:  src, //may be nil, ingest muxer will handle if it is
 			Tag:  tag,
+			Data: bytes.Clone(bts), //scanner re-uses the buffer
 		}
 		if ctx != nil {
 			err = proc.ProcessContext(&ent, ctx)

--- a/ingesters/utils/readers.go
+++ b/ingesters/utils/readers.go
@@ -348,14 +348,14 @@ scannerLoop:
 			ts = time.Now()
 		}
 		ent := &entry.Entry{
-			TS:  entry.FromStandard(ts),
-			Tag: cfg.Tag,
-			SRC: cfg.SRC,
+			TS:   entry.FromStandard(ts),
+			Tag:  cfg.Tag,
+			SRC:  cfg.SRC,
+			Data: bytes.Clone(bts), // copy due to the scanner
 		}
 		for i := range cfg.AttachEnumeratedValues {
 			ent.AddEnumeratedValue(cfg.AttachEnumeratedValues[i])
 		}
-		ent.Data = append(ent.Data, bts...) //force reallocation due to the scanner
 		if cfg.BatchSize == 0 {
 			if err = cfg.Proc.Process(ent); err != nil {
 				return count, totalBytes, err


### PR DESCRIPTION
There were a few ingesters that were not Cloning the response of calls to a `bufio.Scanner.Bytes()` call.  It is extremely difficult to manifest the behavior on any ingester but the HTTP ingester due to the raciness of getting data into the ingest muxer. 

This fixes usage across all ingesters and also cleans up some kind of sloppy append() clone falls.

Addresses https://github.com/gravwell/gravwell/issues/949

Oops, this also includes the following:
1. tweak to megajson generator to simulate timestamps that suck (deeply embedded unix timestamp)
2. tweak to URL-Parameter-Attach to support a wildcard which means attach everything you see (but tag)
3. fix HEC compatible listener so that it supports custom timestamp formats (for /raw endpoint)