### PR TITLE
Crank up the exit sync on production ingesters now that the timeout is more strictly respected

### DIFF
--- a/ingest/entryWriter.go
+++ b/ingest/entryWriter.go
@@ -269,7 +269,10 @@ func (ew *EntryWriter) forceAckNoLock(ctx context.Context) error {
 		return err
 	}
 	//begin servicing acks with blocking and a read deadline
-	for ew.ecb.Count() > 0 && ctx.Err() == nil {
+	for ew.ecb.Count() > 0 {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if err := ew.serviceAcks(true, ctx); err != nil {
 			ew.conn.ClearReadTimeout()
 			return err

--- a/ingesters/HttpIngester/main.go
+++ b/ingesters/HttpIngester/main.go
@@ -238,7 +238,7 @@ func main() {
 			}
 		}
 	}
-	if err := igst.Sync(time.Second); err != nil {
+	if err := igst.Sync(utils.ExitSyncTimeout); err != nil {
 		lg.Error("failed to sync muxer on close", log.KVErr(err))
 	}
 	if err := igst.Close(); err != nil {

--- a/ingesters/IPMIIngester/main.go
+++ b/ingesters/IPMIIngester/main.go
@@ -155,7 +155,7 @@ func main() {
 	cancel()
 
 	lg.Info("IPMI ingester exiting", log.KV("ingesteruuid", id))
-	if err := igst.Sync(time.Second); err != nil {
+	if err := igst.Sync(utils.ExitSyncTimeout); err != nil {
 		lg.Error("failed to sync", log.KVErr(err))
 	}
 	if err := igst.Close(); err != nil {

--- a/ingesters/PacketFleet/main.go
+++ b/ingesters/PacketFleet/main.go
@@ -23,7 +23,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	// Embed tzdata so that we don't rely on potentially broken timezone DBs on the host
 	_ "time/tzdata"
@@ -222,7 +221,7 @@ func main() {
 
 	cancel()
 
-	if err := igst.Sync(time.Second); err != nil {
+	if err := igst.Sync(utils.ExitSyncTimeout); err != nil {
 		lg.Error("failed to sync", log.KVErr(err))
 	}
 	if err := igst.Close(); err != nil {

--- a/ingesters/SimpleRelay/main.go
+++ b/ingesters/SimpleRelay/main.go
@@ -139,7 +139,7 @@ func main() {
 	if err := flshr.Close(); err != nil {
 		lg.Error("failed to close preprocessors", log.KVErr(err))
 	}
-	if err := igst.Sync(time.Second); err != nil {
+	if err := igst.Sync(utils.ExitSyncTimeout); err != nil {
 		lg.Error("failed to sync", log.KVErr(err))
 	}
 	if err := igst.Close(); err != nil {

--- a/ingesters/collectd/main.go
+++ b/ingesters/collectd/main.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"os"
 	"sync"
-	"time"
 
 	// Embed tzdata so that we don't rely on potentially broken timezone DBs on the host
 	_ "time/tzdata"
@@ -143,7 +142,7 @@ func main() {
 	}
 
 	lg.Info("collectd ingester exiting", log.KV("ingesteruuid", id))
-	if err := igst.Sync(time.Second); err != nil {
+	if err := igst.Sync(utils.ExitSyncTimeout); err != nil {
 		lg.Error("failed to sync", log.KVErr(err))
 	}
 	if err := igst.Close(); err != nil {

--- a/ingesters/diskmonitor/main.go
+++ b/ingesters/diskmonitor/main.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/gravwell/gravwell/v3/ingest"
 	"github.com/gravwell/gravwell/v3/ingest/entry"
+	"github.com/gravwell/gravwell/v3/ingesters/utils"
 	"github.com/gravwell/gravwell/v3/ingesters/version"
 
 	gravwelldebug "github.com/gravwell/gravwell/v3/debug"
@@ -187,7 +188,7 @@ func main() {
 		}
 
 	}
-	if err := igst.Sync(time.Second); err != nil {
+	if err := igst.Sync(utils.ExitSyncTimeout); err != nil {
 		fmt.Println("Failed to sync", err)
 	}
 

--- a/ingesters/fileFollow/main_unix.go
+++ b/ingesters/fileFollow/main_unix.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"time"
 
 	"github.com/gravwell/gravwell/v3/debug"
 	"github.com/gravwell/gravwell/v3/filewatch"
@@ -213,7 +212,7 @@ func main() {
 
 	//wait for our ingest relay to exit
 	lg.Info("filefollower ingester exiting", log.KV("ingesteruuid", id))
-	if err := igst.Sync(time.Second); err != nil {
+	if err := igst.Sync(utils.ExitSyncTimeout); err != nil {
 		lg.Error("failed to sync", log.KVErr(err))
 	}
 	if err := igst.Close(); err != nil {

--- a/ingesters/fileFollow/processing_windows.go
+++ b/ingesters/fileFollow/processing_windows.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gravwell/gravwell/v3/ingest"
 	"github.com/gravwell/gravwell/v3/ingest/config"
 	"github.com/gravwell/gravwell/v3/ingest/processors"
+	"github.com/gravwell/gravwell/v3/ingesters/utils"
 	"github.com/gravwell/gravwell/v3/ingesters/version"
 )
 
@@ -132,7 +133,7 @@ func (m *mainService) shutdown() error {
 				}
 			}
 		}
-		if err := m.igst.Sync(time.Second); err != nil {
+		if err := m.igst.Sync(utils.ExitSyncTimeout); err != nil {
 			rerr = fmt.Errorf("Failed to sync the ingest muxer: %v", err)
 			errorout("%s", rerr)
 		} else {

--- a/ingesters/kafka_consumer/main.go
+++ b/ingesters/kafka_consumer/main.go
@@ -11,7 +11,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"time"
 
 	// Embed tzdata so that we don't rely on potentially broken timezone DBs on the host
 	_ "time/tzdata"
@@ -130,7 +129,7 @@ func main() {
 	}
 
 	lg.Info("kafka_consumer ingester exiting", log.KV("ingesteruuid", id))
-	if err := igst.Sync(time.Second); err != nil {
+	if err := igst.Sync(utils.ExitSyncTimeout); err != nil {
 		lg.Error("failed to sync", log.KVErr(err))
 	}
 	if err := igst.Close(); err != nil {

--- a/ingesters/massFile/main.go
+++ b/ingesters/massFile/main.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gravwell/gravwell/v3/ingest"
 	"github.com/gravwell/gravwell/v3/ingest/entry"
+	"github.com/gravwell/gravwell/v3/ingesters/utils"
 	"github.com/gravwell/gravwell/v3/ingesters/version"
 	"github.com/shirou/gopsutil/mem"
 
@@ -230,7 +231,7 @@ func main() {
 		}
 	}
 	if iv != nil {
-		if err := iv.m.Sync(time.Second); err != nil {
+		if err := iv.m.Sync(utils.ExitSyncTimeout); err != nil {
 			fmt.Printf("ERROR: Failed to sync ingester: %v\n", err)
 			os.Exit(-1)
 		}

--- a/ingesters/netflow/main.go
+++ b/ingesters/netflow/main.go
@@ -173,7 +173,7 @@ func main() {
 	exitFn()
 
 	lg.Info("netflow ingester exiting", log.KV("ingesteruuid", id))
-	if err := igst.Sync(time.Second); err != nil {
+	if err := igst.Sync(utils.ExitSyncTimeout); err != nil {
 		lg.Error("failed to sync", log.KVErr(err))
 	}
 	if err := igst.Close(); err != nil {

--- a/ingesters/networkLog/main.go
+++ b/ingesters/networkLog/main.go
@@ -196,7 +196,7 @@ func main() {
 
 	exitFn()
 
-	if err = igst.Sync(time.Second); err != nil {
+	if err := igst.Sync(utils.ExitSyncTimeout); err != nil {
 		lg.Error("failed to sync", log.KVErr(err))
 	}
 	if err = igst.Close(); err != nil {

--- a/ingesters/pcapFileIngester/main.go
+++ b/ingesters/pcapFileIngester/main.go
@@ -147,7 +147,7 @@ func main() {
 			fmt.Println("failed to Simulate packet read", err)
 		}
 	}
-	if err := igst.Sync(10 * time.Second); err != nil {
+	if err := igst.Sync(utils.ExitSyncTimeout); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to sync: %v\n", err)
 	}
 	if err := igst.Close(); err != nil {

--- a/ingesters/reddit_ingester/ingest.go
+++ b/ingesters/reddit_ingester/ingest.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/gravwell/gravwell/v3/ingest"
 	"github.com/gravwell/gravwell/v3/ingest/entry"
+	"github.com/gravwell/gravwell/v3/ingesters/utils"
 	"github.com/gravwell/gravwell/v3/ingesters/version"
 )
 
@@ -114,7 +115,7 @@ func NewIngestWriter() (iw *ingestWriter, err error) {
 }
 
 func (iw *ingestWriter) Close() error {
-	if err := iw.igst.Sync(time.Second); err != nil {
+	if err := iw.igst.Sync(utils.ExitSyncTimeout); err != nil {
 		return err
 	}
 	if err := iw.igst.Close(); err != nil {

--- a/ingesters/s3Ingester/main.go
+++ b/ingesters/s3Ingester/main.go
@@ -187,7 +187,7 @@ func main() {
 	// wait for graceful shutdown
 	wg.Wait()
 
-	if err := igst.Sync(time.Second); err != nil {
+	if err := igst.Sync(utils.ExitSyncTimeout); err != nil {
 		ib.Logger.Error("failed to sync", log.KVErr(err))
 	}
 	if err := igst.Close(); err != nil {

--- a/ingesters/session/main.go
+++ b/ingesters/session/main.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gravwell/gravwell/v3/ingest"
 	"github.com/gravwell/gravwell/v3/ingest/entry"
+	"github.com/gravwell/gravwell/v3/ingesters/utils"
 	"github.com/gravwell/gravwell/v3/ingesters/version"
 
 	gravwelldebug "github.com/gravwell/gravwell/v3/debug"
@@ -222,7 +223,7 @@ mainLoop:
 	}
 	//wait for our ingest relay to exit
 	<-doneChan
-	if err := igst.Sync(time.Second); err != nil {
+	if err := igst.Sync(utils.ExitSyncTimeout); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to sync: %v\n", err)
 	}
 	igst.Close()

--- a/ingesters/snmp/main.go
+++ b/ingesters/snmp/main.go
@@ -198,7 +198,7 @@ func main() {
 	// wait for graceful shutdown
 	wg.Wait()
 
-	if err := igst.Sync(time.Second); err != nil {
+	if err := igst.Sync(utils.ExitSyncTimeout); err != nil {
 		ib.Logger.Error("failed to sync", log.KVErr(err))
 	}
 	if err := igst.Close(); err != nil {

--- a/ingesters/sqsIngester/main.go
+++ b/ingesters/sqsIngester/main.go
@@ -170,7 +170,7 @@ func main() {
 	close(done)
 	wg.Wait()
 
-	if err := igst.Sync(time.Second); err != nil {
+	if err := igst.Sync(utils.ExitSyncTimeout); err != nil {
 		lg.Error("failed to sync", log.KVErr(err))
 	}
 	if err := igst.Close(); err != nil {

--- a/ingesters/utils/runtime.go
+++ b/ingesters/utils/runtime.go
@@ -11,6 +11,11 @@ package utils
 import (
 	"os"
 	"runtime"
+	"time"
+)
+
+const (
+	ExitSyncTimeout = 10 * time.Second
 )
 
 // this will set the GOMAXPROC value ONLY if the environment variable hasn't been set to a valid integer


### PR DESCRIPTION
This PR addresses no specific issue