### PR TITLE
make HEC health API call WillBlock instead of trying to figure out health by hand

### DIFF
--- a/ingesters/HttpIngester/hec.go
+++ b/ingesters/HttpIngester/hec.go
@@ -438,8 +438,8 @@ func (hh *hecHealth) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 	} else if hh.igst == nil {
 		w.WriteHeader(http.StatusServiceUnavailable)
-	} else if cnt, err := hh.igst.Hot(); err != nil || cnt == 0 {
-		w.WriteHeader(http.StatusServiceUnavailable)
+	} else if hh.igst.WillBlock() {
+		w.WriteHeader(http.StatusInsufficientStorage)
 	}
 }
 


### PR DESCRIPTION
This PR addresses no specific issue, but the HEC health API was not calling WillBlock (which checks cache levels and all that) and was instead just returning based on whether we had upstream ingest connections.