### PR TITLE
tweaking some configs to allow generator to be used to just test

### DIFF
--- a/generators/base/base.go
+++ b/generators/base/base.go
@@ -183,7 +183,7 @@ func GetGeneratorConfig(defaultTag string) (gc GeneratorConfig, err error) {
 		return
 	}
 	gc.ConnSet = connSet
-	if *entryCount <= 0 {
+	if *entryCount < 0 {
 		err = errors.New("invalid entry count")
 		return
 	}

--- a/generators/gravwellGenerator/main.go
+++ b/generators/gravwellGenerator/main.go
@@ -84,7 +84,6 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	seedUsers(int(cfg.Count), 256)
 
 	var tag entry.EntryTag
 	if igst, src, err = base.NewIngestMuxer(`unifiedgenerator`, `00000000-0000-0000-0000-000000000001`, cfg, time.Second); err != nil {
@@ -92,16 +91,22 @@ func main() {
 	} else if tag, err = igst.GetTag(cfg.Tag); err != nil {
 		log.Fatalf("Failed to lookup tag %s: %v\n", cfg.Tag, err)
 	}
-	start := time.Now()
+	var start time.Time
+	if cfg.Count > 0 {
+		start = time.Now()
+		seedUsers(int(cfg.Count), 256)
 
-	if !cfg.Streaming {
-		if totalCount, totalBytes, err = base.OneShot(igst, tag, src, cfg, gen, fin); err != nil {
-			log.Fatal("Failed to throw entries ", err)
+		if !cfg.Streaming {
+			if totalCount, totalBytes, err = base.OneShot(igst, tag, src, cfg, gen, fin); err != nil {
+				log.Fatal("Failed to throw entries ", err)
+			}
+		} else {
+			if totalCount, totalBytes, err = base.Stream(igst, tag, src, cfg, gen, fin); err != nil {
+				log.Fatal("Failed to stream entries ", err)
+			}
 		}
 	} else {
-		if totalCount, totalBytes, err = base.Stream(igst, tag, src, cfg, gen, fin); err != nil {
-			log.Fatal("Failed to stream entries ", err)
-		}
+		log.Println("Connection successful")
 	}
 
 	if err = igst.Sync(time.Second); err != nil {
@@ -112,8 +117,8 @@ func main() {
 		log.Fatal("Failed to close ingest muxer ", err)
 	}
 
-	durr := time.Since(start)
-	if err == nil {
+	if err == nil && cfg.Count > 0 {
+		durr := time.Since(start)
 		fmt.Printf("Completed in %v (%s)\n", durr, ingest.HumanSize(totalBytes))
 		fmt.Printf("Total Count: %s\n", ingest.HumanCount(totalCount))
 		fmt.Printf("Entry Rate: %s\n", ingest.HumanEntryRate(totalCount, durr))


### PR DESCRIPTION
This allows the generator to be used to test tag negotiation and connections without sending entries

<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->