### PR TITLE
drop runtime version in ingester startup banners

### DIFF
--- a/ingesters/version/version.go
+++ b/ingesters/version/version.go
@@ -12,6 +12,8 @@ package version
 import (
 	"fmt"
 	"io"
+	"runtime"
+	"strings"
 	"time"
 )
 
@@ -28,6 +30,7 @@ var (
 func PrintVersion(wtr io.Writer) {
 	fmt.Fprintf(wtr, "Version:\t%d.%d.%d\n", MajorVersion, MinorVersion, PointVersion)
 	fmt.Fprintf(wtr, "BuildDate:\t%s\n", BuildDate.Format(`2006-01-02 15:04:05`))
+	fmt.Fprintf(wtr, "Runtime:\t%s\n", strings.TrimPrefix(runtime.Version(), "go"))
 }
 
 func GetVersion() string {


### PR DESCRIPTION
This PR addresses no specific issue:

Old Banner:

```
Version:	5.8.6
BuildDate:	2025-08-05 23:59:59
API Version:	0.9
OS:		linux amd64 [6.1.0-35-amd64] ( )
```

New Banner:
```
Version:	5.8.6
BuildDate:	2025-08-05 23:59:59
Runtime:	1.24.5
API Version:	0.9
OS:		linux amd64 [6.1.0-35-amd64] ( )
```