### PR TITLE
sync before we close

### DIFF
--- a/ingest/muxer.go
+++ b/ingest/muxer.go
@@ -546,6 +546,7 @@ func (im *IngestMuxer) Start() error {
 func (im *IngestMuxer) Close() error {
 	// Inform the world that we're done.
 	im.Info("Ingester exiting", log.KV("ingester", im.name), log.KV("ingesteruuid", im.uuid))
+	im.Sync(time.Second) // attempt to sync with a fast timeout, we don't really care about errors here
 
 	im.mtx.Lock()
 	if im.state == closed {


### PR DESCRIPTION
its pretty easy to drop data if you don't Sync the ingest muxer before closing, all our ingesters always do a sync then close but other users may not.

If you DO do a proper sync then close then this call adds 10ms to the close call, but thats fine, we stripped out a 500ms delay earlier.