### PR TITLE
Define AvailableFilters and Can fields

### DIFF
--- a/client/types/api.go
+++ b/client/types/api.go
@@ -56,10 +56,12 @@ type ErrorObject struct {
 // BaseListResponse contains the common set of fields returned when
 // querying lists of assets.
 type BaseListResponse struct {
-	CursorNext  string `json:"cursor_next"`
-	CursorPrev  string `json:"cursor_prev"`
-	CurrentPage int    `json:"current_page"`
-	TotalCount  int    `json:"total_count"`
+	CursorNext       string            `json:"cursor_next"`
+	CursorPrev       string            `json:"cursor_prev"`
+	CurrentPage      int               `json:"current_page"`
+	TotalCount       int               `json:"total_count"`
+	Type             string            `json:"type"`
+	AvailableFilters []AvailableFilter `json:"available_filters"`
 }
 
 type VersionInfo struct {

--- a/client/types/assets.go
+++ b/client/types/assets.go
@@ -31,7 +31,14 @@ type QueryOptions struct {
 // Filter based on the values given, e.g. Key = "Name", Operation = "=", Values = ["foo", "bar"].
 // Specifying multiple values is an implicit OR.
 type Filter struct {
-	Key       string
-	Operation string
-	Values    []any
+	Key       string `json:"key"`
+	Operation string `json:"operation"`
+	Values    []any  `json:"values"`
+}
+
+// AvailableFilter defines a filter which *could* be applied: a key, valid operations, and optionally a label.
+type AvailableFilter struct {
+	Key        string   `json:"key"`
+	Label      string   `json:"label"`
+	Operations []string `json:"operations"`
 }

--- a/client/types/commonfields.go
+++ b/client/types/commonfields.go
@@ -33,6 +33,9 @@ type CommonFields struct {
 	Description string
 	Labels      []string
 	Version     int
+
+	// Auto-generated for the requesting user based on permissions of this object.
+	Can Actions
 }
 
 func (cf *CommonFields) CanRead(u *User) bool {


### PR DESCRIPTION
AvailableFilters comes back in a list response to tell you what you can filter on.

Can is jammed into CommonFields and will let you know what the requesting user is allowed to do with a particular asset.

