### PR TITLE
adding Warning member on stats and base response_

### DIFF
--- a/client/types/render.go
+++ b/client/types/render.go
@@ -151,8 +151,13 @@ type BaseResponse struct {
 
 	// Indicates that the query results exceeded the on-disk storage limits.
 	OverLimit bool
+
 	// Indicates the range of entries that were dropped due to storage limits.
 	LimitDroppedRange TimeRange
+
+	// Indicates that there is some warning about the query results the user should be aware of.
+	// Will be empty if no warning is present.
+	Warning string
 }
 
 func (br BaseResponse) Err() error {
@@ -288,12 +293,20 @@ type OverviewStatSet struct {
 type OverviewStats struct {
 	//indicates where in the search span the query currently is, can be used for progress
 	SearchPosition entry.Timestamp
+
 	//indicates if the search is finished
 	Finished bool
+
 	// Indicates that the query results exceeded the on-disk storage limits.
 	OverLimit bool
+
 	// Indicates the range of entries that were dropped due to storage limits.
 	LimitDroppedRange TimeRange
+
+	// Indicates that there is some warning about the query results the user should be aware of.
+	// Will be empty if no warning is present.
+	Warning string
+
 	// For some renderers, the EntryCount accurately represents the total
 	// number of results available. This field is set to 'true' in that case,
 	// meaning the EntryCount number can be displayed alongside the results


### PR DESCRIPTION
 so renderers can provide warnings about over limits and storage when finishing