### PR TITLE
refactor (2099): improve hosted runner startup

### DIFF
--- a/ingesters/hosted/plugins/builder.go
+++ b/ingesters/hosted/plugins/builder.go
@@ -1,3 +1,11 @@
+/*************************************************************************
+ * Copyright 2026 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
 package plugins
 
 import (

--- a/ingesters/hosted/plugins/builder.go
+++ b/ingesters/hosted/plugins/builder.go
@@ -1,0 +1,97 @@
+package plugins
+
+import (
+	"github.com/google/uuid"
+	"github.com/gravwell/gravwell/v3/ingesters/hosted"
+	"github.com/gravwell/gravwell/v3/ingesters/hosted/plugins/mimecast"
+	"github.com/gravwell/gravwell/v3/ingesters/hosted/plugins/okta"
+	"github.com/gravwell/gravwell/v3/ingesters/hosted/plugins/tester"
+)
+
+type BuilderConfig interface {
+	UUID() uuid.UUID
+}
+
+type Builder[T BuilderConfig] struct {
+	config  T
+	kind    string
+	id      string
+	version string
+}
+
+func (b *Builder[T]) Config() any {
+	return b.config
+}
+
+func (b *Builder[T]) Kind() string {
+	return b.kind
+}
+
+func (b *Builder[T]) ID() string {
+	return b.id
+}
+
+func (b *Builder[T]) Version() string {
+	return b.version
+}
+
+func (b *Builder[T]) UUID() uuid.UUID {
+	return b.config.UUID()
+}
+
+type TesterBuilder struct {
+	Builder[*tester.Config]
+}
+
+func (tb *TesterBuilder) Build(tn hosted.TagNegotiator) (hosted.Ingester, error) {
+	return tester.NewTesterIngester(*(tb.config), tn)
+}
+
+func NewTesterBuilder(config *tester.Config, kind, id, version string) *TesterBuilder {
+	return &TesterBuilder{
+		Builder[*tester.Config]{
+			config:  config,
+			kind:    kind,
+			id:      id,
+			version: version,
+		},
+	}
+}
+
+type OktaBuilder struct {
+	Builder[*okta.Config]
+}
+
+func (ob *OktaBuilder) Build(tn hosted.TagNegotiator) (hosted.Ingester, error) {
+	return okta.NewOktaIngester(*(ob.config), tn)
+}
+
+func NewOktaBuilder(config *okta.Config, kind, id, version string) *OktaBuilder {
+	return &OktaBuilder{
+		Builder[*okta.Config]{
+			config:  config,
+			kind:    kind,
+			id:      id,
+			version: version,
+		},
+	}
+}
+
+type MimecastBuilder struct {
+	Builder[*mimecast.Config]
+}
+
+func (mb *MimecastBuilder) Build(tn hosted.TagNegotiator) (hosted.Ingester, error) {
+	return mimecast.New(mb.config), nil
+}
+
+func NewMimecastBuilder(config *mimecast.Config, kind, id, version string) *MimecastBuilder {
+	return &MimecastBuilder{
+		Builder[*mimecast.Config]{
+			config:  config,
+			kind:    kind,
+			id:      id,
+			version: version,
+		},
+	}
+}

--- a/ingesters/hosted/plugins/builder.go
+++ b/ingesters/hosted/plugins/builder.go
@@ -20,6 +20,11 @@ type BuilderConfig interface {
 	UUID() uuid.UUID
 }
 
+// Builder is provided as a generic way to implement the IngesterBuilder interface.
+// This can't be truly generic to every config as IngesterBuilder.Build does break standards and returns an interface.
+// To use this a new struct can embed Builder with the same type used in Configs.
+// The Build method will need to be implemented manually. This is done to pivot the types to the interface.
+// And a NewThingBuilder method should be created as well.
 type Builder[T BuilderConfig] struct {
 	config  T
 	kind    string

--- a/ingesters/hosted/plugins/config.go
+++ b/ingesters/hosted/plugins/config.go
@@ -12,6 +12,7 @@ package plugins
 
 import (
 	"fmt"
+	"iter"
 
 	"github.com/google/uuid"
 	"github.com/gravwell/gravwell/v3/ingesters/hosted"
@@ -73,73 +74,31 @@ func (c Configs) IngesterCount() (count int) {
 type NewIngesterCallback func(id, name string, runner hosted.Runner) error
 type NewRuntimeCallback func(id, name string, ingesterUUID uuid.UUID) (hosted.Runtime, error)
 
-func (c Configs) ForEachIngester(tn hosted.TagNegotiator, nrt NewRuntimeCallback, cb NewIngesterCallback) (err error) {
-	// native tester
-	for k, v := range c.Tester {
-		// this shouldn't happen, but scream about it anyway
-		if v == nil {
-			err = fmt.Errorf("%v ingester %q has a nil config", tester.ID, k)
-			return
-		}
-		// get a new ingester
-		var ig *tester.TesterIngester
-		if ig, err = tester.NewTesterIngester(*v, tn); err != nil {
-			err = fmt.Errorf("failed to create new %q ingester %q: %w", tester.ID, k, err)
-			continue
-		}
-		if err = c.buildIngester(k, tester.ID, tester.Name, tester.Version, v.UUID(), ig, nrt, cb); err != nil {
-			return
-		}
-	}
-	// native Okta
-	for k, v := range c.Okta {
-		// this shouldn't happen, but scream about it anyway
-		if v == nil {
-			err = fmt.Errorf("%v ingester %q has a nil config", okta.ID, k)
-			return
-		}
-		// get a new ingester
-		var ig *okta.OktaIngester
-		if ig, err = okta.NewOktaIngester(*v, tn); err != nil {
-			err = fmt.Errorf("failed to create new %q ingester %q: %w", okta.ID, k, err)
-			continue
-		}
-		if err = c.buildIngester(k, okta.ID, okta.Name, okta.Version, v.UUID(), ig, nrt, cb); err != nil {
-			return
-		}
-	}
-	for k, v := range c.Mimecast {
-		// this shouldn't happen, but scream about it anyway
-		if v == nil {
-			err = fmt.Errorf("mimecast ingester %q has a nil config", k)
-			return
-		}
-		// get a new ingester
-		ig := mimecast.New(v)
-
-		if err = c.buildIngester(k, mimecast.ID, mimecast.Name, mimecast.Version, v.UUID(), ig, nrt, cb); err != nil {
-			return
-		}
-	}
-	return
+type IngesterBuilder interface {
+	UUID() uuid.UUID
+	Kind() string
+	ID() string
+	Version() string
+	Build(hosted.TagNegotiator) (hosted.Ingester, error)
+	Config() any
 }
 
-func (c Configs) buildIngester(name, id, kind, ver string, ingesterUUID uuid.UUID, ig hosted.Ingester, nrt NewRuntimeCallback, cb NewIngesterCallback) (err error) {
-	//create a new runtime for this ingester
-	var rt hosted.Runtime
-	if rt, err = nrt(kind, name, ingesterUUID); err != nil {
-		err = fmt.Errorf("failed to create new runtime for %s ingester %q: %w", kind, name, err)
-		return
+func (c Configs) Builders() iter.Seq2[string, IngesterBuilder] {
+	return func(yield func(string, IngesterBuilder) bool) {
+		for name, config := range c.Tester {
+			if !yield(name, NewTesterBuilder(config, tester.Name, tester.ID, tester.Version)) {
+				return
+			}
+		}
+		for name, config := range c.Okta {
+			if !yield(name, NewOktaBuilder(config, okta.Name, okta.ID, okta.Version)) {
+				return
+			}
+		}
+		for name, config := range c.Mimecast {
+			if !yield(name, NewMimecastBuilder(config, mimecast.Name, mimecast.ID, mimecast.Version)) {
+				return
+			}
+		}
 	}
-	// create a new hosted native runner
-	var runner *hosted.NativeRunner
-	if runner, err = hosted.NewNativeRunner(id, name, ver, ingesterUUID, ig, rt); err != nil {
-		err = fmt.Errorf("failed to create new native %s runner %w", kind, err)
-		runner = nil
-		return
-	}
-
-	// create the ingester and ask for the runtime associated with this ingester uuid
-	err = cb(kind, name, runner)
-	return
 }

--- a/ingesters/hosted/plugins/config.go
+++ b/ingesters/hosted/plugins/config.go
@@ -71,9 +71,6 @@ func (c Configs) IngesterCount() (count int) {
 	return
 }
 
-type NewIngesterCallback func(id, name string, runner hosted.Runner) error
-type NewRuntimeCallback func(id, name string, ingesterUUID uuid.UUID) (hosted.Runtime, error)
-
 type IngesterBuilder interface {
 	UUID() uuid.UUID
 	Kind() string

--- a/ingesters/hosted/plugins/config.go
+++ b/ingesters/hosted/plugins/config.go
@@ -33,19 +33,29 @@ type Configs struct {
 func (c Configs) Verify() (err error) {
 	// verify Okta configs
 	for k, v := range c.Okta {
-		if v != nil {
-			if err = v.Verify(); err != nil {
-				err = fmt.Errorf("Okta config %q failed validation %w", k, err)
-				return
-			}
+		if v == nil {
+			err = fmt.Errorf("Okta config %q is nil", k)
+			return
+		}
+		if err = v.Verify(); err != nil {
+			err = fmt.Errorf("Okta config %q failed validation %w", k, err)
+			return
+		}
+	}
+	for k, v := range c.Tester {
+		if v == nil {
+			err = fmt.Errorf("Tester config %q is nil", k)
+			return
 		}
 	}
 	for k, v := range c.Mimecast {
-		if v != nil {
-			if err = v.Verify(); err != nil {
-				err = fmt.Errorf("Mimecast config %q failed validation %w", k, err)
-				return
-			}
+		if v == nil {
+			err = fmt.Errorf("Mimecast config %q is nil", k)
+			return
+		}
+		if err = v.Verify(); err != nil {
+			err = fmt.Errorf("Mimecast config %q failed validation %w", k, err)
+			return
 		}
 	}
 	return

--- a/ingesters/hosted/plugins/config.go
+++ b/ingesters/hosted/plugins/config.go
@@ -90,6 +90,9 @@ type IngesterBuilder interface {
 	Config() any
 }
 
+// Builders returns an iter.Seq2 for use in iterating over each of configured plugins generically.
+// The intention is to not couple the plugins to directly to the runtime or runner.
+// Any new plugins MUST add another loop here returning an IngesterBuilder for each config entry.
 func (c Configs) Builders() iter.Seq2[string, IngesterBuilder] {
 	return func(yield func(string, IngesterBuilder) bool) {
 		for name, config := range c.Tester {

--- a/ingesters/hosted/plugins/mimecast/client.go
+++ b/ingesters/hosted/plugins/mimecast/client.go
@@ -1,3 +1,11 @@
+/*************************************************************************
+ * Copyright 2026 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
 package mimecast
 
 import (

--- a/ingesters/hosted/plugins/mimecast/client_test.go
+++ b/ingesters/hosted/plugins/mimecast/client_test.go
@@ -1,3 +1,11 @@
+/*************************************************************************
+ * Copyright 2026 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
 package mimecast
 
 import (

--- a/ingesters/hosted/plugins/mimecast/config.go
+++ b/ingesters/hosted/plugins/mimecast/config.go
@@ -1,3 +1,11 @@
+/*************************************************************************
+ * Copyright 2026 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
 package mimecast
 
 import (

--- a/ingesters/hosted/plugins/mimecast/events.go
+++ b/ingesters/hosted/plugins/mimecast/events.go
@@ -1,3 +1,11 @@
+/*************************************************************************
+ * Copyright 2026 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
 package mimecast
 
 import (

--- a/ingesters/hosted/plugins/mimecast/mimecast.go
+++ b/ingesters/hosted/plugins/mimecast/mimecast.go
@@ -1,3 +1,11 @@
+/*************************************************************************
+ * Copyright 2026 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
 // Package mimecast is a plugin used for reading data from Mimecast audit logs.
 // It supports both SIEM MTA logs, and general audit logs.
 package mimecast

--- a/ingesters/hosted/runner/config.go
+++ b/ingesters/hosted/runner/config.go
@@ -9,13 +9,10 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/gravwell/gravwell/v3/ingest/attach"
 	"github.com/gravwell/gravwell/v3/ingest/config"
 	"github.com/gravwell/gravwell/v3/ingesters/hosted/storage"
 
-	"github.com/gravwell/gravwell/v3/ingesters/hosted"
 	"github.com/gravwell/gravwell/v3/ingesters/hosted/plugins"
 )
 
@@ -63,19 +60,4 @@ func (c cfgType) AttachConfig() attach.AttachConfig {
 // IngesterBaseConfig implements the required interface for base.cfgHelper which is used during startup
 func (c cfgType) IngestBaseConfig() config.IngestConfig {
 	return c.Global
-}
-
-func (c cfgType) forEachIngester(tn hosted.TagNegotiator, nrt plugins.NewRuntimeCallback, cb plugins.NewIngesterCallback) (err error) {
-	if tn == nil {
-		err = fmt.Errorf("nil tag negotiator")
-		return
-	} else if nrt == nil {
-		err = fmt.Errorf("nil new runtime function")
-		return
-	} else if cb == nil {
-		err = fmt.Errorf("nil new ingester callback")
-		return
-	}
-	err = c.Configs.ForEachIngester(tn, nrt, cb)
-	return
 }

--- a/ingesters/hosted/runner/main.go
+++ b/ingesters/hosted/runner/main.go
@@ -90,7 +90,7 @@ func main() {
 	}
 
 	// Fire up native hosted ingesters first
-	if err = rm.createIngesters(cfg, ib); err != nil {
+	if err = rm.createRunners(cfg, ib); err != nil {
 		rm.stop()  // best effort close
 		sh.Close() // ignore return, but no writes should have occurred
 		ib.Logger.FatalCode(1, "failed to create ingesters", log.KVErr(err))

--- a/ingesters/hosted/runner/manager.go
+++ b/ingesters/hosted/runner/manager.go
@@ -71,8 +71,8 @@ func (rm *runtimeManager) stop() (err error) {
 }
 
 func (rm *runtimeManager) createRunners(c *cfgType, ib base.IngesterBase) (err error) {
-	if rm == nil {
-		return fmt.Errorf("nil runtime manager")
+	if c == nil {
+		return fmt.Errorf("nil config, can't create runners")
 	}
 	for name, builder := range c.Builders() {
 		var ig hosted.Ingester

--- a/ingesters/hosted/runner/manager.go
+++ b/ingesters/hosted/runner/manager.go
@@ -71,6 +71,9 @@ func (rm *runtimeManager) stop() (err error) {
 }
 
 func (rm *runtimeManager) createRunners(c *cfgType, ib base.IngesterBase) (err error) {
+	if rm == nil {
+		return fmt.Errorf("nil runtime manager")
+	}
 	for name, builder := range c.Builders() {
 		var ig hosted.Ingester
 		if ig, err = builder.Build(rm.igst); err != nil {

--- a/ingesters/hosted/runner/manager.go
+++ b/ingesters/hosted/runner/manager.go
@@ -70,6 +70,37 @@ func (rm *runtimeManager) stop() (err error) {
 	return
 }
 
+func (rm *runtimeManager) createRunners(c *cfgType, ib base.IngesterBase) (err error) {
+	for name, builder := range c.Builders() {
+		var ig hosted.Ingester
+		if ig, err = builder.Build(rm.igst); err != nil {
+			return fmt.Errorf("failed to build %s plugin %s: %w", builder.Kind(), name, err)
+		}
+		rt, err := rm.createNativeRuntime(builder.Kind(), name, builder.UUID())
+		if err != nil {
+			return fmt.Errorf("failed to create runtime for %s plugin %s: %w", builder.Kind(), name, err)
+		}
+		runner, err := hosted.NewNativeRunner(builder.ID(), name, builder.Version(), builder.UUID(), ig, rt)
+		if err != nil {
+			return fmt.Errorf("failed to create runner for %s plugin %s: %w", builder.Kind(), name, err)
+		}
+		if existing, exists := rm.mp[builder.UUID()]; exists {
+			ib.Logger.Error("hosted runner UUID collision",
+				log.KV("existing-uuid", existing.UUID()),
+				log.KV("colliding-type", existing.ID()),
+				log.KV("colliding-name", name),
+				log.KV("colliding-uuid", builder.UUID()))
+			continue // just skip it
+		}
+		rm.mp[builder.UUID()] = wrappedRunner{Runner: runner}
+		// TODO(2073): Register individual plugins as child ingesters
+		//rm.igst.RegisterChild(builder.UUID().String(), ingest.IngesterState{
+		//	Configuration:
+		//})
+	}
+	return nil
+}
+
 // createNativeRuntime creates a basic runtime that has handles on loggers, bucket writer, and the context
 func (rm *runtimeManager) createNativeRuntime(kind, name string, ingesterUUID uuid.UUID) (rt hosted.Runtime, err error) {
 	// grab a new native runtime based on the kind, name, and UUID
@@ -88,31 +119,6 @@ func (rm *runtimeManager) createNativeRuntime(kind, name string, ingesterUUID uu
 	}
 	// create the native runtime
 	rt, err = hosted.NewNativeRuntime(rm.ctx, ingesterID, bw, rm.igst, lgr)
-	return
-}
-
-// createIngesters loads up all of the ingesters specified in the config and then goes after any ingesters that may
-// have been pulled
-func (rm *runtimeManager) createIngesters(cfg *cfgType, ib base.IngesterBase) (err error) {
-	// load up the native ingesters
-	err = cfg.forEachIngester(rm.igst, rm.createNativeRuntime, func(name, id string, runner hosted.Runner) error {
-		ingesterUUID := runner.UUID()
-		if existing, ok := rm.mp[ingesterUUID]; ok {
-			ib.Logger.Error("hosted ingester UUID collision",
-				log.KV("existing-uuid", existing.UUID()),
-				log.KV("colliding-type", existing.ID()),
-				log.KV("colliding-name", name),
-				log.KV("colliding-uuid", ingesterUUID))
-			return nil // just skip it
-		}
-
-		wr := wrappedRunner{
-			Runner: runner,
-		}
-		rm.mp[ingesterUUID] = wr
-		return nil
-	})
-
 	return
 }
 

--- a/ingesters/hosted/storage/storage.go
+++ b/ingesters/hosted/storage/storage.go
@@ -1,3 +1,11 @@
+/*************************************************************************
+ * Copyright 2026 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
 // Package storage contains implementations of the storage interface for hosted runtimes.
 package storage
 

--- a/tools/mock/mimecast/main.go
+++ b/tools/mock/mimecast/main.go
@@ -1,3 +1,11 @@
+/*************************************************************************
+ * Copyright 2026 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
 package main
 
 import (

--- a/tools/mock/mimecast/store.go
+++ b/tools/mock/mimecast/store.go
@@ -1,3 +1,11 @@
+/*************************************************************************
+ * Copyright 2026 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
 package main
 
 import (


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses gravwell/issues#1965

## This PR proposes...

Refactoring the creation and startup of hosted ingesters/runners to reduce the use of callbacks in favor of iterators for a more flexible and "linear" logical startup. The individual callbacks were passed around and it wasn't really clear what was actually responsible for what. Now the plugins are responsible for providing a consistent interface for building and the manager handles everything else. 

## PR Tasks

<!-- Add tasks to this list as needed -->

- [x] e2e and/or unit tests included. If not, please provide an explanation.
- [x] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
