### PR TITLE
Tag rollover control

### DIFF
--- a/ingest/entry/defaults.go
+++ b/ingest/entry/defaults.go
@@ -11,6 +11,7 @@ package entry
 const (
 	DefaultTagId  EntryTag = 0
 	GravwellTagId EntryTag = 0xFFFF
+	MaxTagId      EntryTag = 0xFFFF
 
 	MaxDataSize   uint32 = 0x3FFFFFFF
 	MaxSliceCount uint32 = 0x3FFFFFFF

--- a/ingest/entry/enumeratedblock.go
+++ b/ingest/entry/enumeratedblock.go
@@ -253,6 +253,10 @@ func (eb EVBlock) EncodeBuffer(bts []byte) (r int, err error) {
 // EncodeWriter encodes an evblock directly into a writer
 // and returns the number of bytes consumed and a potential error.
 func (eb EVBlock) EncodeWriter(w io.Writer) (r int, err error) {
+	// do nothing if there is nothing to be done
+	if !eb.Populated() {
+		return
+	}
 	// check if its valid
 	if err = eb.Valid(); err != nil {
 		return

--- a/ingest/entry/enumeratedblock_test.go
+++ b/ingest/entry/enumeratedblock_test.go
@@ -142,9 +142,15 @@ func TestEnumeratedValueBlockEmptyAdd(t *testing.T) {
 		t.Fatal("encoded an empty evb to non-empty buff")
 	}
 	buff := make([]byte, 1024)
+	bb := bytes.NewBuffer(nil)
 	if n, err := evb.EncodeBuffer(buff); err != nil {
 		t.Fatal(err)
 	} else if n != 0 {
 		t.Fatalf("EncodeBuffer returned something on empty evb: %d != 0", n)
+	} else if n, err = evb.EncodeWriter(bb); err != nil {
+		t.Fatal(err)
+	} else if n != 0 || bb.Len() > 0 {
+		t.Fatalf("EncodeBuffer returned something on empty evb: %d/%d != 0", n, bb.Len())
 	}
+
 }

--- a/ingest/ingestConnection.go
+++ b/ingest/ingestConnection.go
@@ -162,6 +162,10 @@ func (igst *IngestConnection) NegotiateTag(name string) (tg entry.EntryTag, err 
 	if ok {
 		return tg, nil
 	}
+	if len(igst.tags) >= int(entry.MaxTagId) {
+		err = ErrTooManyTags
+		return
+	}
 
 	if !igst.running {
 		err = ErrNotRunning

--- a/ingest/simple.go
+++ b/ingest/simple.go
@@ -83,6 +83,9 @@ func InitializeConnection(dst, authString string, tags []string, pubKey, privKey
 }
 
 func initConnection(tgt Target, tags []string, pubKey, privKey string, verifyRemoteKey bool) (*IngestConnection, error) {
+	if len(tags) > int(entry.MaxTagId) {
+		return nil, ErrTooManyTags
+	}
 	auth, err := GenAuthHash(tgt.Secret)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR adds some controls in negotiating tags at the ingest layer so that ingesters can fail faster when when trying to negotiate too many tags.


Before the remote side is tracking and will reject too many tags, but that can cause buffering and connection bumps.  This will make it so if a plugin or ingester goes haywire the ingest muxer can shut it down before it has to do the whole loop and have a remote federator/indexer reject the tag allocation.

Just a fail faster patch.