### PR TITLE
make collect ingester not bark every time you restart it

### DIFF
--- a/ingesters/collectd/routines.go
+++ b/ingesters/collectd/routines.go
@@ -113,7 +113,11 @@ func (ci *collectdInstance) routine(ch chan error) {
 	ci.Lock()
 	ci.cancel = &cancel
 	ci.Unlock()
-	ch <- ci.srv.ListenAndWrite(ctx)
+	err := ci.srv.ListenAndWrite(ctx)
+	if err == context.Canceled {
+		err = nil //just closing
+	}
+	ch <- err
 	ci.Lock()
 	ci.state = done
 	ci.Unlock()


### PR DESCRIPTION
don't return an error if we are leaving a routine due to a context.Cancel