### PR TITLE
Add AIRemoteProcessor field

### DIFF
--- a/client/types/host.go
+++ b/client/types/host.go
@@ -74,11 +74,12 @@ type HostSysStats struct {
 }
 
 type DeploymentInfo struct {
-	Distributed     bool //distributed webservers, meaning more than one
-	CBACEnabled     bool //whether CBAC is enabled on the system
-	DefaultLanguage string
-	AIEnabled       bool // is the AI system available at all
-	AIIsRemote      bool // AI requests will be serviced by a remote system
+	Distributed       bool //distributed webservers, meaning more than one
+	CBACEnabled       bool //whether CBAC is enabled on the system
+	DefaultLanguage   string
+	AIEnabled         bool   // is the AI system available at all
+	AIIsRemote        bool   // AI requests will be serviced by a remote system
+	AIRemoteProcessor string // URL of system that services AI requests
 }
 
 func (si SysInfo) Empty() bool {


### PR DESCRIPTION
This PR addresses no issue.

This PR proposes adding `AIRemoteProcessor` as a field on `DeploymentInfo`. 