### PR TITLE
fix client to no wipe out enumerated values on ingest, covers issue #1278

### DIFF
--- a/client/ingest.go
+++ b/client/ingest.go
@@ -32,10 +32,8 @@ func (c *Client) TestIngest() (err error) {
 func (c *Client) IngestEntries(entries []types.StringTagEntry) error {
 	// IngestEntries now just wraps ingest, because that's a more advanced API
 	// and doesn't have memory restrictions
-	var empty []types.EnumeratedPair
 	cb := func(wtr io.Writer) error {
 		for _, e := range entries {
-			e.Enumerated = empty
 			if b, err := json.Marshal(e); err != nil {
 				return err
 			} else {


### PR DESCRIPTION
We were intentionally removing EVs on IngestEntries, no idea why, these are used all over, they should be kept.


This PR addresses https://github.com/gravwell/gravwell/issues/1278