### PR TITLE
fix some dumb inverted logic and do the syscallN dance correctly

### DIFF
--- a/ingesters/winevents/main.go
+++ b/ingesters/winevents/main.go
@@ -78,15 +78,15 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Failed to get interactive session status: %v\n", err)
 		return
 	}
-	if !isService {
-		lg = log.New(os.Stdout)
-	} else {
+	if isService {
 		e, err := eventlog.Open(serviceName)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to get event log handle: %v\n", err)
 			return
 		}
 		lg = log.NewLevelRelay(levelLogger{elog: e})
+	} else {
+		lg = log.New(os.Stdout)
 	}
 	lg.SetAppname(appName)
 
@@ -117,10 +117,12 @@ func main() {
 		return
 	}
 
-	if !isService {
-		runInteractive(s)
-	} else {
+	if isService {
+		lg.Info("starting as service")
 		runService(s)
+	} else {
+		lg.Info("starting in interactive mode")
+		runInteractive(s)
 	}
 	if err := s.Close(); err != nil {
 		lg.Error("failed to create gravwell service", log.KVErr(err))

--- a/winevent/wineventlog/zsyscall_windows.go
+++ b/winevent/wineventlog/zsyscall_windows.go
@@ -79,7 +79,7 @@ var (
 )
 
 func _EvtOpenLog(session EvtHandle, path *uint16, flags uint32) (handle EvtHandle, err error) {
-	r0, _, e1 := syscall.SyscallN(procEvtOpenLog.Addr(), 3, uintptr(session), uintptr(unsafe.Pointer(path)), uintptr(flags))
+	r0, _, e1 := syscall.SyscallN(procEvtOpenLog.Addr(), uintptr(session), uintptr(unsafe.Pointer(path)), uintptr(flags))
 	handle = EvtHandle(r0)
 	if handle == 0 {
 		if e1 != 0 {
@@ -92,7 +92,7 @@ func _EvtOpenLog(session EvtHandle, path *uint16, flags uint32) (handle EvtHandl
 }
 
 func _EvtGetLogInfo(session EvtHandle, id EvtLogPropertyId, buffsize uint32, buff *byte, used *uint32) (err error) {
-	r0, _, e1 := syscall.SyscallN(procEvtGetLogInfo.Addr(), 5, uintptr(session), uintptr(id), uintptr(buffsize), uintptr(unsafe.Pointer(buff)), uintptr(unsafe.Pointer(used)), 0)
+	r0, _, e1 := syscall.SyscallN(procEvtGetLogInfo.Addr(), uintptr(session), uintptr(id), uintptr(buffsize), uintptr(unsafe.Pointer(buff)), uintptr(unsafe.Pointer(used)))
 	if r0 == 0 {
 		if e1 != 0 {
 			err = errnoErr(e1)
@@ -104,7 +104,7 @@ func _EvtGetLogInfo(session EvtHandle, id EvtLogPropertyId, buffsize uint32, buf
 }
 
 func _EvtOpenChannelConfig(session EvtHandle, path *uint16) (handle EvtHandle, err error) {
-	r0, _, e1 := syscall.SyscallN(procEvtOpenChannelConfig.Addr(), 3, uintptr(session), uintptr(unsafe.Pointer(path)), uintptr(0))
+	r0, _, e1 := syscall.SyscallN(procEvtOpenChannelConfig.Addr(), uintptr(session), uintptr(unsafe.Pointer(path)), uintptr(0))
 	handle = EvtHandle(r0)
 	if handle == 0 {
 		if e1 != 0 {
@@ -117,7 +117,7 @@ func _EvtOpenChannelConfig(session EvtHandle, path *uint16) (handle EvtHandle, e
 }
 
 func _EvtGetChannelConfigProperty(handle EvtHandle, id EvtChannelConfigPropertyId, buffsize uint32, buff *byte, used *uint32) (err error) {
-	r0, _, e1 := syscall.SyscallN(procEvtGetChannelConfigProperty.Addr(), 6, uintptr(handle), uintptr(id), 0, uintptr(buffsize), uintptr(unsafe.Pointer(buff)), uintptr(unsafe.Pointer(used)))
+	r0, _, e1 := syscall.SyscallN(procEvtGetChannelConfigProperty.Addr(), uintptr(handle), uintptr(id), 0, uintptr(buffsize), uintptr(unsafe.Pointer(buff)), uintptr(unsafe.Pointer(used)))
 	if r0 == 0 {
 		if e1 != 0 {
 			err = errnoErr(e1)
@@ -129,7 +129,7 @@ func _EvtGetChannelConfigProperty(handle EvtHandle, id EvtChannelConfigPropertyI
 }
 
 func _EvtQuery(session EvtHandle, path *uint16, query *uint16, flags uint32) (handle EvtHandle, err error) {
-	r0, _, e1 := syscall.SyscallN(procEvtQuery.Addr(), 4, uintptr(session), uintptr(unsafe.Pointer(path)), uintptr(unsafe.Pointer(query)), uintptr(flags), 0, 0)
+	r0, _, e1 := syscall.SyscallN(procEvtQuery.Addr(), uintptr(session), uintptr(unsafe.Pointer(path)), uintptr(unsafe.Pointer(query)), uintptr(flags))
 	handle = EvtHandle(r0)
 	if handle == 0 {
 		if e1 != 0 {
@@ -142,7 +142,7 @@ func _EvtQuery(session EvtHandle, path *uint16, query *uint16, flags uint32) (ha
 }
 
 func _EvtSubscribe(session EvtHandle, signalEvent uintptr, channelPath *uint16, query *uint16, bookmark EvtHandle, context uintptr, callback syscall.Handle, flags EvtSubscribeFlag) (handle EvtHandle, err error) {
-	r0, _, e1 := syscall.SyscallN(procEvtSubscribe.Addr(), 8, uintptr(session), uintptr(signalEvent), uintptr(unsafe.Pointer(channelPath)), uintptr(unsafe.Pointer(query)), uintptr(bookmark), uintptr(context), uintptr(callback), uintptr(flags), 0)
+	r0, _, e1 := syscall.SyscallN(procEvtSubscribe.Addr(), uintptr(session), uintptr(signalEvent), uintptr(unsafe.Pointer(channelPath)), uintptr(unsafe.Pointer(query)), uintptr(bookmark), uintptr(context), uintptr(callback), uintptr(flags))
 	handle = EvtHandle(r0)
 	if handle == 0 {
 		if e1 != 0 {
@@ -155,7 +155,7 @@ func _EvtSubscribe(session EvtHandle, signalEvent uintptr, channelPath *uint16, 
 }
 
 func _EvtCreateBookmark(bookmarkXML *uint16) (handle EvtHandle, err error) {
-	r0, _, e1 := syscall.SyscallN(procEvtCreateBookmark.Addr(), 1, uintptr(unsafe.Pointer(bookmarkXML)), 0, 0)
+	r0, _, e1 := syscall.SyscallN(procEvtCreateBookmark.Addr(), uintptr(unsafe.Pointer(bookmarkXML)))
 	handle = EvtHandle(r0)
 	if handle == 0 {
 		if e1 != 0 {
@@ -168,7 +168,7 @@ func _EvtCreateBookmark(bookmarkXML *uint16) (handle EvtHandle, err error) {
 }
 
 func _EvtUpdateBookmark(bookmark EvtHandle, event EvtHandle) (err error) {
-	r1, _, e1 := syscall.SyscallN(procEvtUpdateBookmark.Addr(), 2, uintptr(bookmark), uintptr(event), 0)
+	r1, _, e1 := syscall.SyscallN(procEvtUpdateBookmark.Addr(), uintptr(bookmark), uintptr(event))
 	if r1 == 0 {
 		if e1 != 0 {
 			err = errnoErr(e1)
@@ -180,7 +180,7 @@ func _EvtUpdateBookmark(bookmark EvtHandle, event EvtHandle) (err error) {
 }
 
 func _EvtCreateRenderContext(ValuePathsCount uint32, valuePaths uintptr, flags EvtRenderContextFlag) (handle EvtHandle, err error) {
-	r0, _, e1 := syscall.SyscallN(procEvtCreateRenderContext.Addr(), 3, uintptr(ValuePathsCount), uintptr(valuePaths), uintptr(flags))
+	r0, _, e1 := syscall.SyscallN(procEvtCreateRenderContext.Addr(), uintptr(ValuePathsCount), uintptr(valuePaths), uintptr(flags))
 	handle = EvtHandle(r0)
 	if handle == 0 {
 		if e1 != 0 {
@@ -193,7 +193,7 @@ func _EvtCreateRenderContext(ValuePathsCount uint32, valuePaths uintptr, flags E
 }
 
 func _EvtRender(context EvtHandle, fragment EvtHandle, flags EvtRenderFlag, bufferSize uint32, buffer *byte, bufferUsed *uint32, propertyCount *uint32) (err error) {
-	r1, _, e1 := syscall.SyscallN(procEvtRender.Addr(), 7, uintptr(context), uintptr(fragment), uintptr(flags), uintptr(bufferSize), uintptr(unsafe.Pointer(buffer)), uintptr(unsafe.Pointer(bufferUsed)), uintptr(unsafe.Pointer(propertyCount)), 0, 0)
+	r1, _, e1 := syscall.SyscallN(procEvtRender.Addr(), uintptr(context), uintptr(fragment), uintptr(flags), uintptr(bufferSize), uintptr(unsafe.Pointer(buffer)), uintptr(unsafe.Pointer(bufferUsed)), uintptr(unsafe.Pointer(propertyCount)))
 	if r1 == 0 {
 		if e1 != 0 {
 			err = errnoErr(e1)
@@ -205,7 +205,7 @@ func _EvtRender(context EvtHandle, fragment EvtHandle, flags EvtRenderFlag, buff
 }
 
 func _EvtClose(object EvtHandle) (err error) {
-	r1, _, e1 := syscall.SyscallN(procEvtClose.Addr(), 1, uintptr(object), 0, 0)
+	r1, _, e1 := syscall.SyscallN(procEvtClose.Addr(), uintptr(object))
 	if r1 == 0 {
 		if e1 != 0 {
 			err = errnoErr(e1)
@@ -217,7 +217,7 @@ func _EvtClose(object EvtHandle) (err error) {
 }
 
 func _EvtSeek(resultSet EvtHandle, position int64, bookmark EvtHandle, timeout uint32, flags uint32) (success bool, err error) {
-	r0, _, e1 := syscall.SyscallN(procEvtSeek.Addr(), 5, uintptr(resultSet), uintptr(position), uintptr(bookmark), uintptr(timeout), uintptr(flags), 0)
+	r0, _, e1 := syscall.SyscallN(procEvtSeek.Addr(), uintptr(resultSet), uintptr(position), uintptr(bookmark), uintptr(timeout), uintptr(flags))
 	success = r0 != 0
 	if !success {
 		if e1 != 0 {
@@ -230,7 +230,7 @@ func _EvtSeek(resultSet EvtHandle, position int64, bookmark EvtHandle, timeout u
 }
 
 func _EvtNext(resultSet EvtHandle, eventArraySize uint32, eventArray *EvtHandle, timeout uint32, flags uint32, numReturned *uint32) (err error) {
-	r1, _, e1 := syscall.SyscallN(procEvtNext.Addr(), 6, uintptr(resultSet), uintptr(eventArraySize), uintptr(unsafe.Pointer(eventArray)), uintptr(timeout), uintptr(flags), uintptr(unsafe.Pointer(numReturned)))
+	r1, _, e1 := syscall.SyscallN(procEvtNext.Addr(), uintptr(resultSet), uintptr(eventArraySize), uintptr(unsafe.Pointer(eventArray)), uintptr(timeout), uintptr(flags), uintptr(unsafe.Pointer(numReturned)))
 	if r1 == 0 {
 		if e1 != 0 {
 			err = errnoErr(e1)
@@ -242,7 +242,7 @@ func _EvtNext(resultSet EvtHandle, eventArraySize uint32, eventArray *EvtHandle,
 }
 
 func _EvtOpenChannelEnum(session EvtHandle, flags uint32) (handle EvtHandle, err error) {
-	r0, _, e1 := syscall.SyscallN(procEvtOpenChannelEnum.Addr(), 2, uintptr(session), uintptr(flags), 0)
+	r0, _, e1 := syscall.SyscallN(procEvtOpenChannelEnum.Addr(), uintptr(session), uintptr(flags))
 	handle = EvtHandle(r0)
 	if handle == 0 {
 		if e1 != 0 {
@@ -255,7 +255,7 @@ func _EvtOpenChannelEnum(session EvtHandle, flags uint32) (handle EvtHandle, err
 }
 
 func _EvtNextChannelPath(channelEnum EvtHandle, channelPathBufferSize uint32, channelPathBuffer *uint16, channelPathBufferUsed *uint32) (err error) {
-	r1, _, e1 := syscall.SyscallN(procEvtNextChannelPath.Addr(), 4, uintptr(channelEnum), uintptr(channelPathBufferSize), uintptr(unsafe.Pointer(channelPathBuffer)), uintptr(unsafe.Pointer(channelPathBufferUsed)), 0, 0)
+	r1, _, e1 := syscall.SyscallN(procEvtNextChannelPath.Addr(), uintptr(channelEnum), uintptr(channelPathBufferSize), uintptr(unsafe.Pointer(channelPathBuffer)), uintptr(unsafe.Pointer(channelPathBufferUsed)))
 	if r1 == 0 {
 		if e1 != 0 {
 			err = errnoErr(e1)
@@ -267,7 +267,7 @@ func _EvtNextChannelPath(channelEnum EvtHandle, channelPathBufferSize uint32, ch
 }
 
 func _EvtFormatMessage(publisherMetadata EvtHandle, event EvtHandle, messageID uint32, valueCount uint32, values uintptr, flags EvtFormatMessageFlag, bufferSize uint32, buffer *byte, bufferUsed *uint32) (err error) {
-	r1, _, e1 := syscall.SyscallN(procEvtFormatMessage.Addr(), 9, uintptr(publisherMetadata), uintptr(event), uintptr(messageID), uintptr(valueCount), uintptr(values), uintptr(flags), uintptr(bufferSize), uintptr(unsafe.Pointer(buffer)), uintptr(unsafe.Pointer(bufferUsed)))
+	r1, _, e1 := syscall.SyscallN(procEvtFormatMessage.Addr(), uintptr(publisherMetadata), uintptr(event), uintptr(messageID), uintptr(valueCount), uintptr(values), uintptr(flags), uintptr(bufferSize), uintptr(unsafe.Pointer(buffer)), uintptr(unsafe.Pointer(bufferUsed)))
 	if r1 == 0 {
 		if e1 != 0 {
 			err = errnoErr(e1)
@@ -279,7 +279,7 @@ func _EvtFormatMessage(publisherMetadata EvtHandle, event EvtHandle, messageID u
 }
 
 func _EvtOpenPublisherMetadata(session EvtHandle, publisherIdentity *uint16, logFilePath *uint16, locale uint32, flags uint32) (handle EvtHandle, err error) {
-	r0, _, e1 := syscall.SyscallN(procEvtOpenPublisherMetadata.Addr(), 5, uintptr(session), uintptr(unsafe.Pointer(publisherIdentity)), uintptr(unsafe.Pointer(logFilePath)), uintptr(locale), uintptr(flags), 0)
+	r0, _, e1 := syscall.SyscallN(procEvtOpenPublisherMetadata.Addr(), uintptr(session), uintptr(unsafe.Pointer(publisherIdentity)), uintptr(unsafe.Pointer(logFilePath)), uintptr(locale), uintptr(flags))
 	handle = EvtHandle(r0)
 	if handle == 0 {
 		if e1 != 0 {
@@ -292,7 +292,7 @@ func _EvtOpenPublisherMetadata(session EvtHandle, publisherIdentity *uint16, log
 }
 
 func _EvtExportLog(session EvtHandle, path *uint16, query *uint16, targetFilePath *uint16, flags uint32) (err error) {
-	r1, _, e1 := syscall.SyscallN(procEvtExportLog.Addr(), 5, uintptr(session), uintptr(unsafe.Pointer(path)), uintptr(unsafe.Pointer(query)), uintptr(unsafe.Pointer(targetFilePath)), uintptr(flags), 0)
+	r1, _, e1 := syscall.SyscallN(procEvtExportLog.Addr(), uintptr(session), uintptr(unsafe.Pointer(path)), uintptr(unsafe.Pointer(query)), uintptr(unsafe.Pointer(targetFilePath)), uintptr(flags))
 	if r1 == 0 {
 		if e1 != 0 {
 			err = errnoErr(e1)
@@ -304,7 +304,7 @@ func _EvtExportLog(session EvtHandle, path *uint16, query *uint16, targetFilePat
 }
 
 func _StringFromGUID2(rguid *syscall.GUID, pStr *uint16, strSize uint32) (err error) {
-	r1, _, e1 := syscall.SyscallN(procStringFromGUID2.Addr(), 3, uintptr(unsafe.Pointer(rguid)), uintptr(unsafe.Pointer(pStr)), uintptr(strSize))
+	r1, _, e1 := syscall.SyscallN(procStringFromGUID2.Addr(), uintptr(unsafe.Pointer(rguid)), uintptr(unsafe.Pointer(pStr)), uintptr(strSize))
 	if r1 == 0 {
 		if e1 != 0 {
 			err = errnoErr(e1)


### PR DESCRIPTION
Fix bad syscall conversions from the deprecated API to the new syscallN interface