### PR TITLE
ci: Run tests on any PR

### DIFF
--- a/.github/workflows/golang-testing.yml
+++ b/.github/workflows/golang-testing.yml
@@ -4,10 +4,6 @@ name: golang-testing
 
 on:
   pull_request:
-    branches:
-      - dev
-      - '*'
-      - 'release/*'
 
 jobs:
 
@@ -118,7 +114,7 @@ jobs:
         go test -v ./ipexist
         go test -v ./netflow
         go test -v ./client/...
-    
+
     - name: Build
       run: |
         go build -o /dev/null ./generators/gravwellGenerator


### PR DESCRIPTION
This PR addresses no issue.

We're currently limiting test jobs to PRs that target certain branches. We **should** be running tests on **all** PRs that are opened. That is, we should never merge code that hasn't had tests run and pass.

This PR proposes 

- removing the branch inclusion list, so that all PRs will have tests run on them
- whitespace cleanup
