### PR TITLE
bug(#1574): fix multiword word APP-NAME syslog entries in generator

### DIFF
--- a/generators/gravwellGenerator/consts.go
+++ b/generators/gravwellGenerator/consts.go
@@ -252,7 +252,7 @@ func seedHosts(cnt int) {
 
 func seedApps(cnt int) {
 	for i := 0; i < cnt; i++ {
-		apps = append(apps, fake.App().Name())
+		apps = append(apps, strings.ReplaceAll(fake.App().Name(), " ", "_"))
 	}
 }
 


### PR DESCRIPTION
This PR addresses https://github.com/gravwell/gravwell/issues/1574