### PR TITLE
add transparent decompression on S3 objects

### DIFF
--- a/ingesters/s3Ingester/utils.go
+++ b/ingesters/s3Ingester/utils.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravwell/gravwell/v3/ingest/entry"
 	"github.com/gravwell/gravwell/v3/ingest/log"
 	"github.com/gravwell/gravwell/v3/ingest/processors"
+	"github.com/gravwell/gravwell/v3/ingesters/utils"
 	"github.com/gravwell/gravwell/v3/timegrinder"
 	"github.com/gravwell/jsonparser"
 )
@@ -296,11 +297,17 @@ func ProcessContext(obj *s3.Object, ctx context.Context, svc *s3.S3, bucket stri
 		evs.Add(entry.EnumeratedValue{Name: "key", Value: entry.StringEnumData(*obj.Key)})
 	}
 
+	var smartReader io.Reader
+	if smartReader, err = utils.NewCompressedReader(r.Body); err != nil {
+		err = fmt.Errorf("failed to create transparent decompression reader: %w", err)
+		return
+	}
+
 	switch rdr {
 	case lineReader:
-		err = processLinesContext(ctx, r.Body, maxLineSize, tg, src, tag, &evs, proc)
+		err = processLinesContext(ctx, smartReader, maxLineSize, tg, src, tag, &evs, proc)
 	case cloudtrailReader:
-		err = processCloudtrailContext(ctx, r.Body, tg, src, tag, &evs, proc)
+		err = processCloudtrailContext(ctx, smartReader, tg, src, tag, &evs, proc)
 	default:
 		err = errors.New("no reader set")
 	}

--- a/ingesters/utils/compressed_reader_test.go
+++ b/ingesters/utils/compressed_reader_test.go
@@ -1,0 +1,110 @@
+/*************************************************************************
+ * Copyright 2017 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
+package utils
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestNewCompressedReaderGzip(t *testing.T) {
+	testData := "Hello, this is test data for gzip compression!"
+
+	// Create gzip compressed data
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	if _, err := gw.Write([]byte(testData)); err != nil {
+		t.Fatalf("Failed to write gzip data: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("Failed to close gzip writer: %v", err)
+	}
+
+	// Test NewCompressedReader
+	r, err := NewCompressedReader(&buf)
+	if err != nil {
+		t.Fatalf("NewCompressedReader failed: %v", err)
+	}
+
+	result, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("Failed to read decompressed data: %v", err)
+	}
+
+	if string(result) != testData {
+		t.Errorf("Decompressed data mismatch: got %q, want %q", string(result), testData)
+	}
+}
+
+func TestNewCompressedReaderBzip2(t *testing.T) {
+	// Create bzip2 compressed data
+	// Bzip2 magic: "BZ" followed by version and block size
+	var buf bytes.Buffer
+	buf.Write([]byte("BZh9")) // Bzip2 header with block size 9
+
+	// Since we can't easily create valid bzip2 data without external tools,
+	// we'll just test that the function detects bzip2 format
+	r, err := NewCompressedReader(&buf)
+	if err != nil {
+		t.Fatalf("NewCompressedReader failed: %v", err)
+	}
+
+	// The reader should be a bzip2 reader (won't be able to read valid data though)
+	if r == nil {
+		t.Error("Expected non-nil reader for bzip2 data")
+	}
+}
+
+func TestNewCompressedReaderRaw(t *testing.T) {
+	testData := "Hello, this is uncompressed test data!"
+
+	buf := strings.NewReader(testData)
+
+	r, err := NewCompressedReader(buf)
+	if err != nil {
+		t.Fatalf("NewCompressedReader failed: %v", err)
+	}
+
+	result, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("Failed to read raw data: %v", err)
+	}
+
+	if string(result) != testData {
+		t.Errorf("Raw data mismatch: got %q, want %q", string(result), testData)
+	}
+}
+
+func TestNewCompressedReaderNil(t *testing.T) {
+	_, err := NewCompressedReader(nil)
+	if err == nil {
+		t.Error("Expected error for nil reader, got nil")
+	}
+}
+
+func TestNewCompressedReaderEmpty(t *testing.T) {
+	buf := &bytes.Buffer{}
+
+	r, err := NewCompressedReader(buf)
+	if err != nil {
+		t.Fatalf("NewCompressedReader failed on empty input: %v", err)
+	}
+
+	result, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("Failed to read empty data: %v", err)
+	}
+
+	if len(result) != 0 {
+		t.Errorf("Expected empty result, got %d bytes", len(result))
+	}
+}

--- a/ingesters/utils/readers.go
+++ b/ingesters/utils/readers.go
@@ -11,6 +11,8 @@ package utils
 import (
 	"bufio"
 	"bytes"
+	"compress/bzip2"
+	"compress/gzip"
 	"encoding/csv"
 	"encoding/json"
 	"errors"
@@ -37,13 +39,54 @@ const (
 
 	initBuffSize = 4 * 1024 * 1024
 	maxBuffSize  = 128 * 1024 * 1024
+
+	gzipMagic1  = 0x1f
+	gzipMagic2  = 0x8b
+	bzip2Magic1 = 'B'
+	bzip2Magic2 = 'Z'
 )
 
 var (
 	errInvalidColumns = errors.New("invalid csv import columns")
 	csvCols           = []string{`Timestamp`, `Source`, `Tag`, `Data`}
 	nlBytes           = []byte("\n")
+	errPeekFailed     = errors.New("failed to peek compression header")
 )
+
+// NewCompressedReader wraps an io.Reader in a bufio.Reader and automatically
+// detects and handles gzip, bzip2, or raw data streams. It returns an io.Reader
+// that transparently decompresses the data if compression is detected.
+func NewCompressedReader(r io.Reader) (io.Reader, error) {
+	if r == nil {
+		return nil, errors.New("nil reader")
+	}
+
+	br := bufio.NewReader(r)
+
+	// Peek at the first 2 bytes to detect compression format
+	header, err := br.Peek(2)
+	if err != nil && err != io.EOF {
+		return nil, errPeekFailed
+	}
+
+	// If we couldn't read 2 bytes, just return the buffered reader
+	if len(header) < 2 {
+		return br, nil
+	}
+
+	// Check for gzip magic bytes (0x1f 0x8b)
+	if header[0] == gzipMagic1 && header[1] == gzipMagic2 {
+		return gzip.NewReader(br)
+	}
+
+	// Check for bzip2 magic bytes ('BZ')
+	if header[0] == bzip2Magic1 && header[1] == bzip2Magic2 {
+		return bzip2.NewReader(br), nil
+	}
+
+	// No compression detected, return the buffered reader
+	return br, nil
+}
 
 type TagHandler interface {
 	OverrideTags(entry.EntryTag)


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses https://github.com/gravwell/gravwell/issues/2178

## This PR proposes...

- adding transparent object decompression on S3 ingester

we continually run into customers that double wrap data on S3 and its a huge fight and everyone hates it.
This should safely avoid this issue in the future, unless they triple wrap it... then... :(

## PR Tasks

<!-- Add tasks to this list as needed -->

- [X] e2e and/or unit tests included. If not, please provide an explanation.
- [ ] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
