### PR TITLE
HTTP ingester more defense mechanisms

### DIFF
--- a/ingest/config/env.go
+++ b/ingest/config/env.go
@@ -226,8 +226,10 @@ func loadEnvVarBool(cnd *bool, envName string, defVal bool) (err error) {
 		err = ErrInvalidArg
 		return
 	} else if *cnd {
+		//boolean is already set, exit
 		return
 	} else if len(envName) == 0 {
+		//no environment variable, exit
 		return
 	}
 

--- a/ingesters/HttpIngester/config.go
+++ b/ingesters/HttpIngester/config.go
@@ -30,15 +30,20 @@ const (
 	defaultLogLoc        = `/opt/gravwell/log/gravwell_http_ingester.log`
 
 	defaultMethod = http.MethodPost
+
+	defaultMaxConnections        = 10000
+	defaultMaxConcurrentRequests = 4096
 )
 
 type gbl struct {
 	config.IngestConfig
-	Bind                 string
-	Max_Body             int
-	TLS_Certificate_File string
-	TLS_Key_File         string
-	Health_Check_URL     string
+	Bind                    string
+	Max_Body                int
+	TLS_Certificate_File    string
+	TLS_Key_File            string
+	Health_Check_URL        string
+	Max_Connections         int
+	Max_Concurrent_Requests int
 }
 
 type cfgReadType struct {
@@ -108,6 +113,12 @@ func (c *cfgType) Verify() error {
 	}
 	if err := c.ValidateTLS(); err != nil {
 		return err
+	}
+	if c.Max_Connections == 0 {
+		c.Max_Connections = defaultMaxConnections
+	}
+	if c.Max_Concurrent_Requests == 0 {
+		c.Max_Concurrent_Requests = defaultMaxConcurrentRequests
 	}
 	urls := map[route]string{}
 	if len(c.Listener) == 0 && len(c.HECListener) == 0 && len(c.AFHListener) == 0 {

--- a/ingesters/HttpIngester/handlers.go
+++ b/ingesters/HttpIngester/handlers.go
@@ -18,7 +18,9 @@ import (
 	"net"
 	"net/http"
 	"path"
+	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gravwell/gravwell/v3/ingest"
@@ -32,6 +34,8 @@ import (
 const (
 	//default is 120 seconds
 	keepAliveTimeoutHeader = `timeout=120`
+
+	maxRequestHeadroom = `Max-Concurrent-Request-Headroom`
 )
 
 // note that handleFuncs should read from the reader, not from the Request.Body.
@@ -49,16 +53,18 @@ type routeHandler struct {
 
 type handler struct {
 	sync.RWMutex
-	igst           *ingest.IngestMuxer
-	lgr            *log.Logger
-	reqSI          *utils.StatsItem // per request SI
-	entSI          *utils.StatsItem // per entry SI
-	bytesSI        *utils.StatsItem // bytes SI
-	mp             map[route]routeHandler
-	auth           map[route]authHandler
-	custom         map[route]http.Handler
-	rawLineBreaker string
-	healthCheckURL string
+	igst                  *ingest.IngestMuxer
+	lgr                   *log.Logger
+	reqSI                 *utils.StatsItem // per request SI
+	entSI                 *utils.StatsItem // per entry SI
+	bytesSI               *utils.StatsItem // bytes SI
+	mp                    map[route]routeHandler
+	auth                  map[route]authHandler
+	custom                map[route]http.Handler
+	rawLineBreaker        string
+	healthCheckURL        string
+	maxConcurrentRequests int64
+	activeRequests        int64
 }
 
 func (rh routeHandler) handle(h *handler, w http.ResponseWriter, req *http.Request, rdr io.Reader, ip net.IP) {
@@ -72,22 +78,23 @@ func (rh routeHandler) handle(h *handler, w http.ResponseWriter, req *http.Reque
 	rh.handler(h, rh, w, req, rdr, ip)
 }
 
-func newHandler(igst *ingest.IngestMuxer, lgr *log.Logger, reqSI, entSI, bytesSI *utils.StatsItem) (h *handler, err error) {
+func newHandler(igst *ingest.IngestMuxer, lgr *log.Logger, reqSI, entSI, bytesSI *utils.StatsItem, maxConcurrent int) (h *handler, err error) {
 	if igst == nil {
 		err = errors.New("nil muxer")
 	} else if lgr == nil {
 		err = errors.New("nil logger")
 	} else {
 		h = &handler{
-			RWMutex: sync.RWMutex{},
-			mp:      map[route]routeHandler{},
-			auth:    map[route]authHandler{},
-			custom:  map[route]http.Handler{},
-			igst:    igst,
-			lgr:     lgr,
-			reqSI:   reqSI,
-			entSI:   entSI,
-			bytesSI: bytesSI,
+			RWMutex:               sync.RWMutex{},
+			mp:                    map[route]routeHandler{},
+			auth:                  map[route]authHandler{},
+			custom:                map[route]http.Handler{},
+			igst:                  igst,
+			lgr:                   lgr,
+			reqSI:                 reqSI,
+			entSI:                 entSI,
+			bytesSI:               bytesSI,
+			maxConcurrentRequests: int64(maxConcurrent),
 		}
 	}
 	return
@@ -161,8 +168,43 @@ func drainAndClose(rc io.ReadCloser) {
 	rc.Close()
 }
 
+// optionally add a header telling the client that they are putting a bunch of pressure on the webserver handlers
+// basically if we get close to 50% of maximum we will tack on the header letting them know what they have left
+// if there isn't enough to care about or if the header object isn't populated, we just leave
+// we don't ALWAYS throw the header because under normal circumstances its not with the bandwidth
+func addMaxRequestHeadRoom(max, cur int64, hdr http.Header) {
+	if hdr == nil || cur < (max/2) {
+		// if the header is bad OR we are using less than 50% of the max
+		// don't even waste the bandwidth to send the header value
+		return
+	}
+	avail := max - cur
+	if avail < 0 {
+		avail = 0
+	}
+	hdr.Add(maxRequestHeadroom, strconv.FormatInt(avail, 10))
+}
+
 func (h *handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	h.reqSI.Add(1)
+
+	if h.maxConcurrentRequests > 0 {
+		//increment active requests
+		curr := atomic.AddInt64(&h.activeRequests, 1)
+		defer atomic.AddInt64(&h.activeRequests, -1)
+
+		// add header value letting the client know how many outstanding requests are available
+		addMaxRequestHeadRoom(h.maxConcurrentRequests, curr, rw.Header())
+
+		//check if we are throttling this request because too many are outstanding
+		if curr > h.maxConcurrentRequests {
+			//too many, shut this down now with minimal processing
+			r.Body.Close() // close, we aren't reading this
+			rw.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+	}
+	// we might actually do something with this defer the cleanup
 	defer drainAndClose(r.Body)
 	w := &trackingRW{
 		ResponseWriter: rw,

--- a/ingesters/HttpIngester/main.go
+++ b/ingesters/HttpIngester/main.go
@@ -30,12 +30,16 @@ import (
 	"github.com/gravwell/gravwell/v3/ingesters/utils"
 	"github.com/gravwell/gravwell/v3/ingesters/utils/caps"
 	"github.com/gravwell/gravwell/v3/timegrinder"
+	"golang.org/x/net/netutil"
 )
 
 const (
 	defaultConfigLoc  = `/opt/gravwell/etc/gravwell_http_ingester.conf`
 	defaultConfigDLoc = `/opt/gravwell/etc/gravwell_http_ingester.conf.d`
 	appName           = `httpingester`
+
+	httpServerReadHeaderTimeout = 5 * time.Second
+	httpServerIdleConnTimeout   = 10 * time.Second
 )
 
 var (
@@ -98,7 +102,7 @@ func main() {
 		ib.Logger.FatalCode(0, "failed to get stats item", log.KVErr(err))
 	}
 
-	hnd, err := newHandler(igst, lg, reqSI, entSI, bytesSI)
+	hnd, err := newHandler(igst, lg, reqSI, entSI, bytesSI, cfg.Max_Concurrent_Requests)
 	if err != nil {
 		lg.FatalCode(0, "Failed to create new handler")
 	}
@@ -183,12 +187,13 @@ func main() {
 	srv := &http.Server{
 		Addr:              cfg.Bind,
 		Handler:           hnd,
-		ReadHeaderTimeout: 5 * time.Second,
+		ReadHeaderTimeout: httpServerReadHeaderTimeout,
+		IdleTimeout:       httpServerIdleConnTimeout,
 		ErrorLog:          httpLogger,
 	}
 	srv.SetKeepAlivesEnabled(true)
 	var lst net.Listener
-	if lst, err = newListener(cfg.Bind, ib); err != nil {
+	if lst, err = newListener(cfg.Bind, ib, cfg.Max_Connections); err != nil {
 		lg.Fatalf("failed to bind to %v %v", cfg.Bind, err)
 	}
 	defer lst.Close()
@@ -295,13 +300,19 @@ type instrumentListener struct {
 	lst net.Listener
 }
 
-func newListener(bind string, ib base.IngesterBase) (lst net.Listener, err error) {
+func newListener(bind string, ib base.IngesterBase, maxConn int) (lst net.Listener, err error) {
 	var si *utils.StatsItem
 	var tlst net.Listener
 	if si, err = ib.RegisterStat(`connections`); err != nil {
 		return
 	} else if tlst, err = net.Listen(`tcp`, bind); err != nil {
 		return
+	}
+	if maxConn > 0 {
+		//if maxConn is set, then we wrap our listener in a LimitListener
+		//This will effectively control how many active connections we will service
+		//by throttling Accepts
+		tlst = netutil.LimitListener(tlst, maxConn)
 	}
 	lst = &instrumentListener{
 		s:   si,


### PR DESCRIPTION
This PR addresses no issue.

What it does do:

1. specify a default number of maximum active connections to the HTTP ingester
2. specify a default number of maximum concurrent requests
3. move the health check API up the stack to respond faster with less standup