### PR TITLE
Fix HEC ingester timestamp processing and Windows Upgrade with point versions

### DIFF
--- a/ingesters/HttpIngester/hec.go
+++ b/ingesters/HttpIngester/hec.go
@@ -75,8 +75,13 @@ func (c *custTime) UnmarshalJSON(v []byte) (err error) {
 	}
 	//attempt to parse as a float for the default type
 	if f, err = strconv.ParseFloat(string(raw), 64); err == nil {
-		//got a good parse on a float, sanity check it
-		if f < 0 || f > float64(0xffffffffff) {
+		if f > 1e13 { //microseconds
+			//did some asshole ship microseconds?
+			f = f / float64(1000000)
+		} else if f > 1e10 { //milliseconds
+			//assume its in milliseconds
+			f = f / float64(1000)
+		} else if f < 0 {
 			err = errors.New("invalid timestamp value")
 			return
 		}

--- a/ingesters/fileFollow/product.wxs
+++ b/ingesters/fileFollow/product.wxs
@@ -19,7 +19,7 @@
     <Property Id="ARPPRODUCTICON" Value="gravwellel.ico" />
     <Media Id="1" Cabinet="product.cab" EmbedCab="yes" />
     <!-- We will remove existing product AFTER we install new version so we can copy legacy configuration files -->
-    <MajorUpgrade Schedule="afterInstallFinalize" DowngradeErrorMessage="!(loc.Package_NewerVersionDetected)" />
+    <MajorUpgrade Schedule="afterInstallFinalize" DowngradeErrorMessage="!(loc.Package_NewerVersionDetected)" AllowSameVersionUpgrades="yes" />
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="$(var.Program_Files)">
         <Directory Id="BASEDIR" Name="gravwell">

--- a/ingesters/winevents/product.wxs
+++ b/ingesters/winevents/product.wxs
@@ -19,7 +19,7 @@
     <Property Id="ARPPRODUCTICON" Value="gravwellel.ico" />
     <Media Id="1" Cabinet="product.cab" EmbedCab="yes" />
     <!-- We will remove existing product AFTER we install new version so we can copy legacy configuration files -->
-    <MajorUpgrade Schedule="afterInstallFinalize" DowngradeErrorMessage="!(loc.Package_NewerVersionDetected)" />
+    <MajorUpgrade Schedule="afterInstallFinalize" DowngradeErrorMessage="!(loc.Package_NewerVersionDetected)" AllowSameVersionUpgrades="yes" />
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="$(var.Program_Files)">
         <Directory Id="BASEDIR" Name="gravwell">


### PR DESCRIPTION
The other issue is a customer HEC ingester was throwing a completely bonkers timetamp in a way that totally violates what is supposed to be happening.

So this deals with that edge case.... :(