### PR TITLE
small tweaks as I implement the registry

### DIFF
--- a/client/admin.go
+++ b/client/admin.go
@@ -522,7 +522,7 @@ func (c *Client) Impersonate(uid int32) (nc *Client, err error) {
 	}
 	if dets.UID != uid {
 		nc = nil
-		err = fmt.Errorf("Failed to impersonate new user: %s[%d] != %d", dets.Name, dets.UID, uid)
+		err = fmt.Errorf("Failed to impersonate new user: %s[%d] != %d", dets.User, dets.UID, uid)
 		return
 	}
 	//set the user details the client is ready to use right out of the gate

--- a/client/types/cbac.go
+++ b/client/types/cbac.go
@@ -151,9 +151,9 @@ type CapabilityDesc struct {
 // how the user *obtained* that capability.
 type CapabilityExplanation struct {
 	CapabilityDesc
-	Granted     bool           // True if the user has this capability
-	UserGrant   bool           // True if the capability was explicitly granted to the user
-	GroupGrants []GroupDetails // An array of groups to which the user belongs that grant the capability.
+	Granted     bool    // True if the user has this capability
+	UserGrant   bool    // True if the capability was explicitly granted to the user
+	GroupGrants []Group // An array of groups to which the user belongs that grant the capability.
 }
 
 // CapabilityTemplate is group of capabilities with a name and description, this is used to build up a simplified set of

--- a/client/types/searchlog.go
+++ b/client/types/searchlog.go
@@ -16,7 +16,6 @@ import (
 
 type SearchLog struct {
 	UID            int32 //who started the search
-	GID            int32 //what group the search was assigned to, if any
 	GIDs           []int32
 	Global         bool
 	UserQuery      string //what the user actually typed
@@ -26,7 +25,7 @@ type SearchLog struct {
 }
 
 func (sl SearchLog) Equal(v SearchLog) bool {
-	return sl.UID == v.UID && sl.GID == v.GID && sl.UserQuery == v.UserQuery && sl.EffectiveQuery == v.EffectiveQuery && sl.Launched == v.Launched && utils.Int32SlicesEqual(sl.GIDs, v.GIDs) && sl.Global == v.Global
+	return sl.UID == v.UID && sl.UserQuery == v.UserQuery && sl.EffectiveQuery == v.EffectiveQuery && sl.Launched == v.Launched && utils.Int32SlicesEqual(sl.GIDs, v.GIDs) && sl.Global == v.Global
 }
 
 type SortableSearchLog []SearchLog


### PR DESCRIPTION
Migrating to the new user type means some fields have changed.

The change is searchlog.go is because we're finally killing the single-group sharing thing.