### PR TITLE
set deadline on close so we don't stall on close during shutdown

### DIFF
--- a/ingest/entryReader.go
+++ b/ingest/entryReader.go
@@ -52,6 +52,7 @@ var (
 	ackBatchReadTimerDuration = 10 * time.Millisecond
 	defaultReaderTimeout      = 10 * time.Minute
 	keepAliveInterval         = 1000 * time.Millisecond
+	closeTimeout              = 10 * time.Second
 
 	nilTime time.Time
 )
@@ -241,6 +242,10 @@ func (er *EntryReader) Close() error {
 	if !er.hot {
 		return errors.New("Close on closed EntryTransport")
 	}
+	//try to set a deadline on the connection, we are exiting so everything BETTER wrap up within our closeTimeout
+	er.conn.SetDeadline(time.Now().Add(closeTimeout))
+	defer er.conn.SetDeadline(nilTime)
+
 	if er.started {
 		//close the ack channel and wait for the routine to return
 		close(er.ackChan)

--- a/ingest/entryWriter.go
+++ b/ingest/entryWriter.go
@@ -160,6 +160,10 @@ func (ew *EntryWriter) Close() (err error) {
 	ew.mtx.Lock()
 	defer ew.mtx.Unlock()
 
+	//try to set a deadline on the connection, we are exiting so everything BETTER wrap up within our closeTimeout
+	ew.conn.SetDeadline(time.Now().Add(closeTimeout))
+	defer ew.conn.SetDeadline(nilTime)
+
 	if err = ew.forceAckNoLock(); err == nil {
 		if err = ew.conn.SetReadTimeout(ew.ackTimeout); err != nil {
 			err = ew.conn.Close()


### PR DESCRIPTION
current close deadline is 10s, this seems like a LOOONG time to close out connections and should never hit; but it does act like a nice safety net to avoid leaks on truly stalled connections.