### PR TITLE
add release of file lock for cache

### DIFF
--- a/chancacher/chancacher.go
+++ b/chancacher/chancacher.go
@@ -418,6 +418,9 @@ func (c *ChanCacher) Commit() {
 	c.cacheW.Sync()
 	c.cacheR.Close()
 	c.cacheW.Close()
+	if c.fileLock != nil {
+		c.fileLock.Unlock()
+	}
 
 	c.cacheCommitted = true
 }

--- a/ingest/entryWriter.go
+++ b/ingest/entryWriter.go
@@ -220,10 +220,19 @@ func (ew *EntryWriter) forceAckCtx(ctx context.Context) error {
 	return ew.forceAckNoLock(ctx)
 }
 
+// outstandingEntries gives you a list of entries that have not been confirmed yet
+// the list IS NOT CLEARED, if you call it over and over you will get them all over and over
 func (ew *EntryWriter) outstandingEntries() []*entry.Entry {
 	ew.mtx.Lock()
 	defer ew.mtx.Unlock()
 	return ew.ecb.outstandingEntries()
+}
+
+// ejectOutstandingEntries is almost identical to outstandingEntries, but it also resets the confirmation buffer
+func (ew *EntryWriter) ejectOutstandingEntries() []*entry.Entry {
+	ew.mtx.Lock()
+	defer ew.mtx.Unlock()
+	return ew.ecb.ejectAll()
 }
 
 func (ew *EntryWriter) throwAckSync() error {

--- a/ingest/ingestConnection.go
+++ b/ingest/ingestConnection.go
@@ -113,6 +113,15 @@ func (igst *IngestConnection) outstandingEntries() []*entry.Entry {
 	return igst.ew.outstandingEntries()
 }
 
+func (igst *IngestConnection) ejectOutstandingEntries() []*entry.Entry {
+	igst.mtx.RLock()
+	defer igst.mtx.RUnlock()
+	if igst.ew == nil {
+		return nil
+	}
+	return igst.ew.ejectOutstandingEntries()
+}
+
 func (igst *IngestConnection) Write(ts entry.Timestamp, tag entry.EntryTag, data []byte) error {
 	return igst.WriteEntry(&entry.Entry{TS: ts, SRC: igst.src, Tag: tag, Data: data})
 }


### PR DESCRIPTION
This PR is more work on cleaning up abnormal shutdown and entry recovery in the case of errors.

It does the following:

1. When committing/closing the cache we also release the lock on the file (bug)
2. When grabbing outstanding entries on shutdown or failure we also purge the entryConfBuffer
3. Added a new ejectOutstandingEntries() call to ingestConnections and buffers and stuff