### PR TITLE
File follower and windows file lock fun

### DIFF
--- a/filewatch/filewatch.go
+++ b/filewatch/filewatch.go
@@ -423,7 +423,11 @@ func (wm *WatchManager) Catchup(qc chan os.Signal) (bool, error) {
 	}
 
 	for _, wf := range toProcess {
-		if quit, err := wm.fman.CatchupFile(wf, qc); err != nil || quit {
+		quit, err := wm.fman.CatchupFile(wf, qc)
+		if err != nil {
+			wm.logger.Warn("failed to catch up file", log.KV("file", wf.pth), log.KV("error", err))
+		}
+		if quit {
 			return quit, err
 		}
 	}

--- a/filewatch/filters.go
+++ b/filewatch/filters.go
@@ -663,6 +663,10 @@ func (f *FilterManager) CatchupFile(wf watchedFile, qc chan os.Signal) (bool, er
 	//get ID
 	id, err := getFileIdFromName(wf.pth)
 	if err != nil {
+		//if we catch a file that does not exist during Catchup, just leave, there is nothing to do here
+		if os.IsNotExist(err) {
+			return false, nil
+		}
 		return false, err
 	}
 

--- a/filewatch/followers.go
+++ b/filewatch/followers.go
@@ -209,7 +209,7 @@ func (f *follower) Sync(qc chan os.Signal) (bool, error) {
 		// This makes sure we don't read forever, in case the writer is really fast
 		// and the connection to the indexer isn't.
 		if f.lnr.Index() >= size {
-			return false, nil
+			break // this essentially returns false, nil
 		}
 		select {
 		case _ = <-qc:

--- a/filewatch/fwork_windows.go
+++ b/filewatch/fwork_windows.go
@@ -43,7 +43,7 @@ func getFileIdFromName(name string) (id FileId, err error) {
 	//GetFileINformationByHandle syscall can take time... It looks like a stat...
 	//it smells like a stat... it ain't a stat....
 	shared := uint32(syscall.FILE_SHARE_READ | syscall.FILE_SHARE_WRITE | syscall.FILE_SHARE_DELETE)
-	h, lerr := syscall.CreateFile(p, syscall.GENERIC_READ, shared, nil, syscall.OPEN_EXISTING, syscall.FILE_FLAG_BACKUP_SEMANTICS, 0)
+	h, lerr := syscall.CreateFile(p, syscall.GENERIC_READ, shared, nil, syscall.OPEN_EXISTING, syscall.FILE_FLAG_BACKUP_SEMANTICS|syscall.FILE_ATTRIBUTE_READONLY, 0)
 	if lerr != nil {
 		err = fmt.Errorf("Failed to open %s to check FileID: %w", name, lerr)
 		return
@@ -78,7 +78,7 @@ func openDeletableFile(fpath string) (*os.File, error) {
 	}
 
 	shared := uint32(syscall.FILE_SHARE_READ | syscall.FILE_SHARE_WRITE | syscall.FILE_SHARE_DELETE)
-	h, err := syscall.CreateFile(p, syscall.GENERIC_READ, shared, nil, syscall.OPEN_EXISTING, syscall.FILE_FLAG_BACKUP_SEMANTICS, 0)
+	h, err := syscall.CreateFile(p, syscall.GENERIC_READ, shared, nil, syscall.OPEN_EXISTING, syscall.FILE_FLAG_BACKUP_SEMANTICS|syscall.FILE_ATTRIBUTE_READONLY, 0)
 	if err != nil {
 		if os.IsNotExist(err) {
 			err = os.ErrNotExist

--- a/filewatch/fwork_windows.go
+++ b/filewatch/fwork_windows.go
@@ -30,22 +30,32 @@ func getFileId(f *os.File) (id FileId, err error) {
 	return
 }
 
+// getFileIdFromName is a windows version of stat that returns something roughly equal to a device and inode.
+// there is voodoo, we all hate it... yet here we are...
 func getFileIdFromName(name string) (id FileId, err error) {
-
+	var attrib *syscall.SecurityAttributes
 	p, lerr := syscall.UTF16PtrFromString(name)
 	if lerr != nil {
 		err = lerr
 		return
 	}
-	h, lerr := syscall.CreateFile(p, 0, 0, nil, syscall.OPEN_EXISTING, syscall.FILE_FLAG_BACKUP_SEMANTICS, 0)
+
+	//make sure to drop the share attributes even in this call because apparently
+	//GetFileINformationByHandle syscall can take time... It looks like a stat...
+	//it smells like a stat... it ain't a stat....
+	shared := uint32(syscall.FILE_SHARE_READ | syscall.FILE_SHARE_WRITE | syscall.FILE_SHARE_DELETE)
+	h, lerr := syscall.CreateFile(p, syscall.GENERIC_READ, shared, attrib, syscall.OPEN_EXISTING, syscall.FILE_FLAG_BACKUP_SEMANTICS, 0)
 	if lerr != nil {
-		err = fmt.Errorf("Failed to open %s to check FileID: %v", name, lerr)
+		err = fmt.Errorf("Failed to open %s to check FileID: %w", name, lerr)
 		return
 	}
 	defer syscall.CloseHandle(h)
 	var bhfi syscall.ByHandleFileInformation
 	if err = syscall.GetFileInformationByHandle(h, &bhfi); err != nil {
-		err = fmt.Errorf("Failed to get FileID for %s: %v", name, err)
+		if os.IsNotExist(err) {
+			err = os.ErrNotExist
+		}
+		err = &os.PathError{Op: "open", Path: name, Err: os.ErrNotExist}
 		return
 	}
 	id.Major = uint64(bhfi.VolumeSerialNumber)
@@ -72,7 +82,10 @@ func openDeletableFile(fpath string) (*os.File, error) {
 	shared := uint32(syscall.FILE_SHARE_READ | syscall.FILE_SHARE_WRITE | syscall.FILE_SHARE_DELETE)
 	h, err := syscall.CreateFile(p, syscall.GENERIC_READ, shared, attrib, syscall.OPEN_EXISTING, syscall.FILE_ATTRIBUTE_NORMAL, 0)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to open %s : %v", fpath, err)
+		if os.IsNotExist(err) {
+			err = os.ErrNotExist
+		}
+		return nil, &os.PathError{Op: "open", Path: fpath, Err: err}
 	}
 
 	return os.NewFile(uintptr(h), fpath), nil
@@ -97,6 +110,9 @@ func createDeletableFile(fpath string) (*os.File, error) {
 	h, err := syscall.CreateFile(p, syscall.GENERIC_READ|syscall.GENERIC_WRITE, shared,
 		attrib, syscall.CREATE_NEW|syscall.OPEN_ALWAYS, syscall.FILE_ATTRIBUTE_NORMAL, 0)
 	if err != nil {
+		if os.IsNotExist(err) {
+			err = &os.PathError{Op: "open", Path: fpath, Err: os.ErrNotExist}
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
This fixes two main bugs:
1. The file follower could exit on error if a file is rotated out during the Catchup call.  This seems like one hell of a race to hit, but I am able to trigger it on the regular with Windows.  Never could in Linux.
2. Windows file follower calls its equivelent of a "stat" with SHARE attributes, because apparently "stat" in windows grabs a file handle in an exclusive way and holds it for a long time... because reasons.

