### PR TITLE
Add/update Messages fields for various types

### DIFF
--- a/client/types/render.go
+++ b/client/types/render.go
@@ -290,6 +290,7 @@ type StatSet struct {
 	Stats     []SearchModuleStats
 	TS        entry.Timestamp
 	populated bool
+	Messages  []Message
 }
 
 type OverviewStatSet struct {
@@ -539,6 +540,48 @@ func (is IngestStats) MarshalJSON() ([]byte, error) {
 		Ingesters:         emptyIngesterStats(is.Ingesters),
 		Missing:           emptyIngesterStates(is.Missing),
 	})
+}
+
+func (s SearchMetadata) MarshalJSON() ([]byte, error) {
+	type alias SearchMetadata
+	return json.Marshal(&struct {
+		alias
+		Messages emptyMessages
+	}{
+		alias:    alias(s),
+		Messages: emptyMessages(s.Messages),
+	})
+}
+
+func (o OverviewStats) MarshalJSON() ([]byte, error) {
+	type alias OverviewStats
+	return json.Marshal(&struct {
+		alias
+		Messages emptyMessages
+	}{
+		alias:    alias(o),
+		Messages: emptyMessages(o.Messages),
+	})
+}
+
+func (b BaseResponse) MarshalJSON() ([]byte, error) {
+	type alias BaseResponse
+	return json.Marshal(&struct {
+		alias
+		Messages emptyMessages
+	}{
+		alias:    alias(b),
+		Messages: emptyMessages(b.Messages),
+	})
+}
+
+type emptyMessages []Message
+
+func (em emptyMessages) MarshalJSON() ([]byte, error) {
+	if len(em) == 0 {
+		return emptyList, nil
+	}
+	return json.Marshal(([]Message)(em))
 }
 
 func (r RawResponse) MarshalJSON() ([]byte, error) {

--- a/client/types/render.go
+++ b/client/types/render.go
@@ -168,9 +168,9 @@ type BaseResponse struct {
 	Messages []Message
 }
 
-func (br BaseResponse) Err() error {
-	if br.Error != `` {
-		return errors.New(br.Error)
+func (b BaseResponse) Err() error {
+	if b.Error != `` {
+		return errors.New(b.Error)
 	}
 	return nil
 }

--- a/client/types/search.go
+++ b/client/types/search.go
@@ -174,6 +174,9 @@ type LaunchResponse struct {
 	RenderModule string     `json:",omitempty"`
 	RenderCmd    string     `json:",omitempty"`
 	Info         SearchInfo `json:",omitempty"`
+
+	// Errors, warnings, etc.
+	Messages []Message
 }
 
 // StartSearchRequest represents a search that is sent to the search controller
@@ -406,6 +409,17 @@ func CheckMacroName(name string) error {
 		}
 	}
 	return nil
+}
+
+func (l LaunchResponse) MarshalJSON() ([]byte, error) {
+	type alias LaunchResponse
+	return json.Marshal(&struct {
+		alias
+		Messages emptyMessages
+	}{
+		alias:    alias(l),
+		Messages: emptyMessages(l.Messages),
+	})
 }
 
 func (si SearchInfo) MarshalJSON() ([]byte, error) {

--- a/client/types/stats.go
+++ b/client/types/stats.go
@@ -201,10 +201,12 @@ func (ss *StatSet) MarshalJSON() ([]byte, error) {
 	type alias StatSet
 	return json.Marshal(&struct {
 		alias
-		Stats sms
+		Stats    sms
+		Messages emptyMessages
 	}{
-		alias: alias(*ss),
-		Stats: sms(ss.Stats),
+		alias:    alias(*ss),
+		Stats:    sms(ss.Stats),
+		Messages: emptyMessages(ss.Messages),
 	})
 }
 


### PR DESCRIPTION
Updates gravwell/issues#1742

This PR adds the Messages field to some missed types, and updates all types with the Messages field to encode an empty array when no messages are present. 