### PR TITLE
baseline results API options before larger API changes come in

### DIFF
--- a/client/types/render.go
+++ b/client/types/render.go
@@ -109,8 +109,9 @@ const (
 
 type ResultsOptions struct {
 	Fence    Geofence
-	BinCount int `json:"binCount,omitempty"`
-	BinWidth int `json:"binWidth,omitempty"`
+	BinCount int    `json:"binCount,omitempty"`
+	BinWidth int    `json:"binWidth,omitempty"`
+	Op       string `json:"op,omitempty"`
 }
 
 type ResultsResponse struct {


### PR DESCRIPTION
## This PR proposes...

Adding an "op" field to the results API options. This is for stats ops (count, min, max). This will appear in an upstream API change, but we're staging it now for related PR to unblock some other work.

