### PR TITLE
add functionality to ignore digest objects in cloudtrail streams

### DIFF
--- a/ingesters/s3Ingester/utils.go
+++ b/ingesters/s3Ingester/utils.go
@@ -401,8 +401,8 @@ func processCloudtrailContext(ctx context.Context, rdr io.Reader, tg *timegrinde
 		}
 		if recordarray, dt, _, err = jsonparser.Get([]byte(obj), `Records`); err != nil {
 			if err == jsonparser.KeyPathNotFoundError {
-				// check if this is a digest file, if so we just skip it
-				if isCloudTrailDigestFile(obj) {
+				// check if this is a digest object, if so we just skip it
+				if isCloudTrailDigestObject(obj) {
 					err = nil
 					continue
 				}
@@ -442,7 +442,7 @@ var cloudTrailDigestFileKeys = []string{
 	`digestS3Object`,
 }
 
-func isCloudTrailDigestFile(obj json.RawMessage) (ok bool) {
+func isCloudTrailDigestObject(obj json.RawMessage) (ok bool) {
 	//check if this is a digest file, we do this a few ways
 	//first check the top level looking for a few keys that are part of the digest file specification
 	// see here for more info:


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses no specific issue

## This PR proposes...

- adding functionality to skip cloudtrail digest objects in cloudtrail streams

### Why

If data file integrity is enabled in cloudtrail then AWS delivers streams of object pointers that are not log files at all, but rather an object digest that gives hashes for all the data objects it sent.  Our decoder gets these objects, doesn't know what to do with them, throws an error, and continues.

These errors build up in our output logs, the SQS stream redelivers objects.  Everyone has a bad time.

This detects these objects in the cloudtrail stream and just ignores them, there is nothing to be done anyway

## PR Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e and/or unit tests included. If not, please provide an explanation.
- [x] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
