### PR TITLE
remove PIDFile specifications from service files

### DIFF
--- a/ingesters/HttpIngester/gravwell_http_ingester.service
+++ b/ingesters/HttpIngester/gravwell_http_ingester.service
@@ -17,7 +17,6 @@ StandardOutput=null
 StandardError=journal
 LimitNPROC=infinity
 LimitNOFILE=infinity
-PIDFile=/var/run/gravwell_http_ingester.pid
 TimeoutStopSec=60
 KillMode=process
 KillSignal=SIGINT

--- a/ingesters/networkLog/gravwell_network_capture.service
+++ b/ingesters/networkLog/gravwell_network_capture.service
@@ -12,7 +12,6 @@ User=gravwell
 Group=gravwell
 LimitNPROC=infinity
 LimitNOFILE=infinity
-PIDFile=/var/run/gravwell_network_capture.pid
 TimeoutStopSec=5
 KillMode=process
 KillSignal=SIGINT


### PR DESCRIPTION
These aren't used and systemd now barks about it.