### PR TITLE
bump runtime to 1.24.13 due to some tls security issues in stdlib

### DIFF
--- a/.github/workflows/golang-testing.yml
+++ b/.github/workflows/golang-testing.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: 1.24.12
+        go-version: 1.24.13
         cache: false
 
     - name: Go Tidy

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravwell/gravwell/v3
 
-go 1.24.12
+go 1.24.13
 
 require (
 	cloud.google.com/go/pubsub v1.38.0


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses no specific issue

## This PR proposes...

- Bump golang runtime from 1.24.12 to 1.24.13

## PR Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e and/or unit tests included. If not, please provide an explanation.
- [ ] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
