### PR TITLE
FEAT(#1138): gwcli: upgrade attach with auto-updates and details pane

### DIFF
--- a/gwcli/mother/builtins.go
+++ b/gwcli/mother/builtins.go
@@ -106,6 +106,7 @@ func pwd(m *Mother, _ []string) tea.Cmd {
 	return tea.Println(m.pwd.UseLine())
 }
 
-func quit(*Mother, []string) tea.Cmd {
+func quit(m *Mother, _ []string) tea.Cmd {
+	m.exiting = true
 	return tea.Sequence(tea.Println("Bye"), tea.Quit)
 }

--- a/gwcli/stylesheet/styles.go
+++ b/gwcli/stylesheet/styles.go
@@ -23,8 +23,10 @@ var (
 
 	// styles useful when displaying multiple, composed models
 	Composable = struct {
-		Unfocused lipgloss.Style
-		Focused   lipgloss.Style
+		Unfocused lipgloss.Style // for a blurred model that could be focused at some point
+		Focused   lipgloss.Style // for a focused model that could be blurred at some point
+		Primary   lipgloss.Style // for a model that does not change focus and is the center of attention
+		Secondary lipgloss.Style // for a model that does not change focus and is related to Primary
 	}{
 		Unfocused: lipgloss.NewStyle().
 			Align(lipgloss.Left, lipgloss.Center).
@@ -33,6 +35,7 @@ var (
 			Align(lipgloss.Left, lipgloss.Center).
 			BorderStyle(lipgloss.NormalBorder()).
 			BorderForeground(AccentColor1),
+		// NOTE(rlandau): the other styles are set in init()
 	}
 	Header1Style   = lipgloss.NewStyle().Foreground(PrimaryColor).Bold(true)
 	Header2Style   = lipgloss.NewStyle().Foreground(SecondaryColor)
@@ -43,3 +46,9 @@ var (
 	IndexStyle   = lipgloss.NewStyle().Foreground(AccentColor1)
 	ExampleStyle = lipgloss.NewStyle().Foreground(AccentColor2)
 )
+
+func init() {
+	Composable.Primary = Composable.Focused.BorderStyle(lipgloss.RoundedBorder())
+	Composable.Secondary = Composable.Focused.BorderStyle(lipgloss.RoundedBorder()).BorderForeground(PrimaryColor)
+
+}

--- a/gwcli/tree/queries/attach/actor.go
+++ b/gwcli/tree/queries/attach/actor.go
@@ -203,10 +203,12 @@ func (a *attach) SetArgs(_ *pflag.FlagSet, tokens []string) (invalid string, _ t
 	// if a sid was not given, prepare a list of queries for the user to select from
 	a.mode = selecting
 
-	cmd, err := a.sv.init()
+	cmd, noAttachables, err := a.sv.init()
 	if err != nil { // check that we actually have data to manipulate
+		return "", nil, err
+	} else if noAttachables {
 		a.mode = quitting
-		return "", tea.Println(err), nil
+		return "", tea.Println("you have no attachable searches"), nil
 	}
 
 	return "", cmd, nil

--- a/gwcli/tree/queries/attach/actor.go
+++ b/gwcli/tree/queries/attach/actor.go
@@ -1,4 +1,21 @@
+/*************************************************************************
+ * Copyright 2025 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
 package attach
+
+/*
+This file contains the action.Model implementation of the attach action, providing interactive usage.
+It passes control down to selecting view, then downloads and passes results to datascope when they are ready.
+
+Attach is some hideous amalgamation of the query actor and edit scaffolding actor.
+
+Fits the tea.Model interface.
+*/
 
 import (
 	"errors"
@@ -13,14 +30,6 @@ import (
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/querysupport"
 	"github.com/spf13/pflag"
 )
-
-/*
-This file contains the action.Model implementation of the attach action, providing interactive usage.
-
-Attach is some hideous amalgamation of the query actor and edit scaffolding actor.
-
-Fits the tea.Model interface.
-*/
 
 const GenericErrorText string = "an error occurred"
 

--- a/gwcli/tree/queries/attach/actor.go
+++ b/gwcli/tree/queries/attach/actor.go
@@ -87,6 +87,7 @@ func (a *attach) Update(msg tea.Msg) tea.Cmd {
 		} else if search != nil { // prepare datascope and hand off control
 			a.mode = displaying
 			a.search = search
+			a.sv.destroy()
 
 			results, tbl, err := querysupport.GetResultsForDataScope(search)
 			if err != nil {
@@ -129,6 +130,7 @@ func (a *attach) Done() bool {
 func (a *attach) Reset() error {
 	a.mode = inactive
 	a.ds = nil
+	a.sv.destroy()
 	a.sv = nil
 	a.flagset = initialLocalFlagSet()
 	if a.search != nil {

--- a/gwcli/tree/queries/attach/actor.go
+++ b/gwcli/tree/queries/attach/actor.go
@@ -66,7 +66,7 @@ type attach struct {
 var Attach action.Model = Initial()
 
 func Initial() *attach {
-	a := &attach{mode: inactive}
+	a := &attach{mode: inactive, flagset: initialLocalFlagSet()}
 
 	return a
 }
@@ -141,8 +141,10 @@ func (a *attach) Done() bool {
 func (a *attach) Reset() error {
 	a.mode = inactive
 	a.ds = nil
-	a.sv.destroy()
-	a.sv = nil
+	if a.sv != nil {
+		a.sv.destroy()
+		a.sv = nil
+	}
 	a.flagset = initialLocalFlagSet()
 	if a.search != nil {
 		a.search.Close()

--- a/gwcli/tree/queries/attach/actor.go
+++ b/gwcli/tree/queries/attach/actor.go
@@ -77,8 +77,10 @@ func (a *attach) Update(msg tea.Msg) tea.Cmd {
 	switch a.mode {
 	case quitting:
 		return nil
-	case inactive: // should not be possible, but if we are, bootstrap ourselves into selecting mode
-	// TODO
+	case inactive: // should not be possible, quit out if it occurs
+		clilog.Writer.Warnf("attach triggered update in inactive mode")
+		a.mode = quitting
+		return tea.Println(GenericErrorText)
 	case displaying: // pass control to datascope
 		if a.ds == nil {
 			clilog.Writer.Errorf("attach cannot be in display mode without a valid datascope")

--- a/gwcli/tree/queries/attach/actor.go
+++ b/gwcli/tree/queries/attach/actor.go
@@ -106,7 +106,8 @@ func (a *attach) Update(msg tea.Msg) tea.Cmd {
 				return tea.Println(err)
 			}
 			var dsCmd tea.Cmd
-			a.ds, dsCmd, err = datascope.NewDataScope(results, true, search, tbl)
+			a.ds, dsCmd, err = datascope.NewDataScope(results, true, search, tbl,
+				datascope.WithAutoDownload(a.flags.OutPath, a.flags.Append, a.flags.JSON, a.flags.CSV))
 			if err != nil {
 				a.mode = quitting
 				return tea.Println(err)

--- a/gwcli/tree/queries/attach/attach.go
+++ b/gwcli/tree/queries/attach/attach.go
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2024 Gravwell, Inc. All rights reserved.
+ * Copyright 2025 Gravwell, Inc. All rights reserved.
  * Contact: <legal@gravwell.io>
  *
  * This software may be modified and distributed under the terms of the
@@ -9,8 +9,10 @@
 // Package attach implements search re-attachment, for fetching backgrounded queries.
 // It bears significant similarities to the load-bearing query action, but is different enough to not be folded in.
 //
-// See gwcli/assets/attach_flow.drawio.svg for a flowchart of user interaction.
+// See gwcli/assets/attach_flow.drawio.svg for a rough flowchart of user interaction.
 package attach
+
+/* This file sets up the action and defines non-interactive use of attach. */
 
 import (
 	"errors"

--- a/gwcli/tree/queries/attach/selecting.go
+++ b/gwcli/tree/queries/attach/selecting.go
@@ -178,19 +178,20 @@ func (sv *selectingView) view() string {
 	sv.listMu.RUnlock()
 
 	// build the right-hand side details panel
-	details := fmt.Sprintf("Query: %v\n\n"+
-		"%v --> %v\n\n"+
-		"%v\n\n"+
-		"Clients: %d",
+	details := fmt.Sprintf("%v\n\n"+
+		stylesheet.Header1Style.Render("Query")+": %v\n"+
+		"\t%v --> %v\n\n"+
+		stylesheet.Header1Style.Render("Clients")+": %d",
+		stylesheet.IndexStyle.Render(a.State.String()),
 		a.UserQuery,
 		a.StartRange.String(), a.EndRange.String(),
-		stylesheet.IndexStyle.Render(a.State.String()),
 		a.AttachedClients)
 
 	// the details are always considered "focus" from a view standpoint
 	details = stylesheet.Composable.Focused.
 		Width((sv.width / 2) - widthBuffer).
 		Height(coerceHeight(sv.height)).
+		PaddingLeft(widthBuffer).AlignHorizontal(lipgloss.Left).
 		Render(details)
 
 	var errSpnrHelp string // displays either the busywait spinner, an error, or help text on how to select
@@ -215,6 +216,7 @@ func (sv *selectingView) view() string {
 
 var _ listsupport.Item = attachable{}
 
+// An attachable is just a wrapper around the SearchCtrlStatus type to allow us to fit it to the Item interface.
 type attachable struct {
 	types.SearchCtrlStatus
 }

--- a/gwcli/tree/queries/attach/selecting.go
+++ b/gwcli/tree/queries/attach/selecting.go
@@ -1,4 +1,16 @@
+/*************************************************************************
+ * Copyright 2025 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
 package attach
+
+/* This file implements the "selecting view" of interactive attach.
+Users are shown a list of attach-able searches and their statuses, can inspect each (a "details" view), and attach to one.
+When a user attaches to a query, selecting view waits on it, only returning control to actor.go once the search is done. */
 
 import (
 	"errors"

--- a/gwcli/tree/queries/attach/selecting.go
+++ b/gwcli/tree/queries/attach/selecting.go
@@ -297,7 +297,7 @@ func composeDetails(a attachable) string {
 	}
 
 	// the details are always considered "focus" from a view standpoint
-	return details.String()
+	return lipgloss.NewStyle().Margin(1, 1, 1, 1).Render(details.String())
 
 }
 

--- a/gwcli/tree/queries/attach/selecting.go
+++ b/gwcli/tree/queries/attach/selecting.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/spinner"
@@ -33,7 +34,8 @@ import (
 )
 
 const (
-	widthBuffer = 1 // extra space to leave on the left and right of EACH element, AFTER halving (as two elements total)
+	widthBuffer          = 1 // extra space to leave on the left and right of EACH element, AFTER halving (as two elements total)
+	updaterSleepDuration = time.Second * 2
 )
 
 type selectingView struct {
@@ -77,6 +79,7 @@ func (sv *selectingView) init() (cmd tea.Cmd, err error) {
 		go func(itmIdx int, a attachable, done <-chan bool) {
 			// update until the search is done or errors
 			for a.State.Status != types.SearchStatusCompleted && a.State.Status != types.SearchStatusError {
+				time.Sleep(updaterSleepDuration)
 				select {
 				case <-done: // check if we are done
 					clilog.Writer.Debugf("updater %d closing up shop", itmIdx)

--- a/gwcli/tree/queries/attach/selecting.go
+++ b/gwcli/tree/queries/attach/selecting.go
@@ -178,34 +178,20 @@ func (sv *selectingView) view() string {
 	sv.listMu.RUnlock()
 
 	// build the right-hand side details panel
-	details := ""
-	details = fmt.Sprintf("Query: %v\n\n"+
+	details := fmt.Sprintf("Query: %v\n\n"+
 		"%v --> %v\n\n"+
-		"%v\n\n",
+		"%v\n\n"+
+		"Clients: %d",
 		a.UserQuery,
 		a.StartRange.String(), a.EndRange.String(),
-		stylesheet.IndexStyle.Render(a.State.String()))
+		stylesheet.IndexStyle.Render(a.State.String()),
+		a.AttachedClients)
 
 	// the details are always considered "focus" from a view standpoint
 	details = stylesheet.Composable.Focused.
 		Width((sv.width / 2) - widthBuffer).
 		Height(coerceHeight(sv.height)).
 		Render(details)
-
-	/*
-		var sb strings.Builder
-
-		sb.WriteString("Started: " + a.LaunchInfo.Started.String())
-		if !a.LaunchInfo.Expires.Equal(time.Time{}) { // if an expire was set, attach it to Started
-			if a.LaunchInfo.Expires.Compare(time.Now()) < 1 { // earlier than or equal to now
-				sb.WriteString(" | Expired: ")
-			} else {
-				sb.WriteString(" | Expires: ")
-			}
-			sb.WriteString(a.LaunchInfo.Expires.String())
-		}
-		sb.WriteString("\n\n")
-	*/
 
 	var errSpnrHelp string // displays either the busywait spinner, an error, or help text on how to select
 	if sv.search != nil {

--- a/gwcli/tree/queries/attach/selecting.go
+++ b/gwcli/tree/queries/attach/selecting.go
@@ -278,34 +278,6 @@ func (sv *selectingView) view() string {
 	}
 	sv.listMu.RUnlock()
 
-	// build the right-hand side details panel
-	var details strings.Builder
-	details.WriteString(fmt.Sprintf("%v\n\n"+
-		stylesheet.Header1Style.Render("Query")+": %v\n"+
-		stylesheet.Header1Style.Render("Range")+": %v --> %v\n\n"+
-		stylesheet.Header1Style.Render("Started")+": %v\n"+
-		stylesheet.Header1Style.Render("Clients")+": %d\n"+
-		stylesheet.Header1Style.Render("Storage")+": %dB",
-		stylesheet.IndexStyle.Render(a.State.String()),
-		a.UserQuery,
-		a.StartRange.String(), a.EndRange.String(),
-		a.LaunchInfo.Started,
-		a.AttachedClients,
-		a.StoredData))
-	if a.NoHistory {
-		details.WriteString("\n" + stylesheet.Header2Style.Render("No History Mode"))
-	}
-	if a.Error != "" {
-		details.WriteString("\nError: " + stylesheet.ErrStyle.Render(a.Error))
-	}
-
-	// the details are always considered "focus" from a view standpoint
-	detailsStr := stylesheet.Composable.Focused.
-		Width((sv.width / 2) - widthBuffer).
-		Height(coerceHeight(sv.height)).
-		PaddingLeft(widthBuffer).AlignHorizontal(lipgloss.Left).
-		Render(details.String())
-
 	var errSpnrHelp string // displays either the busywait spinner, an error, or help text on how to select
 	if sv.search != nil {
 		errSpnrHelp = sv.spnr.View()
@@ -316,7 +288,7 @@ func (sv *selectingView) view() string {
 	}
 
 	return lipgloss.JoinVertical(lipgloss.Center,
-		lipgloss.JoinHorizontal(lipgloss.Center, list, detailsStr),
+		lipgloss.JoinHorizontal(lipgloss.Center, list, viewDetails(a, sv.height, sv.width)),
 		lipgloss.NewStyle().
 			AlignHorizontal(lipgloss.Center).
 			Width(sv.width).
@@ -405,6 +377,38 @@ func coerceHeight(h int) int {
 	const heightBuffer int = 4 // extra space to leave on the top and bottom of the composed elements
 
 	return min(h-heightBuffer, listHeightMax)
+
+}
+
+// viewDetails generates the right-hand side details pane for the given attachable (which should be the currently selected item).
+func viewDetails(a attachable, svHeight, svWidth int) string {
+	// build the right-hand side details panel
+	var details strings.Builder
+	details.WriteString(fmt.Sprintf("%v\n\n"+
+		stylesheet.Header1Style.Render("Query")+": %v\n"+
+		stylesheet.Header1Style.Render("Range")+": %v --> %v\n\n"+
+		stylesheet.Header1Style.Render("Started")+": %v\n"+
+		stylesheet.Header1Style.Render("Clients")+": %d\n"+
+		stylesheet.Header1Style.Render("Storage")+": %dB",
+		stylesheet.IndexStyle.Render(a.State.String()),
+		a.UserQuery,
+		a.StartRange.String(), a.EndRange.String(),
+		a.LaunchInfo.Started,
+		a.AttachedClients,
+		a.StoredData))
+	if a.NoHistory {
+		details.WriteString("\n" + stylesheet.Header2Style.Render("No History Mode"))
+	}
+	if a.Error != "" {
+		details.WriteString("\nError: " + stylesheet.ErrStyle.Render(a.Error))
+	}
+
+	// the details are always considered "focus" from a view standpoint
+	return stylesheet.Composable.Focused.
+		Width((svWidth / 2) - widthBuffer).
+		Height(coerceHeight(svHeight)).
+		PaddingLeft(widthBuffer).AlignHorizontal(lipgloss.Left).
+		Render(details.String())
 
 }
 

--- a/gwcli/tree/queries/attach/shared.go
+++ b/gwcli/tree/queries/attach/shared.go
@@ -1,14 +1,22 @@
+/*************************************************************************
+ * Copyright 2025 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
 package attach
+
+/*
+This file contains subroutines and data used by both interactive and non-interactive usage, typically to enforce consistency.
+*/
 
 import (
 	"fmt"
 
 	ft "github.com/gravwell/gravwell/v4/gwcli/stylesheet/flagtext"
 )
-
-/*
-This file contains subroutines and data used by both interactive and non-interactive usage, typically to enforce consistency.
-*/
 
 // Returns an error string stating that the wrong number of arguments were given.
 // Interactive mode expects 0 or 1, script mode expects exactly 1.


### PR DESCRIPTION
This PR addresses https://github.com/gravwell/gravwell/issues/1138.

This PR is focused on upgrading `attach` after the initial implementation.

The primary two changes are:

1.  Creation of a details view and its composition with the list. the details view is a couple panels containing additional information about the currently selected item in the list. Example screencap (with dummy data):
![image](https://github.com/user-attachments/assets/9a19fa2a-f855-4c35-a944-74b3943e9691)

2. Implementation of a background updater goroutine to keep the list up to date. The updater automatically pings the backend to look for new searches to add to the list or invalid searches to remove from the list. It is also able to update the statuses of existing searches so a user can tell if the search they are about to attach to has completed or if they will have to attach and wait.

>[!NOTE]
>This PR comes with a workaround to a bug in the Bubbles library that makes horizontally composing lists with other elements unreliable. In its current state, we can work around this bug by disabling filtering and explicitly setting help width. The bug is *likely* a combination of faulty handling in how the list Bubble handles width (it doesn't) and how it passes that width to its calculations for determining what help to show (again, it doesn't). There are two PRs ([1](https://github.com/charmbracelet/bubbles/pull/749), [2](https://github.com/charmbracelet/bubbles/pull/760)) to fix the bug (afai can tell, both are necessary for what we are trying to do). 
