### PR TITLE
registry: implement cleanupresources and remove the Domain field

### DIFF
--- a/client/resources.go
+++ b/client/resources.go
@@ -145,6 +145,11 @@ func (c *Client) PurgeResource(id string) error {
 	return c.deleteStaticURL(resourcesIdUrl(id), nil, ezParam("purge", "true"))
 }
 
+// CleanupResources (admin-only) purges all deleted resources for all users.
+func (c *Client) CleanupResources() error {
+	return c.deleteStaticURL(RESOURCES_URL, nil)
+}
+
 // UpdateResourceMetadata sets the specified resource's metadata.
 func (c *Client) UpdateResourceMetadata(id string, metadata types.Resource) error {
 	return c.putStaticURL(resourcesIdUrl(id), metadata)

--- a/client/types/resource.go
+++ b/client/types/resource.go
@@ -72,7 +72,6 @@ func (ru *ResourceUpdate) Close() {
 type Resource struct {
 	CommonFields
 
-	Domain      int16 // Webserver domain of this resource. Only webservers in this domain can access it.
 	Size        uint64
 	Hash        string
 	ContentType string // Guessed at update time if possible


### PR DESCRIPTION
## This PR proposes...

Webservers no longer know or care about the domain, except when actively talking to an indexer. We do not store it on a per-resource basis.

Also implements the CleanupResources function on the client library.

## PR Tasks

- [x] e2e and/or unit tests included. If not, please provide an explanation.

No tests, as this must be tested within the backend (it is).

## Reviewer Tasks

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
