### PR TITLE
Add new type for searchctrl stats API

### DIFF
--- a/client/types/marshallers_test.go
+++ b/client/types/marshallers_test.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -509,5 +510,38 @@ func TestRawResponseEncode(t *testing.T) {
 	}
 	if len(x.Entries) != 1 {
 		t.Fatal("invalid decode")
+	}
+}
+
+func TestStatSetResponseEncode(t *testing.T) {
+	ssr := StatSetResponse{
+		Stats: []StatSet{
+			{
+				Stats: []SearchModuleStats{
+					{
+						Name: "test",
+						ModuleStatsUpdate: ModuleStatsUpdate{
+							InputCount: 1,
+						},
+					},
+				},
+				TS: entry.Timestamp{
+					Sec: 1,
+				},
+			},
+		},
+		Messages: []Message{
+			{
+				ID: 1,
+			},
+		},
+	}
+	bb := bytes.NewBuffer(nil)
+	if err := json.NewEncoder(bb).Encode(ssr); err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.TrimSpace(bb.String()) != `{"Stats":[{"TS":"0000-12-31T17:00:05-06:59","ModuleStats":[{"InputCount":1,"OutputCount":0,"InputBytes":0,"OutputBytes":0,"Duration":0,"ScratchWritten":0,"Name":"test","Args":""}]}],"Messages":[{"ID":1,"Severity":"","Value":""}]}` {
+		t.Fatal("invalid marshal", bb.String())
 	}
 }

--- a/client/types/marshallers_test.go
+++ b/client/types/marshallers_test.go
@@ -12,7 +12,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"net"
-	"strings"
 	"testing"
 	"time"
 
@@ -510,38 +509,5 @@ func TestRawResponseEncode(t *testing.T) {
 	}
 	if len(x.Entries) != 1 {
 		t.Fatal("invalid decode")
-	}
-}
-
-func TestStatSetResponseEncode(t *testing.T) {
-	ssr := StatSetResponse{
-		Stats: []StatSet{
-			{
-				Stats: []SearchModuleStats{
-					{
-						Name: "test",
-						ModuleStatsUpdate: ModuleStatsUpdate{
-							InputCount: 1,
-						},
-					},
-				},
-				TS: entry.Timestamp{
-					Sec: 1,
-				},
-			},
-		},
-		Messages: []Message{
-			{
-				ID: 1,
-			},
-		},
-	}
-	bb := bytes.NewBuffer(nil)
-	if err := json.NewEncoder(bb).Encode(ssr); err != nil {
-		t.Fatal(err)
-	}
-
-	if strings.TrimSpace(bb.String()) != `{"Stats":[{"TS":"0000-12-31T17:00:05-06:59","ModuleStats":[{"InputCount":1,"OutputCount":0,"InputBytes":0,"OutputBytes":0,"Duration":0,"ScratchWritten":0,"Name":"test","Args":""}]}],"Messages":[{"ID":1,"Severity":"","Value":""}]}` {
-		t.Fatal("invalid marshal", bb.String())
 	}
 }

--- a/client/types/render.go
+++ b/client/types/render.go
@@ -286,11 +286,15 @@ type SearchStatsResponse struct {
 	Size        int               `json:",omitempty"`
 }
 
+type StatSetResponse struct {
+	Stats    []StatSet
+	Messages []Message
+}
+
 type StatSet struct {
-	Stats     []SearchModuleStats
+	Stats     []SearchModuleStats `json:"ModuleStats"`
 	TS        entry.Timestamp
 	populated bool
-	Messages  []Message
 }
 
 type OverviewStatSet struct {

--- a/client/types/render.go
+++ b/client/types/render.go
@@ -546,6 +546,17 @@ func (is IngestStats) MarshalJSON() ([]byte, error) {
 	})
 }
 
+func (s StatSetResponse) MarshalJSON() ([]byte, error) {
+	type alias StatSetResponse
+	return json.Marshal(&struct {
+		alias
+		Messages emptyMessages
+	}{
+		alias:    alias(s),
+		Messages: emptyMessages(s.Messages),
+	})
+}
+
 func (s SearchMetadata) MarshalJSON() ([]byte, error) {
 	type alias SearchMetadata
 	return json.Marshal(&struct {

--- a/client/types/stats.go
+++ b/client/types/stats.go
@@ -201,12 +201,10 @@ func (ss *StatSet) MarshalJSON() ([]byte, error) {
 	type alias StatSet
 	return json.Marshal(&struct {
 		alias
-		Stats    sms
-		Messages emptyMessages
+		Stats sms `json:"ModuleStats"`
 	}{
-		alias:    alias(*ss),
-		Stats:    sms(ss.Stats),
-		Messages: emptyMessages(ss.Messages),
+		alias: alias(*ss),
+		Stats: sms(ss.Stats),
 	})
 }
 


### PR DESCRIPTION
Updates https://github.com/gravwell/issues/issues/1742

This PR adds a new type that correctly wraps the `StatSet` type to match the API. 

Example output from the marshaler:

```
{
  "Stats": [
    {
      "TS": "0000-12-31T17:00:05-06:59",
      "ModuleStats": [
        {
          "InputCount": 1,
          "OutputCount": 0,
          "InputBytes": 0,
          "OutputBytes": 0,
          "Duration": 0,
          "ScratchWritten": 0,
          "Name": "test",
          "Args": ""
        }
      ]
    }
  ],
  "Messages": [
    {
      "ID": 1,
      "Severity": "",
      "Value": ""
    }
  ]
}
```