### PR TITLE
do not re-use underlying slices

### DIFF
--- a/ingest/entry/entry.go
+++ b/ingest/entry/entry.go
@@ -51,8 +51,8 @@ type Entry struct {
 }
 
 func init() {
-	gob.Register(EVBlock{})
-	gob.Register(Entry{})
+	gob.Register(&EVBlock{})
+	gob.Register(&Entry{})
 	gob.Register([]Entry{})
 	gob.Register([]*Entry{})
 }


### PR DESCRIPTION
These things shouldn't be re-used and it only causes opportunities for bugs by upstream users.