### PR TITLE
muxer and ingest reporting resilience

### DIFF
--- a/ingest/entryWriter.go
+++ b/ingest/entryWriter.go
@@ -10,6 +10,7 @@ package ingest
 
 import (
 	"bufio"
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -45,7 +46,8 @@ const (
 
 	maxThrottleDur time.Duration = 5 * time.Second
 
-	flushTimeout time.Duration = 10 * time.Second
+	flushTimeout        time.Duration = 10 * time.Second
+	negotiateTagTimeout time.Duration = 10 * time.Second
 )
 
 const (
@@ -92,9 +94,15 @@ type EntryWriter struct {
 	id            entrySendID
 	ackTimeout    time.Duration
 	serverVersion uint16
+	ctx           context.Context
 }
 
 func NewEntryWriter(conn net.Conn) (*EntryWriter, error) {
+	//NewEntryWriterEx allows for passing in a good context
+	return newEntryWriterCtx(conn, context.Background())
+}
+
+func newEntryWriterCtx(conn net.Conn, ctx context.Context) (*EntryWriter, error) {
 	if err := setReadBuffer(conn, ACK_WRITER_BUFFER_SIZE); err != nil {
 		return nil, err
 	}
@@ -104,6 +112,7 @@ func NewEntryWriter(conn net.Conn) (*EntryWriter, error) {
 		OutstandingEntryCount: MAX_UNCONFIRMED_COUNT,
 		BufferSize:            WRITE_BUFFER_SIZE,
 		Timeout:               CLOSING_SERVICE_ACK_TIMEOUT,
+		CTX:                   ctx,
 	}
 	if err := ewc.validate(); err != nil {
 		return nil, err
@@ -117,6 +126,7 @@ type EntryReaderWriterConfig struct {
 	BufferSize            int
 	Timeout               time.Duration
 	TagMan                TagManager
+	CTX                   context.Context
 }
 
 func NewEntryWriterEx(cfg EntryReaderWriterConfig) (*EntryWriter, error) {
@@ -125,6 +135,9 @@ func NewEntryWriterEx(cfg EntryReaderWriterConfig) (*EntryWriter, error) {
 		return nil, err
 	}
 	utc := newUnthrottledConn(cfg.Conn)
+	if cfg.CTX == nil {
+		cfg.CTX = context.Background()
+	}
 
 	return &EntryWriter{
 		conn:       utc,
@@ -136,6 +149,7 @@ func NewEntryWriterEx(cfg EntryReaderWriterConfig) (*EntryWriter, error) {
 		buff:       make([]byte, READ_ENTRY_HEADER_SIZE),
 		id:         1,
 		ackTimeout: cfg.Timeout,
+		ctx:        cfg.CTX,
 	}, nil
 }
 
@@ -167,8 +181,9 @@ func (ew *EntryWriter) Close() (err error) {
 	//try to set a deadline on the connection, we are exiting so everything BETTER wrap up within our closeTimeout
 	ew.conn.SetDeadline(time.Now().Add(closeTimeout))
 	defer ew.conn.SetDeadline(nilTime)
-
-	if err = ew.forceAckNoLock(); err == nil {
+	ctx, cf := context.WithTimeout(ew.ctx, closeTimeout)
+	defer cf()
+	if err = ew.forceAckNoLock(ctx); err == nil {
 		if err = ew.conn.SetReadTimeout(ew.ackTimeout); err != nil {
 			err = ew.conn.Close()
 			ew.hot = false
@@ -177,7 +192,7 @@ func (ew *EntryWriter) Close() (err error) {
 		//read acks is a liberal implementation which will pull any available
 		//acks from the read buffer. We don't care if we get an error here
 		//because this is largely used when trying to refire a connection
-		err = ew.readAcks(true)
+		err = ew.readAcks(true, ctx)
 	}
 
 	ew.hot = false
@@ -188,41 +203,15 @@ func (ew *EntryWriter) Close() (err error) {
 func (ew *EntryWriter) ForceAck() error {
 	ew.mtx.Lock()
 	defer ew.mtx.Unlock()
-	return ew.forceAckNoLock()
+	return ew.forceAckNoLock(ew.ctx)
 }
 
-func (ew *EntryWriter) forceAckTimeout(to time.Duration) error {
-	if to <= 0 {
-		//no timeout, just use the regular one
-		return ew.ForceAck()
-	}
-	now := time.Now()
-
-	//setup some timeouts
-	if err := ew.conn.SetWriteTimeout(to); err != nil {
-		return err
-	} else if err := ew.throwAckSync(); err != nil {
-		return err
-	} else if err := ew.conn.ClearWriteTimeout(); err != nil {
-		return err
-	}
-
-	//begin servicing acks with blocking and a read deadline
-	for ew.ecb.Count() > 0 {
-		if time.Since(now) > to {
-			ew.conn.ClearReadTimeout()
-			return ErrTimeout
-		}
-		if err := ew.serviceAcks(true); err != nil {
-			ew.conn.ClearReadTimeout()
-			return err
-		}
-	}
-	if ew.ecb.Count() > 0 {
-		return fmt.Errorf("Failed to confirm %d entries", ew.ecb.Count())
-	}
-	return nil
-
+// forceAckCtx is just like ForceAck but lets us provide a different context
+// this is almost always for managing timeouts and shutdowns
+func (ew *EntryWriter) forceAckCtx(ctx context.Context) error {
+	ew.mtx.Lock()
+	defer ew.mtx.Unlock()
+	return ew.forceAckNoLock(ctx)
 }
 
 func (ew *EntryWriter) outstandingEntries() []*entry.Entry {
@@ -260,13 +249,13 @@ func (ew *EntryWriter) Ping() (err error) {
 // and ACK of all outstanding entries.  This is primarily used when
 // closing the connection to ensure that all the entries actually
 // made it to the ingester. The caller MUST hold the lock
-func (ew *EntryWriter) forceAckNoLock() error {
+func (ew *EntryWriter) forceAckNoLock(ctx context.Context) error {
 	if err := ew.throwAckSync(); err != nil {
 		return err
 	}
 	//begin servicing acks with blocking and a read deadline
-	for ew.ecb.Count() > 0 {
-		if err := ew.serviceAcks(true); err != nil {
+	for ew.ecb.Count() > 0 && ctx.Err() == nil {
+		if err := ew.serviceAcks(true, ctx); err != nil {
 			ew.conn.ClearReadTimeout()
 			return err
 		}
@@ -274,7 +263,7 @@ func (ew *EntryWriter) forceAckNoLock() error {
 	if ew.ecb.Count() > 0 {
 		return fmt.Errorf("Failed to confirm %d entries", ew.ecb.Count())
 	}
-	return nil
+	return ctx.Err() //if everything is fine this will return nil
 }
 
 // Write expects to have exclusive control over the entry and all
@@ -302,7 +291,7 @@ func (ew *EntryWriter) writeFlush(ent *entry.Entry, flush bool) (err error) {
 	}
 
 	//check if any acks can be serviced
-	if err = ew.serviceAcks(blocking); err == nil {
+	if err = ew.serviceAcks(blocking, ew.ctx); err == nil {
 		_, err = ew.writeEntry(ent, flush)
 	}
 
@@ -338,7 +327,7 @@ func (ew *EntryWriter) WriteWithHint(ent *entry.Entry) (bool, error) {
 	}
 
 	//check if any acks can be serviced
-	if err = ew.serviceAcks(blocking); err != nil {
+	if err = ew.serviceAcks(blocking, ew.ctx); err != nil {
 		return false, err
 	}
 	return ew.writeEntry(ent, true)
@@ -363,21 +352,22 @@ func (ew *EntryWriter) WriteBatch(ents [](*entry.Entry)) (int, error) {
 }
 
 func (ew *EntryWriter) writeEntry(ent *entry.Entry, flush bool) (bool, error) {
-	var flushed bool
-	var err error
 	//if our conf buffer is full force an ack service
 	if ew.ecb.Full() {
 		if err := ew.flush(); err != nil {
 			return false, err
 		}
-		if err := ew.serviceAcks(true); err != nil {
+		if err := ew.serviceAcks(true, ew.ctx); err != nil {
 			return false, err
 		}
 	}
 
 	flushed, ackId, err := ew.encodeAndSendEntry(ent, flush)
+	if err != nil {
+		return false, err
+	}
 
-	if err = ew.ecb.Add(&entryConfirmation{ackId, ent}); err != nil {
+	if err := ew.ecb.Add(&entryConfirmation{ackId, ent}); err != nil {
 		return false, err
 	}
 	return flushed, nil
@@ -591,7 +581,7 @@ func (ew *EntryWriter) SendIngesterState(state IngesterState) (err error) {
 	}
 
 	// First attempt to sync
-	err = ew.forceAckNoLock()
+	err = ew.forceAckNoLock(ew.ctx)
 	if err != nil {
 		return
 	}
@@ -681,7 +671,7 @@ func (ew *EntryWriter) SendIngesterAPIVersion() (err error) {
 	}
 
 	// First attempt to sync
-	err = ew.forceAckNoLock()
+	err = ew.forceAckNoLock(ew.ctx)
 	if err != nil {
 		return
 	}
@@ -750,7 +740,7 @@ func (ew *EntryWriter) IdentifyIngester(name string, version string, id string) 
 	}
 
 	// First attempt to sync
-	err = ew.forceAckNoLock()
+	err = ew.forceAckNoLock(ew.ctx)
 	if err != nil {
 		return
 	}
@@ -802,6 +792,7 @@ func (ew *EntryWriter) IdentifyIngester(name string, version string, id string) 
 }
 
 func (ew *EntryWriter) NegotiateTag(name string) (tg entry.EntryTag, err error) {
+	ts := time.Now()
 	if err = CheckTag(name); err != nil {
 		return
 	}
@@ -814,7 +805,7 @@ func (ew *EntryWriter) NegotiateTag(name string) (tg entry.EntryTag, err error) 
 	}
 
 	// First attempt to sync
-	err = ew.forceAckNoLock()
+	err = ew.forceAckNoLock(ew.ctx)
 	if err != nil {
 		return
 	}
@@ -872,6 +863,10 @@ tagCmdLoop:
 			break tagCmdLoop
 		case PONG_MAGIC:
 			// unsolicited, can come whenever
+			if time.Since(ts) > negotiateTagTimeout {
+				err = ErrTimeout
+				break tagCmdLoop
+			}
 		default:
 			err = fmt.Errorf("Unexpected response to tag negotiation request: %#v", ac)
 			break tagCmdLoop
@@ -894,13 +889,13 @@ func (ew *EntryWriter) Ack() error {
 		ew.mtx.Unlock()
 		return nil
 	}
-	err := ew.serviceAcks(true)
+	err := ew.serviceAcks(true, ew.ctx)
 	ew.mtx.Unlock()
 	return err
 }
 
 // serviceAcks MUST be called with the parent holding the mutex
-func (ew *EntryWriter) serviceAcks(blocking bool) error {
+func (ew *EntryWriter) serviceAcks(blocking bool, ctx context.Context) error {
 	//only flush if we are blocking
 	if blocking && ew.bIO.Buffered() > 0 {
 		if err := ew.flush(); err != nil {
@@ -908,13 +903,13 @@ func (ew *EntryWriter) serviceAcks(blocking bool) error {
 		}
 	}
 	//attempt to read acks
-	if err := ew.readAcks(blocking); err != nil {
+	if err := ew.readAcks(blocking, ctx); err != nil {
 		if blocking && isTimeout(err) {
 			//if we attempted to read and we are full, force a sync, something is wrong
 			if err := ew.throwAckSync(); err != nil {
 				return err
 			}
-			return ew.readAcks(true)
+			return ew.readAcks(true, ctx)
 		}
 		return err
 	}
@@ -923,13 +918,13 @@ func (ew *EntryWriter) serviceAcks(blocking bool) error {
 		if err := ew.throwAckSync(); err != nil {
 			return err
 		}
-		return ew.readAcks(true)
+		return ew.readAcks(true, ctx)
 	}
 	return nil
 }
 
 // readAcks pulls out all of the acks in the ackBuffer and services them
-func (ew *EntryWriter) readAcks(blocking bool) (err error) {
+func (ew *EntryWriter) readAcks(blocking bool, ctx context.Context) (err error) {
 	var ac ackCommand
 	var ok bool
 	var dur time.Duration
@@ -971,9 +966,19 @@ loop:
 				break loop
 			}
 			blocking = origBlock
+			//check on our context, always let at least one cycle go through
+			if err = ctx.Err(); err != nil {
+				fmt.Println("CTX CLOSED", err)
+				break loop
+			}
 		case PONG_MAGIC:
 			// try again
 			blocking = origBlock
+			//check on our context, always let at least one cycle go through
+			if err = ctx.Err(); err != nil {
+				fmt.Println("CTX CLOSED", err)
+				break loop
+			}
 		}
 	}
 	if err == nil {

--- a/ingest/ingestConnection.go
+++ b/ingest/ingestConnection.go
@@ -71,6 +71,20 @@ func (igst *IngestConnection) Close() error {
 	return igst.ew.Close()
 }
 
+func (igst *IngestConnection) closeTimeout(to time.Duration) error {
+	if to <= 0 {
+		//if someone alls this without a valid timeout, just use the exported one
+		return igst.Close()
+	}
+	igst.mtx.Lock()
+	defer igst.mtx.Unlock()
+	if !igst.running {
+		return errors.New("Already closed")
+	}
+	igst.running = false
+	return igst.ew.closeTimeout(to)
+}
+
 func (igst *IngestConnection) IdentifyIngester(name, version, id string) (err error) {
 	igst.mtx.RLock()
 	defer igst.mtx.RUnlock()

--- a/ingest/muxer.go
+++ b/ingest/muxer.go
@@ -945,9 +945,8 @@ loop:
 			if err == nil {
 				good++
 			} else {
-				if lastErr == nil {
-					lastErr = err
-				}
+				//this will merge errors and even return nil if we need to
+				lastErr = mergeError(lastErr, err)
 				down++
 			}
 		case <-tmr.C:
@@ -964,7 +963,7 @@ loop:
 	} else if down == total {
 		return ErrAllConnsDown
 	} else if timeout {
-		// in this case and the lastError case,
+		// if its a timeout, throw the constant timeout error so that the caller can detect it and do the right thing
 		return ErrTimeout
 	}
 	return lastErr

--- a/ingest/simple.go
+++ b/ingest/simple.go
@@ -9,6 +9,7 @@
 package ingest
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"net"
@@ -79,10 +80,10 @@ func InitializeConnection(dst, authString string, tags []string, pubKey, privKey
 		Address: dst,
 		Secret:  authString,
 	}
-	return initConnection(tgt, tags, pubKey, privKey, verifyRemoteKey)
+	return initConnection(tgt, tags, pubKey, privKey, verifyRemoteKey, context.Background())
 }
 
-func initConnection(tgt Target, tags []string, pubKey, privKey string, verifyRemoteKey bool) (*IngestConnection, error) {
+func initConnection(tgt Target, tags []string, pubKey, privKey string, verifyRemoteKey bool, parentCtx context.Context) (*IngestConnection, error) {
 	if len(tags) > int(entry.MaxTagId) {
 		return nil, ErrTooManyTags
 	}
@@ -107,11 +108,11 @@ func initConnection(tgt Target, tags []string, pubKey, privKey string, verifyRem
 		} else if certs == nil {
 			return nil, ErrInvalidCerts
 		}
-		return newTLSConnection(dest, tgt.Tenant, auth, certs, verifyRemoteKey, tags)
+		return newTLSConnection(dest, tgt.Tenant, auth, certs, verifyRemoteKey, tags, parentCtx)
 	case "tcp":
-		return newTCPConnection(dest, tgt.Tenant, auth, tags)
+		return newTCPConnection(dest, tgt.Tenant, auth, tags, parentCtx)
 	case "pipe":
-		return newPipeConnection(dest, tgt.Tenant, auth, tags)
+		return newPipeConnection(dest, tgt.Tenant, auth, tags, parentCtx)
 	default:
 		break
 	}
@@ -193,10 +194,10 @@ func checkTLSPublicKey(local, remote []byte) bool {
 //
 // Deprecated: Use the IngestMuxer instead.
 func NewTLSConnection(dst string, auth AuthHash, certs *TLSCerts, verify bool, tags []string) (*IngestConnection, error) {
-	return newTLSConnection(dst, SystemTenant, auth, certs, verify, tags)
+	return newTLSConnection(dst, SystemTenant, auth, certs, verify, tags, context.Background())
 }
 
-func newTLSConnection(dst, tenant string, auth AuthHash, certs *TLSCerts, verify bool, tags []string) (*IngestConnection, error) {
+func newTLSConnection(dst, tenant string, auth AuthHash, certs *TLSCerts, verify bool, tags []string, ctx context.Context) (*IngestConnection, error) {
 	if err := checkTags(tags); err != nil {
 		return nil, err
 	}
@@ -205,7 +206,7 @@ func newTLSConnection(dst, tenant string, auth AuthHash, certs *TLSCerts, verify
 		return nil, err
 	}
 
-	return completeIngestConnection(conn, src, tenant, auth, tags)
+	return completeIngestConnection(conn, src, tenant, auth, tags, ctx)
 }
 
 // negotiate a TLS connection and check the public cert if requested
@@ -245,10 +246,10 @@ func newTlsConn(dst string, certs *TLSCerts, verify bool) (net.Conn, net.IP, err
 //
 // Deprecated: Use the IngestMuxer instead.
 func NewTCPConnection(dst string, auth AuthHash, tags []string) (*IngestConnection, error) {
-	return newTCPConnection(dst, SystemTenant, auth, tags)
+	return newTCPConnection(dst, SystemTenant, auth, tags, context.Background())
 }
 
-func newTCPConnection(dst, tenant string, auth AuthHash, tags []string) (*IngestConnection, error) {
+func newTCPConnection(dst, tenant string, auth AuthHash, tags []string, ctx context.Context) (*IngestConnection, error) {
 	err := checkTags(tags)
 	if err != nil {
 		return nil, err
@@ -257,7 +258,7 @@ func newTCPConnection(dst, tenant string, auth AuthHash, tags []string) (*Ingest
 	if err != nil {
 		return nil, err
 	}
-	return completeIngestConnection(conn, src, tenant, auth, tags)
+	return completeIngestConnection(conn, src, tenant, auth, tags, ctx)
 }
 
 func newTcpConn(dst string) (net.Conn, net.IP, error) {
@@ -286,10 +287,10 @@ func newTcpConn(dst string) (net.Conn, net.IP, error) {
 //
 // Deprecated: Use the IngestMuxer instead.
 func NewPipeConnection(dst string, auth AuthHash, tags []string) (*IngestConnection, error) {
-	return newPipeConnection(dst, SystemTenant, auth, tags)
+	return newPipeConnection(dst, SystemTenant, auth, tags, context.Background())
 }
 
-func newPipeConnection(dst, tenant string, auth AuthHash, tags []string) (*IngestConnection, error) {
+func newPipeConnection(dst, tenant string, auth AuthHash, tags []string, ctx context.Context) (*IngestConnection, error) {
 	err := checkTags(tags)
 	if err != nil {
 		return nil, err
@@ -298,7 +299,7 @@ func newPipeConnection(dst, tenant string, auth AuthHash, tags []string) (*Inges
 	if err != nil {
 		return nil, err
 	}
-	return completeIngestConnection(conn, src, tenant, auth, tags)
+	return completeIngestConnection(conn, src, tenant, auth, tags, ctx)
 }
 
 func newPipeConn(dst string) (net.Conn, net.IP, error) {
@@ -310,14 +311,14 @@ func newPipeConn(dst string) (net.Conn, net.IP, error) {
 	return conn, localhostAddr, nil
 }
 
-func negotiateEntryWriter(conn net.Conn, tenant string, auth AuthHash, tags []string) (*EntryWriter, map[string]entry.EntryTag, error) {
+func negotiateEntryWriter(conn net.Conn, tenant string, auth AuthHash, tags []string, ctx context.Context) (*EntryWriter, map[string]entry.EntryTag, error) {
 	tagIDs, serverVersion, err := authenticate(conn, tenant, auth, tags)
 	if err != nil {
 		conn.Close()
 		return nil, nil, err
 	}
 
-	ew, err := NewEntryWriter(conn)
+	ew, err := newEntryWriterCtx(conn, ctx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -326,9 +327,9 @@ func negotiateEntryWriter(conn net.Conn, tenant string, auth AuthHash, tags []st
 }
 
 // completeIngestConnection performs the authentication and tag negotiation
-func completeIngestConnection(conn net.Conn, src net.IP, tenant string, auth AuthHash, tags []string) (*IngestConnection, error) {
+func completeIngestConnection(conn net.Conn, src net.IP, tenant string, auth AuthHash, tags []string, ctx context.Context) (*IngestConnection, error) {
 	EnableKeepAlive(conn, defaultKeepAliveInterval)
-	ew, tagIDs, err := negotiateEntryWriter(conn, tenant, auth, tags)
+	ew, tagIDs, err := negotiateEntryWriter(conn, tenant, auth, tags, ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -340,6 +341,7 @@ func completeIngestConnection(conn net.Conn, src net.IP, tenant string, auth Aut
 		tags:    tagIDs,
 		running: true,
 		mtx:     sync.RWMutex{},
+		ctx:     ctx,
 	}
 	return &igst, nil
 }

--- a/ingest/utils.go
+++ b/ingest/utils.go
@@ -13,6 +13,7 @@ import (
 	"crypto/tls"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"math/rand"
 	"net"
 	"strings"
@@ -198,4 +199,19 @@ func tagbitmask(tg entry.EntryTag) (offset int, mask byte) {
 	offset = (int(tg) / 8)
 	mask = byte(1 << (int(tg) % 8))
 	return
+}
+
+func mergeError(ogErr, newErr error) error {
+	if ogErr == newErr {
+		return ogErr //if they are the same error, do not stack
+	} else if ogErr != nil && newErr != nil {
+		//stack the errors in a way that can be unwrapped if needed
+		return fmt.Errorf("%w %w", ogErr, newErr)
+	}
+	//check if one side is nil and if so, just return the other
+	if ogErr != nil && newErr == nil {
+		return ogErr
+	}
+	//incoming error is the first error or og is still nil
+	return newErr
 }


### PR DESCRIPTION
This PR does teh following:

1. Removes the global muxer level ingester state reporting routine
2. Adds some functionality in the individual muxer routines to have individual ingestConnections report state
3. Reduces the frequency of ingester state updates when the only thing changing is ingest rates
4. Adds some timeouts to the ingestConnection close routines so that we can detect and close bad connections
5. Adds a new notification boolean on the ingestConnection routine that can signal to the system that grabs new connections that we think the upstream host is unhealthy and we should backoff and sleep before grabbing a new connection