### PR TITLE
feat(#1764): Add UpdateUser library method

### DIFF
--- a/client/admin.go
+++ b/client/admin.go
@@ -168,6 +168,11 @@ func (c *Client) UpdateUserInfo(id int32, user, name, email string) error {
 	return c.methodStaticPushURL(http.MethodPut, usersInfoUrl(id), req, nil)
 }
 
+// UpdateUser (admin-only) will update the specified user's details.
+func (c *Client) UpdateUser(uid int32, udet types.UserDetails) error {
+	return c.putStaticURL(usersInfoUrl(uid), udet)
+}
+
 // AddGroup (admin-only) creates a new group with the given name and description.
 func (c *Client) AddGroup(name, desc string) error {
 	gpInfo := types.AddGroup{


### PR DESCRIPTION
This PR adds the `UpdateUser` library method, allowing for updates to a user's details via a `UserDetails` object. This is analogous to the `UpdateGroup` method and is required by the CLI for setting user CBAC permissions.

This PR addresses [#1764](https://github.com/gravwell/gravwell/issues/1764).