### PR TITLE
enforce time window stuff on more of Kafka consumer and HTTP ingester with HEC

### DIFF
--- a/ingesters/HttpIngester/auth.go
+++ b/ingesters/HttpIngester/auth.go
@@ -349,17 +349,16 @@ func (jah *jwtAuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, ss)
 		jah.lgr.Info("successful login", log.KV("address", getRemoteIP(r)))
 	}
-	return
 }
 
-func (bah *jwtAuthHandler) AuthRequest(r *http.Request) error {
+func (jah *jwtAuthHandler) AuthRequest(r *http.Request) error {
 	ss, err := getJWTToken(r)
 	if err != nil {
 		return err
 	}
 	var claims jwt.StandardClaims
 	//attempt to validate the signed string
-	tok, err := jwt.ParseWithClaims(ss, &claims, bah.secretParser)
+	tok, err := jwt.ParseWithClaims(ss, &claims, jah.secretParser)
 	if err != nil {
 		return err
 	}
@@ -379,12 +378,12 @@ func (bah *jwtAuthHandler) AuthRequest(r *http.Request) error {
 	return nil
 }
 
-func (bah *jwtAuthHandler) secretParser(token *jwt.Token) (interface{}, error) {
+func (jah *jwtAuthHandler) secretParser(token *jwt.Token) (interface{}, error) {
 	// Don't forget to validate the alg is what you expect:
 	if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 		return nil, errors.New("Unexpected signing method")
 	}
-	return []byte(bah.secret), nil
+	return []byte(jah.secret), nil
 }
 
 type cookieAuthHandler struct {
@@ -455,7 +454,6 @@ func (cah *cookieAuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 		Path:    `/`,
 	}
 	http.SetCookie(w, &c)
-	return
 }
 
 func (cah *cookieAuthHandler) AuthRequest(r *http.Request) (err error) {

--- a/ingesters/HttpIngester/config.go
+++ b/ingesters/HttpIngester/config.go
@@ -348,7 +348,7 @@ func (pa *paramAttacher) process(req *http.Request) {
 	if req == nil {
 		pa.exts = nil
 		return
-	} else if pa.active == false {
+	} else if !pa.active {
 		return
 	}
 
@@ -364,7 +364,6 @@ func (pa *paramAttacher) process(req *http.Request) {
 			pa.processSet(v)
 		}
 	}
-	return
 }
 
 func (pa *paramAttacher) processSet(vals url.Values) {

--- a/ingesters/HttpIngester/handlers.go
+++ b/ingesters/HttpIngester/handlers.go
@@ -14,7 +14,6 @@ import (
 	"compress/gzip"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"path"
@@ -419,13 +418,12 @@ func handleMulti(h *handler, cfg routeHandler, w http.ResponseWriter, r *http.Re
 		h.lgr.Warn("failed to handle multiline upload", log.KVErr(err))
 		w.WriteHeader(http.StatusBadRequest)
 	}
-	return
 }
 
 func handleSingle(h *handler, cfg routeHandler, w http.ResponseWriter, r *http.Request, rdr io.Reader, ip net.IP) {
 	//using a limited Reader here makes sense because we are going to be eathing the entire HTTP request body as a single entry
 	lr := io.LimitedReader{R: rdr, N: int64(maxBody + 1)}
-	b, err := ioutil.ReadAll(&lr)
+	b, err := io.ReadAll(&lr)
 	if err != nil && err != io.EOF {
 		h.lgr.Info("got bad request", log.KV("address", ip), log.KVErr(err))
 		w.WriteHeader(http.StatusBadRequest)

--- a/ingesters/HttpIngester/hec.go
+++ b/ingesters/HttpIngester/hec.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gravwell/gravwell/v3/ingest/entry"
 	"github.com/gravwell/gravwell/v3/ingest/log"
 	"github.com/gravwell/gravwell/v3/ingesters/utils"
+	"github.com/gravwell/gravwell/v3/timegrinder"
 )
 
 const (
@@ -52,6 +53,7 @@ type hecHandler struct {
 	rawLineBreaker string
 	maxSize        uint
 	debugPosts     bool
+	timeWindow     timegrinder.TimestampWindow
 }
 
 type hecEvent struct {
@@ -226,7 +228,7 @@ loop:
 					ts = entry.FromStandard(extracted)
 				}
 			} else {
-				ts = entry.FromStandard(time.Time(hev.TS))
+				ts = entry.FromStandard(hh.timeWindow.Override(time.Time(hev.TS)))
 			}
 		}
 
@@ -359,7 +361,7 @@ func (hh *hecHandler) handleRaw(h *handler, cfg routeHandler, w http.ResponseWri
 
 	brdr := bufio.NewReader(rdr)
 	var done bool
-	for done == false {
+	for !done {
 		ln, err := brdr.ReadBytes('\n')
 		if len(ln) > 0 {
 			data += len(ln)
@@ -530,7 +532,7 @@ func (hev hecEvent) empty() bool {
 		return false
 	} else if len(hev.Host) > 0 || len(hev.Source) > 0 || len(hev.Sourcetype) > 0 || len(hev.Index) > 0 {
 		return false
-	} else if time.Time(hev.TS).IsZero() != true {
+	} else if !time.Time(hev.TS).IsZero() {
 		return false
 	}
 	return true

--- a/ingesters/kafka_consumer/config_test.go
+++ b/ingesters/kafka_consumer/config_test.go
@@ -8,36 +8,13 @@
 package main
 
 import (
-	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 )
 
-var (
-	tmpDir string
-)
-
-func TestMain(m *testing.M) {
-	var err error
-	if tmpDir, err = ioutil.TempDir(os.TempDir(), `sr`); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create tempdir %v\n", err)
-		os.Exit(-1)
-	}
-	r := m.Run()
-	if r == 0 {
-		if err = os.RemoveAll(tmpDir); err != nil {
-			r = -2
-		}
-	} else {
-		os.RemoveAll(tmpDir)
-	}
-	os.Exit(r)
-}
-
 func TestBasicConfig(t *testing.T) {
-	fout, err := ioutil.TempFile(tmpDir, `cfg`)
+	fout, err := os.CreateTemp(t.TempDir(), `cfg`)
 	if err != nil {
 		t.Fatal()
 	}
@@ -45,7 +22,7 @@ func TestBasicConfig(t *testing.T) {
 	if n, err := io.WriteString(fout, baseConfig); err != nil {
 		t.Fatal(err)
 	} else if n != len(baseConfig) {
-		t.Fatal(fmt.Sprintf("Failed to write full file: %d != %d", n, len(baseConfig)))
+		t.Fatalf("Failed to write full file: %d != %d", n, len(baseConfig))
 	}
 	cfg, err := GetConfig(fout.Name(), ``)
 	if err != nil {
@@ -60,7 +37,7 @@ func TestBasicConfig(t *testing.T) {
 		t.Fatal("invalid secret")
 	}
 	if len(cfg.Consumers) != 3 {
-		t.Fatal(fmt.Sprintf("invalid listener counts: %d != 7", len(cfg.Consumers)))
+		t.Fatalf("invalid listener counts: %d != 7", len(cfg.Consumers))
 	}
 }
 

--- a/timegrinder/timestampWindow.go
+++ b/timegrinder/timestampWindow.go
@@ -39,3 +39,17 @@ func (w *TimestampWindow) Valid(t time.Time) bool {
 	}
 	return true
 }
+
+// Override takes a timesatmp and returns a potentially overriden timestamp
+// this is a shorthand for if !w.Valid(ts) {return entry.Now()}
+func (w *TimestampWindow) Override(t time.Time) time.Time {
+	if w.Enabled() {
+		now := time.Now()
+		if w.MaxPastDelta != 0 && t.Before(now.Add(-1*w.MaxPastDelta)) {
+			t = now //override to now
+		} else if w.MaxFutureDelta != 0 && t.After(now.Add(w.MaxFutureDelta)) {
+			t = now //override to now
+		}
+	}
+	return t // all good
+}


### PR DESCRIPTION
enforcing time window constrains on kafka consumer and HTTP when not using timegrinder or when using HEC endpoints.  Also cleaning up some staticcheck complaints.


This PR addresses https://github.com/gravwell/gravwell/issues/1416