### PR TITLE
Preprocessor: Add Regexdrop processor

### DIFF
--- a/ingest/processors/processors.go
+++ b/ingest/processors/processors.go
@@ -78,6 +78,7 @@ func CheckProcessor(id string) error {
 	case SyslogRouterProcessor:
 	case TagSrcRouterProcessor:
 	case RegexReplaceProcessor:
+	case RegexDropProcessor:
 	default:
 		return checkProcessorOS(id)
 	}
@@ -147,6 +148,8 @@ func ProcessorLoadConfig(vc *config.VariableConfig) (cfg interface{}, err error)
 		cfg, err = TagSrcRouterLoadConfig(vc)
 	case RegexReplaceProcessor:
 		cfg, err = RegexReplaceLoadConfig(vc)
+	case RegexDropProcessor:
+		cfg, err = RegexDropLoadConfig(vc)
 	default:
 		cfg, err = processorLoadConfigOS(vc)
 	}
@@ -316,6 +319,12 @@ func newProcessor(vc *config.VariableConfig, tgr Tagger) (p Processor, err error
 			return
 		}
 		p, err = NewRegexReplacer(cfg)
+	case RegexDropProcessor:
+		var cfg RegexDropConfig
+		if err = vc.MapTo(&cfg); err != nil {
+			return
+		}
+		p, err = NewRegexDropper(cfg)
 	default:
 		p, err = newProcessorOS(vc, tgr)
 	}

--- a/ingest/processors/regexdrop.go
+++ b/ingest/processors/regexdrop.go
@@ -1,0 +1,98 @@
+/*************************************************************************
+ * Copyright 2018 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
+package processors
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+
+	"github.com/gravwell/gravwell/v3/ingest/config"
+	"github.com/gravwell/gravwell/v3/ingest/entry"
+)
+
+const (
+	RegexDropProcessor string = `regexdrop`
+)
+
+type RegexDropConfig struct {
+	Regex  string // Regex is the regular expression to match against
+	Invert bool   // Invert negates the match, if true entries that match are kept
+}
+
+// RegexDropLoadConfig loads the configuration for the regexdrop processor
+func RegexDropLoadConfig(vc *config.VariableConfig) (c RegexDropConfig, err error) {
+	if err = vc.MapTo(&c); err != nil {
+		return
+	}
+	_, err = c.validate()
+	return
+}
+
+func (c *RegexDropConfig) validate() (rx *regexp.Regexp, err error) {
+	if len(c.Regex) == 0 {
+		return nil, errors.New("Regex is required")
+	}
+	if rx, err = regexp.Compile(c.Regex); err != nil {
+		return nil, fmt.Errorf("invalid regex: %w", err)
+	}
+	return
+}
+
+// NewRegexDropper creates a new regexdrop processor
+func NewRegexDropper(cfg RegexDropConfig) (*RegexDropper, error) {
+	rx, err := cfg.validate()
+	if err != nil {
+		return nil, err
+	}
+	return &RegexDropper{
+		RegexDropConfig: cfg,
+		rx:              rx,
+	}, nil
+}
+
+type RegexDropper struct {
+	nocloser
+	RegexDropConfig
+	rx *regexp.Regexp
+}
+
+// Config updates the configuration for the regexdrop processor
+func (r *RegexDropper) Config(v interface{}) (err error) {
+	if v == nil {
+		err = ErrNilConfig
+	} else if cfg, ok := v.(RegexDropConfig); ok {
+		if r.rx, err = cfg.validate(); err != nil {
+			return
+		}
+		r.RegexDropConfig = cfg
+	} else {
+		err = fmt.Errorf("Invalid configuration, unknown type %T", v)
+	}
+	return
+}
+
+// Process filters entries based on regex match
+// If Invert is false: drops entries that match (keeps non-matches)
+// If Invert is true: drops entries that don't match (keeps only matches)
+func (r *RegexDropper) Process(ents []*entry.Entry) (rset []*entry.Entry, err error) {
+	if len(ents) == 0 {
+		return
+	}
+	rset = ents[:0]
+	for _, ent := range ents {
+		if ent == nil {
+			continue
+		}
+		if r.rx.Match(ent.Data) == r.Invert {
+			rset = append(rset, ent)
+		}
+	}
+	return
+}

--- a/ingest/processors/regexdrop_test.go
+++ b/ingest/processors/regexdrop_test.go
@@ -1,0 +1,627 @@
+/*************************************************************************
+ * Copyright 2018 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
+package processors
+
+import (
+	"testing"
+
+	"github.com/gravwell/gravwell/v3/ingest/entry"
+)
+
+func TestRegexDropConfigValidation(t *testing.T) {
+	// Test valid configuration
+	validConfig := RegexDropConfig{
+		Regex:  `test`,
+		Invert: false,
+	}
+
+	_, err := NewRegexDropper(validConfig)
+	if err != nil {
+		t.Errorf("Valid config should not return error: %v", err)
+	}
+
+	// Test invalid regex
+	invalidConfig := RegexDropConfig{
+		Regex:  `[`,
+		Invert: false,
+	}
+
+	_, err = NewRegexDropper(invalidConfig)
+	if err == nil {
+		t.Error("Invalid regex should return error")
+	}
+
+	// Test empty regex
+	emptyConfig := RegexDropConfig{
+		Regex:  ``,
+		Invert: false,
+	}
+
+	_, err = NewRegexDropper(emptyConfig)
+	if err == nil {
+		t.Error("Empty regex should return error")
+	}
+}
+
+func TestRegexDropProcessor(t *testing.T) {
+	// Create a regex drop processor that drops entries matching "drop"
+	cfg := RegexDropConfig{
+		Regex:  `drop`,
+		Invert: false,
+	}
+
+	processor, err := NewRegexDropper(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create processor: %v", err)
+	}
+
+	// Test with mixed entries - some match, some don't
+	entry1 := &entry.Entry{
+		Tag:  1,
+		SRC:  nil,
+		TS:   entry.Now(),
+		Data: []byte("This should be kept"),
+	}
+
+	entry2 := &entry.Entry{
+		Tag:  1,
+		SRC:  nil,
+		TS:   entry.Now(),
+		Data: []byte("This should drop this entry"),
+	}
+
+	entry3 := &entry.Entry{
+		Tag:  1,
+		SRC:  nil,
+		TS:   entry.Now(),
+		Data: []byte("Also kept"),
+	}
+
+	entries := []*entry.Entry{entry1, entry2, entry3}
+	result, err := processor.Process(entries)
+	if err != nil {
+		t.Fatalf("Process failed: %v", err)
+	}
+
+	if len(result) != 2 {
+		t.Errorf("Expected 2 results, got %d", len(result))
+	}
+
+	// Verify the correct entries were kept
+	if string(result[0].Data) != "This should be kept" {
+		t.Errorf("Expected first entry to be 'This should be kept', got '%s'", string(result[0].Data))
+	}
+
+	if string(result[1].Data) != "Also kept" {
+		t.Errorf("Expected second entry to be 'Also kept', got '%s'", string(result[1].Data))
+	}
+}
+
+func TestRegexDropProcessorInvert(t *testing.T) {
+	// Create a regex drop processor with Invert=true (keep only matches)
+	cfg := RegexDropConfig{
+		Regex:  `keep`,
+		Invert: true,
+	}
+
+	processor, err := NewRegexDropper(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create processor: %v", err)
+	}
+
+	// Test with mixed entries
+	entry1 := &entry.Entry{
+		Tag:  1,
+		SRC:  nil,
+		TS:   entry.Now(),
+		Data: []byte("This should be dropped"),
+	}
+
+	entry2 := &entry.Entry{
+		Tag:  1,
+		SRC:  nil,
+		TS:   entry.Now(),
+		Data: []byte("keep this entry"),
+	}
+
+	entry3 := &entry.Entry{
+		Tag:  1,
+		SRC:  nil,
+		TS:   entry.Now(),
+		Data: []byte("Also dropped"),
+	}
+
+	entry4 := &entry.Entry{
+		Tag:  1,
+		SRC:  nil,
+		TS:   entry.Now(),
+		Data: []byte("keep this one too"),
+	}
+
+	entries := []*entry.Entry{entry1, entry2, entry3, entry4}
+	result, err := processor.Process(entries)
+	if err != nil {
+		t.Fatalf("Process failed: %v", err)
+	}
+
+	if len(result) != 2 {
+		t.Errorf("Expected 2 results, got %d", len(result))
+	}
+
+	// Verify the correct entries were kept (only those with "keep")
+	if string(result[0].Data) != "keep this entry" {
+		t.Errorf("Expected first entry to be 'keep this entry', got '%s'", string(result[0].Data))
+	}
+
+	if string(result[1].Data) != "keep this one too" {
+		t.Errorf("Expected second entry to be 'keep this one too', got '%s'", string(result[1].Data))
+	}
+}
+
+func TestRegexDropProcessorNoMatches(t *testing.T) {
+	// Test when no entries match
+	cfg := RegexDropConfig{
+		Regex:  `xyz`,
+		Invert: false,
+	}
+
+	processor, err := NewRegexDropper(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create processor: %v", err)
+	}
+
+	entry1 := &entry.Entry{
+		Tag:  1,
+		SRC:  nil,
+		TS:   entry.Now(),
+		Data: []byte("This is a test string"),
+	}
+
+	entry2 := &entry.Entry{
+		Tag:  1,
+		SRC:  nil,
+		TS:   entry.Now(),
+		Data: []byte("Another test string"),
+	}
+
+	entries := []*entry.Entry{entry1, entry2}
+	result, err := processor.Process(entries)
+	if err != nil {
+		t.Fatalf("Process failed: %v", err)
+	}
+
+	// All entries should be kept since none match
+	if len(result) != 2 {
+		t.Errorf("Expected 2 results, got %d", len(result))
+	}
+}
+
+func TestRegexDropProcessorAllMatch(t *testing.T) {
+	// Test when all entries match
+	cfg := RegexDropConfig{
+		Regex:  `test`,
+		Invert: false,
+	}
+
+	processor, err := NewRegexDropper(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create processor: %v", err)
+	}
+
+	entry1 := &entry.Entry{
+		Tag:  1,
+		SRC:  nil,
+		TS:   entry.Now(),
+		Data: []byte("This is a test string"),
+	}
+
+	entry2 := &entry.Entry{
+		Tag:  1,
+		SRC:  nil,
+		TS:   entry.Now(),
+		Data: []byte("Another test string"),
+	}
+
+	entries := []*entry.Entry{entry1, entry2}
+	result, err := processor.Process(entries)
+	if err != nil {
+		t.Fatalf("Process failed: %v", err)
+	}
+
+	// All entries should be dropped since all match
+	if len(result) != 0 {
+		t.Errorf("Expected 0 results, got %d", len(result))
+	}
+}
+
+func TestRegexDropProcessorNilEntry(t *testing.T) {
+	// Test with nil entries
+	cfg := RegexDropConfig{
+		Regex:  `test`,
+		Invert: false,
+	}
+
+	processor, err := NewRegexDropper(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create processor: %v", err)
+	}
+
+	entries := []*entry.Entry{nil, nil}
+	result, err := processor.Process(entries)
+	if err != nil {
+		t.Fatalf("Process failed: %v", err)
+	}
+
+	if len(result) != 0 {
+		t.Errorf("Expected 0 results for nil entries, got %d", len(result))
+	}
+}
+
+func TestRegexDropProcessorEmptyEntry(t *testing.T) {
+	// Test with empty entry data
+	cfg := RegexDropConfig{
+		Regex:  `test`,
+		Invert: false,
+	}
+
+	processor, err := NewRegexDropper(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create processor: %v", err)
+	}
+
+	entry1 := &entry.Entry{
+		Tag:  1,
+		SRC:  nil,
+		TS:   entry.Now(),
+		Data: []byte(""),
+	}
+
+	entries := []*entry.Entry{entry1}
+	result, err := processor.Process(entries)
+	if err != nil {
+		t.Fatalf("Process failed: %v", err)
+	}
+
+	// Empty entry should be kept since it doesn't match "test"
+	if len(result) != 1 {
+		t.Errorf("Expected 1 result, got %d", len(result))
+	}
+}
+
+func TestRegexDropProcessorComplexRegex(t *testing.T) {
+	// Test with complex regex pattern (email addresses)
+	cfg := RegexDropConfig{
+		Regex:  `\w+@\w+\.\w+`,
+		Invert: false,
+	}
+
+	processor, err := NewRegexDropper(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create processor: %v", err)
+	}
+
+	entry1 := &entry.Entry{
+		Tag:  1,
+		SRC:  nil,
+		TS:   entry.Now(),
+		Data: []byte("Normal log entry"),
+	}
+
+	entry2 := &entry.Entry{
+		Tag:  1,
+		SRC:  nil,
+		TS:   entry.Now(),
+		Data: []byte("Contact user@example.com for info"),
+	}
+
+	entry3 := &entry.Entry{
+		Tag:  1,
+		SRC:  nil,
+		TS:   entry.Now(),
+		Data: []byte("Another normal entry"),
+	}
+
+	entries := []*entry.Entry{entry1, entry2, entry3}
+	result, err := processor.Process(entries)
+	if err != nil {
+		t.Fatalf("Process failed: %v", err)
+	}
+
+	// Only entries without email addresses should be kept
+	if len(result) != 2 {
+		t.Errorf("Expected 2 results, got %d", len(result))
+	}
+
+	if string(result[0].Data) != "Normal log entry" {
+		t.Errorf("Expected 'Normal log entry', got '%s'", string(result[0].Data))
+	}
+
+	if string(result[1].Data) != "Another normal entry" {
+		t.Errorf("Expected 'Another normal entry', got '%s'", string(result[1].Data))
+	}
+}
+
+func TestRegexDropProcessorCaseInsensitive(t *testing.T) {
+	// Test case-insensitive matching using (?i) flag
+	cfg := RegexDropConfig{
+		Regex:  `(?i)error`,
+		Invert: false,
+	}
+
+	processor, err := NewRegexDropper(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create processor: %v", err)
+	}
+
+	entry1 := &entry.Entry{
+		Tag:  1,
+		SRC:  nil,
+		TS:   entry.Now(),
+		Data: []byte("This is an ERROR"),
+	}
+
+	entry2 := &entry.Entry{
+		Tag:  1,
+		SRC:  nil,
+		TS:   entry.Now(),
+		Data: []byte("This is an Error"),
+	}
+
+	entry3 := &entry.Entry{
+		Tag:  1,
+		SRC:  nil,
+		TS:   entry.Now(),
+		Data: []byte("This is fine"),
+	}
+
+	entry4 := &entry.Entry{
+		Tag:  1,
+		SRC:  nil,
+		TS:   entry.Now(),
+		Data: []byte("This has error in it"),
+	}
+
+	entries := []*entry.Entry{entry1, entry2, entry3, entry4}
+	result, err := processor.Process(entries)
+	if err != nil {
+		t.Fatalf("Process failed: %v", err)
+	}
+
+	// Only the entry without "error" (case-insensitive) should be kept
+	if len(result) != 1 {
+		t.Errorf("Expected 1 result, got %d", len(result))
+	}
+
+	if string(result[0].Data) != "This is fine" {
+		t.Errorf("Expected 'This is fine', got '%s'", string(result[0].Data))
+	}
+}
+
+func TestRegexDropProcessorJSON(t *testing.T) {
+	// Test dropping JSON entries with specific fields
+	cfg := RegexDropConfig{
+		Regex:  `"level":"error"`,
+		Invert: false,
+	}
+
+	processor, err := NewRegexDropper(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create processor: %v", err)
+	}
+
+	entry1 := &entry.Entry{
+		Tag:  1,
+		SRC:  nil,
+		TS:   entry.Now(),
+		Data: []byte(`{"level":"info","message":"All good"}`),
+	}
+
+	entry2 := &entry.Entry{
+		Tag:  1,
+		SRC:  nil,
+		TS:   entry.Now(),
+		Data: []byte(`{"level":"error","message":"Something bad"}`),
+	}
+
+	entry3 := &entry.Entry{
+		Tag:  1,
+		SRC:  nil,
+		TS:   entry.Now(),
+		Data: []byte(`{"level":"warning","message":"Be careful"}`),
+	}
+
+	entries := []*entry.Entry{entry1, entry2, entry3}
+	result, err := processor.Process(entries)
+	if err != nil {
+		t.Fatalf("Process failed: %v", err)
+	}
+
+	// Only non-error entries should be kept
+	if len(result) != 2 {
+		t.Errorf("Expected 2 results, got %d", len(result))
+	}
+}
+
+func TestRegexDropProcessorMixedNilAndValid(t *testing.T) {
+	// Test with mix of nil and valid entries
+	cfg := RegexDropConfig{
+		Regex:  `drop`,
+		Invert: false,
+	}
+
+	processor, err := NewRegexDropper(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create processor: %v", err)
+	}
+
+	entry1 := &entry.Entry{
+		Tag:  1,
+		SRC:  nil,
+		TS:   entry.Now(),
+		Data: []byte("Keep this"),
+	}
+
+	entry2 := &entry.Entry{
+		Tag:  1,
+		SRC:  nil,
+		TS:   entry.Now(),
+		Data: []byte("drop this"),
+	}
+
+	entries := []*entry.Entry{nil, entry1, nil, entry2, nil}
+	result, err := processor.Process(entries)
+	if err != nil {
+		t.Fatalf("Process failed: %v", err)
+	}
+
+	// Only entry1 should be kept (nil entries are skipped, entry2 matches and is dropped)
+	if len(result) != 1 {
+		t.Errorf("Expected 1 result, got %d", len(result))
+	}
+
+	if string(result[0].Data) != "Keep this" {
+		t.Errorf("Expected 'Keep this', got '%s'", string(result[0].Data))
+	}
+}
+
+func TestRegexDropProcessorConfigUpdate(t *testing.T) {
+	// Test updating configuration
+	cfg := RegexDropConfig{
+		Regex:  `drop`,
+		Invert: false,
+	}
+
+	processor, err := NewRegexDropper(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create processor: %v", err)
+	}
+
+	// Update configuration to use Invert=true
+	newCfg := RegexDropConfig{
+		Regex:  `keep`,
+		Invert: true,
+	}
+
+	err = processor.Config(newCfg)
+	if err != nil {
+		t.Fatalf("Failed to update config: %v", err)
+	}
+
+	// Test that the new config is applied
+	entry1 := &entry.Entry{
+		Tag:  1,
+		SRC:  nil,
+		TS:   entry.Now(),
+		Data: []byte("keep this entry"),
+	}
+
+	entry2 := &entry.Entry{
+		Tag:  1,
+		SRC:  nil,
+		TS:   entry.Now(),
+		Data: []byte("drop this entry"),
+	}
+
+	entries := []*entry.Entry{entry1, entry2}
+	result, err := processor.Process(entries)
+	if err != nil {
+		t.Fatalf("Process failed: %v", err)
+	}
+
+	// With Invert=true and Regex="keep", only entries with "keep" should be kept
+	if len(result) != 1 {
+		t.Errorf("Expected 1 result, got %d", len(result))
+	}
+
+	if string(result[0].Data) != "keep this entry" {
+		t.Errorf("Expected 'keep this entry', got '%s'", string(result[0].Data))
+	}
+}
+
+func TestRegexDropProcessorConfigNil(t *testing.T) {
+	// Test Config with nil value
+	cfg := RegexDropConfig{
+		Regex:  `test`,
+		Invert: false,
+	}
+
+	processor, err := NewRegexDropper(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create processor: %v", err)
+	}
+
+	err = processor.Config(nil)
+	if err == nil {
+		t.Error("Config with nil should return error")
+	}
+}
+
+func TestRegexDropProcessorConfigInvalidType(t *testing.T) {
+	// Test Config with invalid type
+	cfg := RegexDropConfig{
+		Regex:  `test`,
+		Invert: false,
+	}
+
+	processor, err := NewRegexDropper(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create processor: %v", err)
+	}
+
+	err = processor.Config("invalid type")
+	if err == nil {
+		t.Error("Config with invalid type should return error")
+	}
+}
+
+func TestRegexDropProcessorConfigEmptyRegex(t *testing.T) {
+	// Test Config with empty regex
+	cfg := RegexDropConfig{
+		Regex:  `test`,
+		Invert: false,
+	}
+
+	processor, err := NewRegexDropper(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create processor: %v", err)
+	}
+
+	newCfg := RegexDropConfig{
+		Regex:  ``,
+		Invert: false,
+	}
+
+	err = processor.Config(newCfg)
+	if err == nil {
+		t.Error("Config with empty regex should return error")
+	}
+}
+
+func TestRegexDropProcessorConfigInvalidRegex(t *testing.T) {
+	// Test Config with invalid regex
+	cfg := RegexDropConfig{
+		Regex:  `test`,
+		Invert: false,
+	}
+
+	processor, err := NewRegexDropper(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create processor: %v", err)
+	}
+
+	newCfg := RegexDropConfig{
+		Regex:  `[`,
+		Invert: false,
+	}
+
+	err = processor.Config(newCfg)
+	if err == nil {
+		t.Error("Config with invalid regex should return error")
+	}
+}


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses [ISSUE_LINK]

## This PR proposes a new preprocessor for dropping via regex x. 
- This preprocessor gives the user the option to either allow or disallow entries through the ingester via a regex pattern. The user specifies two settings, Regex for the regex and Invert which tells the preprocessor to either block all matches on false or allow matches on true. 

- This preprocessor has been tested with the HTTP ingester

## PR Tasks

<!-- Add tasks to this list as needed -->

- [ X ] e2e and/or unit tests included. If not, please provide an explanation.


## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
