### PR TITLE
clean up some more state operations and make failures across multiple overlapping filters not affect other filters

### DIFF
--- a/filewatch/filters.go
+++ b/filewatch/filters.go
@@ -372,13 +372,13 @@ func (f *FilterManager) RenameFollower(fpath string) error {
 			flw.Close()
 			delete(f.states, stid)
 			delete(f.followers, stid)
-			return err
+			continue
 		}
 		if ok {
 			found = true
 			//we found it, make sure its not the same damn file name
 			if p == fpath {
-				return nil
+				continue // keep checking other followers
 			}
 			//different filter but we must keep tracking
 			if flw.FilterId() != i {
@@ -407,7 +407,6 @@ func (f *FilterManager) RenameFollower(fpath string) error {
 				//return nil
 			} else if v.loc == p {
 				//just update the names
-				delete(f.followers, stid)
 				flw.FileName = stid
 				st, ok := f.states[stid]
 				if !ok {
@@ -607,6 +606,7 @@ func (f *FilterManager) checkRename(fpath string, id FileId) (isRename bool, err
 			if filterId >= len(f.filters) || filterId < 0 {
 				//filter outside of range, delete the follower
 				removeFollower = true
+				continue // so we don't try to use this index
 			}
 			//check the filter glob against the new name
 			if f.filters[filterId].loc == fdir && f.matchFile(f.filters[filterId].mtchs, fname) {

--- a/filewatch/followers.go
+++ b/filewatch/followers.go
@@ -144,23 +144,25 @@ func (f *follower) FileId() FileId {
 // lastFileModTime is a helper that pulls back the file modification time
 // this suppresses all errors and returns the zero time if anything goes wrong
 func (f *follower) lastFileModTime() (r time.Time) {
-	if f == nil || f.FilePath == `` {
+	if f == nil || f.lnr == nil {
 		return
 	}
-	if fi, err := os.Stat(f.FilePath); err == nil {
-		r = fi.ModTime()
+	var err error
+	if r, err = f.lnr.LastModTime(); err != nil {
+		r = time.Time{}
 	}
 
 	return
 }
 
 // fileSize just returns the current file size
-func (f *follower) fileSize() (s int64) {
-	if f == nil || f.FilePath == `` {
+func (f *follower) fileSize() (sz int64) {
+	if f == nil || f.lnr == nil {
 		return
 	}
-	if fi, err := os.Stat(f.FilePath); err == nil {
-		s = fi.Size()
+	var err error
+	if sz, err = f.lnr.FileSize(); err != nil {
+		sz = 0
 	}
 
 	return

--- a/filewatch/reader.go
+++ b/filewatch/reader.go
@@ -11,6 +11,7 @@ package filewatch
 import (
 	"errors"
 	"os"
+	"time"
 )
 
 const (
@@ -32,6 +33,7 @@ type Reader interface {
 	Close() error
 	ID() (FileId, error)
 	FileSize() (int64, error)
+	LastModTime() (time.Time, error)
 }
 
 type ReaderConfig struct {
@@ -58,6 +60,14 @@ func (br baseReader) FileSize() (sz int64, err error) {
 		sz = -1
 	} else {
 		sz = fi.Size()
+	}
+	return
+}
+
+func (br baseReader) LastModTime() (t time.Time, err error) {
+	var fi os.FileInfo
+	if fi, err = br.f.Stat(); err == nil {
+		t = fi.ModTime()
 	}
 	return
 }

--- a/filewatch/reader_windows.go
+++ b/filewatch/reader_windows.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/gravwell/gravwell/v3/winevent"
 	"github.com/gravwell/gravwell/v3/winevent/wineventlog"
@@ -100,6 +101,14 @@ func (evr *EvtxReader) FileSize() (sz int64, err error) {
 		sz = -1
 	} else {
 		sz = fi.Size()
+	}
+	return
+}
+
+func (evr *EvtxReader) LastModTime() (t time.Time, err error) {
+	var fi os.FileInfo
+	if fi, err = evr.ReaderConfig.Fin.Stat(); err == nil {
+		t = fi.ModTime()
 	}
 	return
 }


### PR DESCRIPTION
This PR is working on all the weird event ordering and overlapping stuff.