### PR TITLE
SimpleRelay add stale data flush on RFC TCP streams

### DIFF
--- a/.github/workflows/golang-testing.yml
+++ b/.github/workflows/golang-testing.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.23.5
+        go-version: 1.23.6
         cache: false
 
     - name: Go Tidy

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/Jeffail/gabs/v2 v2.7.0
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/asergeyev/nradix v0.0.0-20170505151046-3872ab85bb56
-	github.com/aws/aws-sdk-go v1.34.0
+	github.com/aws/aws-sdk-go v1.55.6
 	github.com/bmatcuk/doublestar/v4 v4.4.0
 	github.com/brianvoe/gofakeit v3.18.0+incompatible
 	github.com/bxcodec/faker/v3 v3.3.1

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aws/aws-sdk-go v1.34.0 h1:brux2dRrlwCF5JhTL7MUT3WUwo9zfDHZZp3+g3Mvlmo=
 github.com/aws/aws-sdk-go v1.34.0/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk=
+github.com/aws/aws-sdk-go v1.55.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWpi6yML8=

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,6 @@ github.com/asergeyev/nradix v0.0.0-20170505151046-3872ab85bb56 h1:Wi5Tgn8K+jDcBY
 github.com/asergeyev/nradix v0.0.0-20170505151046-3872ab85bb56/go.mod h1:8BhOLuqtSuT5NZtZMwfvEibi09RO3u79uqfHZzfDTR4=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
-github.com/aws/aws-sdk-go v1.34.0 h1:brux2dRrlwCF5JhTL7MUT3WUwo9zfDHZZp3+g3Mvlmo=
-github.com/aws/aws-sdk-go v1.34.0/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk=
 github.com/aws/aws-sdk-go v1.55.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
@@ -155,7 +153,6 @@ github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
-github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/goccy/go-json v0.8.1 h1:4/Wjm0JIJaTDm8K1KcGrLHJoa8EsJ13YWeX+6Kfq6uI=
@@ -254,7 +251,6 @@ github.com/jcmturner/gokrb5/v8 v8.4.4 h1:x1Sv4HaTpepFkXbt2IkL29DXRf8sOfZXo8eRKh6
 github.com/jcmturner/gokrb5/v8 v8.4.4/go.mod h1:1btQEpgT6k+unzCwX1KdWMEwPPkkgBtP+F6aCACiMrs=
 github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZY=
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
-github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
@@ -344,7 +340,6 @@ github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpE
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -414,7 +409,6 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=

--- a/ingesters/SimpleRelay/rfc5424Handlers.go
+++ b/ingesters/SimpleRelay/rfc5424Handlers.go
@@ -16,11 +16,20 @@ import (
 	"net"
 	"os"
 	"regexp"
+	"time"
 
 	"github.com/gravwell/gravwell/v3/ingest/entry"
 	"github.com/gravwell/gravwell/v3/ingest/log"
 	"github.com/gravwell/gravwell/v3/ingest/processors"
 	"github.com/gravwell/gravwell/v3/timegrinder"
+)
+
+const (
+	// the default amount of time we will pump the RFC5424 TCP reader
+	// we have to do this because the last entry read is held until the connection drops
+	// or we get a new entry, so we will periodically pump the reader
+	defaultReaderPumpInterval time.Duration = 5 * time.Second
+	maxDataStaleTime          time.Duration = 10 * time.Second
 )
 
 func rfc5424ConnHandlerTCP(c net.Conn, cfg handlerConfig) {
@@ -74,7 +83,11 @@ func rfc5424ConnHandlerTCP(c net.Conn, cfg handlerConfig) {
 			return
 		}
 	}
-	s := bufio.NewScanner(c)
+	//wrap our connection in a read pumper so that we can force the scanner to wake up periodcally
+	//this lets us detect a message that doesn't have a terminator and has been sitting in the buffer
+	//for a while.  Overall this is a way to enable the SimpleRelay ingster to detect the "last log message" and push it once its been sitting for a while
+	pumper := newReadTimeoutPumper(c, defaultReaderPumpInterval)
+	s := bufio.NewScanner(pumper)
 	s.Buffer(make([]byte, initDataSize), maxDataSize)
 	splitter := func(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		idx, sz := rfc5424StartIndex(data)
@@ -86,8 +99,17 @@ func rfc5424ConnHandlerTCP(c net.Conn, cfg handlerConfig) {
 				//we are oversized, just throw what we have
 				advance = maxRFCSize
 				token = data[0:advance]
+			} else {
+				//ask for more data
+				if len(data) > 0 && pumper.lastRead() > maxDataStaleTime {
+					//throw what we have, its been sitting for a while
+					advance = len(data)
+					token = data
+					return
+				}
+				//asking for more data
 			}
-			return //ask for more data
+			return
 		}
 		if idx > 0 {
 			advance = idx //advance to start the match
@@ -100,8 +122,17 @@ func rfc5424ConnHandlerTCP(c net.Conn, cfg handlerConfig) {
 			if atEOF {
 				token = data
 				err = bufio.ErrFinalToken
+			} else {
+				//ask for more data
+				if len(data) > 0 && pumper.lastRead() > maxDataStaleTime {
+					//throw what we have, its been sitting for a while
+					advance = len(data)
+					token = data
+					return
+				}
+				//asking for more data
 			}
-			return //ask for more data
+			return
 		}
 		advance = sz + idx2
 		token = data[:advance]
@@ -294,4 +325,62 @@ func rfc5424StartIndex(buf []byte) (idx, sz int) {
 	}
 	//if we hit here, its bad
 	return -1, 0
+}
+
+type readTimeoutPumper struct {
+	conn     net.Conn
+	interval time.Duration
+	last     time.Time
+}
+
+func newReadTimeoutPumper(conn net.Conn, interval time.Duration) *readTimeoutPumper {
+	if interval <= 0 {
+		interval = defaultReaderPumpInterval
+	}
+	return &readTimeoutPumper{
+		conn:     conn,
+		interval: interval,
+	}
+}
+
+func (rtp *readTimeoutPumper) lastRead() time.Duration {
+	if rtp.last.IsZero() {
+		return 0
+	}
+	return time.Since(rtp.last)
+}
+
+func (rtp *readTimeoutPumper) Read(buff []byte) (n int, err error) {
+	//set timeout
+	if err = rtp.conn.SetReadDeadline(time.Now().Add(rtp.interval)); err != nil {
+		return
+	}
+	n, err = rtp.conn.Read(buff)
+	if err != nil {
+		// clear timeout not matter what
+		rtp.conn.SetReadDeadline(time.Time{})
+		if isTimeout(err) {
+			//only pump the artificial newline if we read nothing and there is a buffer
+			if n <= 0 && len(buff) > 0 {
+				n = 1
+				buff[0] = 0xA // this will get trimmed off
+			}
+			err = nil // if its just a timeout, clear the error
+		}
+	} else {
+		//clear timeout but set error
+		err = rtp.conn.SetReadDeadline(time.Time{})
+		// got an actual read, so update last timestamp
+		rtp.last = time.Now()
+	}
+	return
+}
+
+func isTimeout(err error) bool {
+	if err == nil {
+		return false
+	} else if nerr, ok := err.(net.Error); ok {
+		return nerr.Timeout()
+	}
+	return false
 }

--- a/ingesters/SimpleRelay/rfc5424Handlers.go
+++ b/ingesters/SimpleRelay/rfc5424Handlers.go
@@ -328,18 +328,18 @@ func rfc5424StartIndex(buf []byte) (idx, sz int) {
 }
 
 type readTimeoutPumper struct {
-	conn     net.Conn
-	interval time.Duration
-	last     time.Time
+	conn    net.Conn
+	timeout time.Duration
+	last    time.Time
 }
 
-func newReadTimeoutPumper(conn net.Conn, interval time.Duration) *readTimeoutPumper {
-	if interval <= 0 {
-		interval = defaultReaderPumpInterval
+func newReadTimeoutPumper(conn net.Conn, timeout time.Duration) *readTimeoutPumper {
+	if timeout <= 0 {
+		timeout = defaultReaderPumpInterval
 	}
 	return &readTimeoutPumper{
-		conn:     conn,
-		interval: interval,
+		conn:    conn,
+		timeout: timeout,
 	}
 }
 
@@ -352,7 +352,7 @@ func (rtp *readTimeoutPumper) lastRead() time.Duration {
 
 func (rtp *readTimeoutPumper) Read(buff []byte) (n int, err error) {
 	//set timeout
-	if err = rtp.conn.SetReadDeadline(time.Now().Add(rtp.interval)); err != nil {
+	if err = rtp.conn.SetReadDeadline(time.Now().Add(rtp.timeout)); err != nil {
 		return
 	}
 	n, err = rtp.conn.Read(buff)


### PR DESCRIPTION
adding ability to force out data on an RFC5424 or RFC3164 stream that doesn't have a follow up header block

This PR addresses no specific issue, but tries to make SimpleRelay detect stale data on a TCP connection that doesn't have a follow up RFC header block.

Might be worth porting into the other RFC reader type and maybe regex reader types too.

I did some limited speed tests using the generator on my workstation and saw no difference whatsoever in syslog throughput.