### PR TITLE
fix up sync timeouts on ingest muxer when a zero value timeout is provided

### DIFF
--- a/generators/gravwellGenerator/main.go
+++ b/generators/gravwellGenerator/main.go
@@ -90,7 +90,7 @@ func main() {
 		log.Println("Connection successful")
 	}
 
-	if err = igst.Sync(10 * time.Second); err != nil {
+	if err = igst.Sync(0); err != nil {
 		log.Println("Failed to sync ingest muxer ", err)
 	}
 	if err = igst.Close(); err != nil {


### PR DESCRIPTION
In the ingest muxer Sync code if a zero value is provided (no timeout) we were not respecting that zero value timeout all the way through all the synchronization mechanisms, so it could often cause instant timeouts rather than No timeout.