### PR TITLE
Conditionally encode entry data with base64 instead of always.

### DIFF
--- a/client/types/render.go
+++ b/client/types/render.go
@@ -476,6 +476,20 @@ func (ee emptyEntries) MarshalJSON() ([]byte, error) {
 	return json.Marshal(([]SearchEntry)(ee))
 }
 
+type emptyPrintableEntries []SearchEntry
+
+func (ee emptyPrintableEntries) MarshalJSON() ([]byte, error) {
+	if len(ee) == 0 {
+		return emptyList, nil
+	}
+
+	var pse []PrintableSearchEntry
+	for _, v := range ([]SearchEntry)(ee) {
+		pse = append(pse, PrintableSearchEntry(v))
+	}
+	return json.Marshal(pse)
+}
+
 type emptyIngesterStats []IngesterStats
 
 func (eis emptyIngesterStats) MarshalJSON() ([]byte, error) {
@@ -530,6 +544,15 @@ func (is IngestStats) MarshalJSON() ([]byte, error) {
 
 func (rr RawResponse) MarshalJSON() ([]byte, error) {
 	type alias RawResponse
+	if rr.printableData {
+		return json.Marshal(&struct {
+			alias
+			Entries emptyPrintableEntries
+		}{
+			alias:   alias(rr),
+			Entries: emptyPrintableEntries(rr.Entries),
+		})
+	}
 	return json.Marshal(&struct {
 		alias
 		Entries emptyEntries

--- a/client/types/searchentry.go
+++ b/client/types/searchentry.go
@@ -10,6 +10,7 @@ package types
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net"
 	"time"
@@ -25,6 +26,8 @@ type StringTagEntry struct {
 	Data       []byte
 	Enumerated []EnumeratedPair
 }
+
+type PrintableSearchEntry SearchEntry
 
 // Search entry is the entry that makes it out of the search pipeline.
 type SearchEntry struct {
@@ -45,6 +48,22 @@ type EnumeratedPair struct {
 type RawEnumeratedValue struct {
 	Type uint16
 	Data []byte
+}
+
+func (p PrintableSearchEntry) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		TS         entry.Timestamp
+		SRC        net.IP
+		Tag        entry.EntryTag
+		Data       string
+		Enumerated []EnumeratedPair
+	}{
+		TS:         p.TS,
+		SRC:        p.SRC,
+		Tag:        p.Tag,
+		Data:       string(p.Data),
+		Enumerated: p.Enumerated,
+	})
 }
 
 // Return the string representation of an enumerated value in a SearchEntry.

--- a/client/types/text.go
+++ b/client/types/text.go
@@ -27,6 +27,11 @@ type RawResponse struct {
 	ContainsBinaryEntries bool            //just a flag to tell the GUI that we might have data that needs some help
 	Entries               []SearchEntry   `json:",omitempty"`
 	Explore               []ExploreResult `json:",omitempty"`
+	printableData         bool            // true if the search entries have printable DATA fields.
+}
+
+func (r *RawResponse) SetPrintableData(b bool) {
+	r.printableData = b
 }
 
 type RawRequest struct {


### PR DESCRIPTION
Updates gravwell/backend-issues#5692
