### PR TITLE
Tweaks migrate tool to work with Splunk free licenses

### DIFF
--- a/migrate/config.go
+++ b/migrate/config.go
@@ -147,7 +147,7 @@ func (c *cfgType) getSplunkConn(splunkName string) (sc splunkConn, err error) {
 	for k, vv := range c.Splunk {
 		if k == splunkName {
 			// Connect to Splunk server
-			sc = newSplunkConn(vv.Server, vv.Token)
+			sc = newSplunkConn(vv.Server, vv.Token, vv.Insecure_Skip_TLS_Verify)
 			return
 		}
 	}

--- a/migrate/splunk.go
+++ b/migrate/splunk.go
@@ -42,14 +42,15 @@ var (
 )
 
 type splunk struct {
-	Server                  string   // the Splunk server, e.g. splunk.example.com
-	Token                   string   // a Splunk auth token
-	Max_Chunk               int      // maximum number of entries to try and grab at once. Defaults to a conservative 500,000
-	Ingest_From_Unix_Time   int      // a timestamp to use as the default start time for this Splunk server (default 1)
-	Ingest_To_Unix_Time     int      // a timestamp to use as the end time for this Splunk server (default 0, meaning "now")
-	Index_Sourcetype_To_Tag []string // a mapping of index+sourcetype to Gravwell tag
-	Disable_Intrinsics      bool     // If set, no additional fields will be attached as intrinsic EVs on the ingested data
-	Preprocessor            []string
+	Server                   string   // the Splunk server, e.g. splunk.example.com
+	Insecure_Skip_TLS_Verify bool     // don't verify the *splunk* certs
+	Token                    string   // a Splunk auth token
+	Max_Chunk                int      // maximum number of entries to try and grab at once. Defaults to a conservative 500,000
+	Ingest_From_Unix_Time    int      // a timestamp to use as the default start time for this Splunk server (default 1)
+	Ingest_To_Unix_Time      int      // a timestamp to use as the end time for this Splunk server (default 0, meaning "now")
+	Index_Sourcetype_To_Tag  []string // a mapping of index+sourcetype to Gravwell tag
+	Disable_Intrinsics       bool     // If set, no additional fields will be attached as intrinsic EVs on the ingested data
+	Preprocessor             []string
 }
 
 func (s *splunk) Validate(procs processors.ProcessorConfig) (err error) {
@@ -516,7 +517,7 @@ func checkMappings(cfgName string, ctx context.Context, updateChan chan string) 
 	status := splunkTracker.GetStatus(cfgName)
 
 	// Connect to Splunk server and get a list of all sourcetypes & indexes
-	sc := newSplunkConn(c.Server, c.Token)
+	sc := newSplunkConn(c.Server, c.Token, c.Insecure_Skip_TLS_Verify)
 
 	var st []sourcetypeIndex
 	st, err = sc.GetIndexSourcetypes(c.Ingest_From_Unix_Time, c.Ingest_To_Unix_Time)

--- a/migrate/splunkconn.go
+++ b/migrate/splunkconn.go
@@ -13,7 +13,6 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -25,10 +24,6 @@ import (
 
 	"github.com/gravwell/gravwell/v3/ingest/config"
 	"github.com/gravwell/gravwell/v3/ingest/log"
-)
-
-var (
-	fInsecureSkipTlsVerify = flag.Bool("insecure-skip-tls-verify", false, "Skip TLS validation for HTTPS connections")
 )
 
 type splunkEntry struct {
@@ -77,10 +72,10 @@ type splunkConn struct {
 	Client  *http.Client
 }
 
-func newSplunkConn(server, token string) splunkConn {
+func newSplunkConn(server, token string, skipTlsVerify bool) splunkConn {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: *fInsecureSkipTlsVerify,
+			InsecureSkipVerify: skipTlsVerify,
 		}, // ignore expired SSL certificates
 	}
 	client := &http.Client{Transport: tr}
@@ -100,7 +95,9 @@ func (c *splunkConn) GetEventIndexes() (indexes []splunkEntry, err error) {
 	if req, err = http.NewRequest(http.MethodGet, idxURL, nil); err != nil {
 		return
 	}
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token))
+	if c.Token != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token))
+	}
 	if resp, err = c.Client.Do(req); err != nil {
 		return
 	}
@@ -135,7 +132,9 @@ func (c *splunkConn) GetSourceTypes() (sourcetypes []string, err error) {
 	if req, err = http.NewRequest(http.MethodGet, u, nil); err != nil {
 		return
 	}
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token))
+	if c.Token != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token))
+	}
 	if resp, err = c.Client.Do(req); err != nil {
 		return
 	}
@@ -195,7 +194,9 @@ func (c *splunkConn) GetIndexSourcetypes(start, end int) (m []sourcetypeIndex, e
 		return
 	}
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token))
+	if c.Token != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token))
+	}
 	if resp, err = c.Client.Do(req); err != nil {
 		return
 	}
@@ -216,7 +217,9 @@ func (c *splunkConn) GetIndexSourcetypes(start, end int) (m []sourcetypeIndex, e
 	if req, err = http.NewRequest(http.MethodGet, u, nil); err != nil {
 		return
 	}
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token))
+	if c.Token != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token))
+	}
 	if resp, err = c.Client.Do(req); err != nil {
 		return
 	}
@@ -260,7 +263,9 @@ func (c *splunkConn) RunExportSearch(query string, earliest, latest time.Time, p
 		return
 	}
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token))
+	if c.Token != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token))
+	}
 	if resp, err = c.Client.Do(req); err != nil {
 		return
 	}


### PR DESCRIPTION
If the user doesn't set the `Token` parameter on the Splunk config block, we'll assume it's a free license and omit the auth header entirely.

Also adds Insecure-Skip-TLS-Verify on the Splunk config block so we can handle Splunk servers with self-signed certs.

