### PR TITLE
Update RemoteAIService description

### DIFF
--- a/client/types/cbac.go
+++ b/client/types/cbac.go
@@ -793,7 +793,7 @@ func (c Capability) Description() string {
 	case AlertWrite:
 		return `User can create, update, and delete alerts`
 	case RemoteAIService:
-		return `User can submit request to the remote AI service APIs`
+		return `User can submit requests to the remote AI service APIs`
 	}
 	return `UNKNOWN`
 }


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses no issue. 
Very minor change. Singular should be "a request" or plural should be "requests."
Changed description to "User can submit requests to the remote AI service APIs"

Noticed this language could use correction when Wisely posted a screenshot with the CBAC table working in mattermost: 
https://mm.gravwell.io/gravwell/pl/pooymu6aupg43msafmkzsrq1zh