### PR TITLE
Add special cases to catch ShardInfo too far in the future.

### DIFF
--- a/client/types/encoding_test.go
+++ b/client/types/encoding_test.go
@@ -1,0 +1,39 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestJsonMaxDate(t *testing.T) {
+	si := ShardInfo{
+		Start: time.Date(10001, time.January, 1, 0, 0, 0, 0, time.UTC),
+		End:   time.Date(10001, time.January, 2, 0, 0, 0, 0, time.UTC),
+	}
+	b, err := json.Marshal(si)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var x ShardInfo
+	if err := json.Unmarshal(b, &x); err != nil {
+		t.Fatal(err)
+	} else if x.Start != maxJsonTimestamp || x.End != maxJsonTimestamp {
+		t.Fatalf("Invalid timestamps on future shard: %v, %v", x.Start, x.End)
+	}
+
+	si = ShardInfo{
+		Start: time.Now(),
+		End:   time.Now().Add(1 * time.Hour),
+	}
+	b, err = json.Marshal(si)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(b, &x); err != nil {
+		t.Fatal(err)
+	} else if x.Start.Unix() != si.Start.Unix() || x.End.Unix() != si.End.Unix() {
+		t.Fatalf("Invalid timestamps on current shard: %v != %v, %v != %v", x.Start, si.Start, x.End, si.End)
+	}
+
+}

--- a/client/types/manage.go
+++ b/client/types/manage.go
@@ -16,6 +16,10 @@ import (
 	"github.com/google/uuid"
 )
 
+var (
+	maxJsonTimestamp = time.Date(9999, time.December, 12, 23, 59, 59, 99, time.UTC)
+)
+
 type IndexerRequest struct {
 	DialString string
 
@@ -58,6 +62,12 @@ func (si ShardInfo) MarshalJSON() ([]byte, error) {
 		Size:    si.Size,
 		Stored:  si.Stored,
 		Cold:    si.Cold,
+	}
+	if si.Start.After(maxJsonTimestamp) {
+		x.Start = maxJsonTimestamp
+	}
+	if si.End.After(maxJsonTimestamp) {
+		x.End = maxJsonTimestamp
 	}
 	if !si.RemoteState.isEmpty() {
 		x.RemoteState = &si.RemoteState


### PR DESCRIPTION
encoding/json won't handle years greater than 9999, so define a max timestamp and set the ShardInfo's Start/End fields to that in MarshalJSON if they're too big.

