### PR TITLE
tweak the validate function a bit so it can be used by internal components too

### DIFF
--- a/ingest/config/validate/validate.go
+++ b/ingest/config/validate/validate.go
@@ -38,7 +38,7 @@ func ValidateConfig(fnc interface{}, pth, confdPath string) {
 
 // ValidateIngesterConfig behaves same as ValidateConfig but also asserts that the provided config
 // can return an IngestBaseConfig object.
-func ValidateIngesterConfigBase(fnc interface{}, pth, confdPath string) {
+func ValidateIngesterConfig(fnc interface{}, pth, confdPath string) {
 	validateConfig(fnc, pth, confdPath, true) // this is used by ingesters
 }
 

--- a/ingest/config/validate/validate.go
+++ b/ingest/config/validate/validate.go
@@ -31,8 +31,19 @@ var (
 // The config handling function will take those two paths and process a config and return two values.
 // The first value is an opaque object (hence the reflect voodoo).  The second value is an error object
 // the point of this function is to make it easy for ingester writers to just hand in their GetConfig function
-// and the two paths and get a "go/no go" on the configurations
+// and the two paths and get a "go/no go" on the configurations.
+// ValidateConfig also asserts that the provided config object can return an IngestBaseConfig object.
 func ValidateConfig(fnc interface{}, pth, confdPath string) {
+	validateConfig(fnc, pth, confdPath, true) // this is used by ingesters
+}
+
+// ValidateConfigBase behaves the same as ValidateConfig but does not assert that the provided config
+// can return an IngestBaseConfig object.
+func ValidateConfigBase(fnc interface{}, pth, confdPath string) {
+	validateConfig(fnc, pth, confdPath, false) // this is used by ingesters
+}
+
+func validateConfig(fnc interface{}, pth, confdPath string, assertIngester bool) {
 	if !*vflag {
 		return
 	}
@@ -83,11 +94,12 @@ func ValidateConfig(fnc interface{}, pth, confdPath string) {
 	} else if obj == nil {
 		fmt.Printf("Config file %q returned a nil object\n", pth)
 		os.Exit(exitCode)
-	} else if ok, err = callVerifyFunc(obj); err != nil {
-		fmt.Printf("Config Verify function returned error: %v\n", err)
+	} else if err = callVerifyFunc(obj); err != nil {
+		fmt.Printf("Config Verify function returned error (%T): %v\n", obj, err)
 		os.Exit(exitCode)
-	} else if !ok {
-		fmt.Println("WARNING: ingester config does not contain Verify function")
+	} else if _, ok = obj.(igstConfig); !ok && assertIngester {
+		fmt.Printf("config object does not implement IngestBaseConfig interface\n")
+		os.Exit(exitCode)
 	}
 	if confdPath != `` {
 		fmt.Println(pth, "with overlay", confdPath, "is valid")
@@ -105,14 +117,13 @@ type igstConfig interface {
 	IngestBaseConfig() config.IngestConfig
 }
 
-func callVerifyFunc(obj interface{}) (ok bool, err error) {
+func callVerifyFunc(obj interface{}) (err error) {
+	var ok bool
 	var vv validator
 	if obj == nil {
 		err = errors.New("config is nil")
 	} else if vv, ok = obj.(validator); !ok {
 		err = errors.New("config object does not implement Verify interface")
-	} else if _, ok = obj.(igstConfig); !ok {
-		err = errors.New("config object does not implement IngestBaseConfig interface")
 	} else {
 		err = vv.Verify()
 	}

--- a/ingest/config/validate/validate.go
+++ b/ingest/config/validate/validate.go
@@ -32,15 +32,14 @@ var (
 // The first value is an opaque object (hence the reflect voodoo).  The second value is an error object
 // the point of this function is to make it easy for ingester writers to just hand in their GetConfig function
 // and the two paths and get a "go/no go" on the configurations.
-// ValidateConfig also asserts that the provided config object can return an IngestBaseConfig object.
 func ValidateConfig(fnc interface{}, pth, confdPath string) {
-	validateConfig(fnc, pth, confdPath, true) // this is used by ingesters
+	validateConfig(fnc, pth, confdPath, false) // this is used by NOT ingesters
 }
 
-// ValidateConfigBase behaves the same as ValidateConfig but does not assert that the provided config
+// ValidateIngesterConfig behaves same as ValidateConfig but also asserts that the provided config
 // can return an IngestBaseConfig object.
-func ValidateConfigBase(fnc interface{}, pth, confdPath string) {
-	validateConfig(fnc, pth, confdPath, false) // this is used by ingesters
+func ValidateIngesterConfigBase(fnc interface{}, pth, confdPath string) {
+	validateConfig(fnc, pth, confdPath, true) // this is used by ingesters
 }
 
 func validateConfig(fnc interface{}, pth, confdPath string, assertIngester bool) {

--- a/ingesters/Shodan/main.go
+++ b/ingesters/Shodan/main.go
@@ -79,7 +79,7 @@ func init() {
 		ingest.PrintVersion(os.Stdout)
 		os.Exit(0)
 	}
-	validate.ValidateConfig(GetConfig, *confLoc, *confdLoc)
+	validate.ValidateIngesterConfig(GetConfig, *confLoc, *confdLoc)
 	lg = log.New(os.Stderr) // DO NOT close this, it will prevent backtraces from firing
 	lg.SetAppname(appName)
 	if *stderrOverride != `` {

--- a/ingesters/base/base.go
+++ b/ingesters/base/base.go
@@ -83,7 +83,7 @@ func Init(ibc IngesterBaseConfig) (ib IngesterBase, err error) {
 	if err = ibc.validate(); err != nil {
 		return
 	}
-	validate.ValidateConfig(ib.GetConfigFunc, *confLoc, *confdLoc)
+	validate.ValidateIngesterConfig(ib.GetConfigFunc, *confLoc, *confdLoc)
 
 	var fp string
 	if pth := filepath.Clean(*stderrOverride); pth != `` && pth != `.` {

--- a/ingesters/canbus/main.go
+++ b/ingesters/canbus/main.go
@@ -69,7 +69,7 @@ func init() {
 		os.Exit(0)
 	}
 	debugOn = *verbose
-	validate.ValidateConfig(GetConfig, *confLoc, *confdLoc) // this will exit if the flags are set, also no overlays
+	validate.ValidateIngesterConfig(GetConfig, *confLoc, *confdLoc) // this will exit if the flags are set, also no overlays
 }
 
 func main() {

--- a/ingesters/fileFollow/main_windows.go
+++ b/ingesters/fileFollow/main_windows.go
@@ -65,7 +65,7 @@ func init() {
 		confLoc = *configOverride
 	}
 	debugOn = *verboseF
-	validate.ValidateConfig(GetConfig, confLoc, ``) //windows doesn't support conf.d style overlays for now
+	validate.ValidateIngesterConfig(GetConfig, confLoc, ``) //windows doesn't support conf.d style overlays for now
 }
 
 func main() {

--- a/ingesters/winevents/main.go
+++ b/ingesters/winevents/main.go
@@ -64,7 +64,7 @@ func init() {
 		confLoc = *configOverride
 	}
 	debugOn = *verboseF
-	validate.ValidateConfig(GetConfig, confLoc, ``)
+	validate.ValidateIngesterConfig(GetConfig, confLoc, ``)
 }
 
 func main() {

--- a/migrate/main.go
+++ b/migrate/main.go
@@ -49,7 +49,7 @@ func init() {
 	lg = log.New(&discard{})
 	//lg.AddWriter(os.Stderr)
 	lg.SetAppname(appName)
-	validate.ValidateConfig(GetConfig, *confLoc, *confdLoc)
+	validate.ValidateIngesterConfig(GetConfig, *confLoc, *confdLoc)
 }
 
 func main() {


### PR DESCRIPTION
Validate config function was too strict and trying to assert that everything was an ingester, this broke validate on other components.