### PR TITLE
fix(#2257): do not clobber unchanged values while editting

### DIFF
--- a/gwcli/start_delve.sh
+++ b/gwcli/start_delve.sh
@@ -15,4 +15,4 @@
 #
 #!/bin/bash
 
-dlv debug --headless --api-version=2 --listen=127.0.0.1:43000 . -- -u admin --insecure
+dlv debug --headless --api-version=2 --listen=127.0.0.1:43000 . -- "$@"

--- a/gwcli/tree/admin/users/users.go
+++ b/gwcli/tree/admin/users/users.go
@@ -212,7 +212,7 @@ func edit() action.Pair {
 				return descriptionLine(item.Admin, item.Email)
 			},
 			UpdateSub: func(data *types.User) (identifier string, err error) {
-				return strconv.FormatInt(int64(data.ID), 10), connection.Client.UpdateUser(*data)
+				return data.Name, connection.Client.UpdateUser(*data)
 			},
 		},
 	)

--- a/gwcli/tree/extractors/extractors.go
+++ b/gwcli/tree/extractors/extractors.go
@@ -448,7 +448,7 @@ func edit() action.Pair {
 
 					clilog.Writer.Warn("extractor update caused warnings", params...)
 				}
-				return data.ID, nil
+				return data.Name, nil
 			},
 		},
 	)

--- a/gwcli/tree/resources/resources.go
+++ b/gwcli/tree/resources/resources.go
@@ -301,13 +301,7 @@ func edit() action.Pair {
 			return item.Description
 		},
 		UpdateSub: func(data *types.Resource) (identifier string, err error) {
-			err = connection.Client.UpdateResourceMetadata(data.ID, types.Resource{
-				CommonFields: types.CommonFields{
-					Name:        data.Name,
-					Description: data.Description,
-				},
-			})
-			return data.ID, err
+			return data.ID, connection.Client.UpdateResourceMetadata(data.ID, *data)
 		},
 	})
 }

--- a/gwcli/tree/resources/resources.go
+++ b/gwcli/tree/resources/resources.go
@@ -301,7 +301,7 @@ func edit() action.Pair {
 			return item.Description
 		},
 		UpdateSub: func(data *types.Resource) (identifier string, err error) {
-			return data.ID, connection.Client.UpdateResourceMetadata(data.ID, *data)
+			return data.Name, connection.Client.UpdateResourceMetadata(data.ID, *data)
 		},
 	})
 }

--- a/gwcli/tree/secrets/secrets.go
+++ b/gwcli/tree/secrets/secrets.go
@@ -216,13 +216,14 @@ func edit() action.Pair {
 			return item.Description
 		},
 		UpdateSub: func(data *types.Secret) (identifier string, err error) {
-			s, err := connection.Client.UpdateSecret(data.ID, types.SecretCreate{
-				CommonFields: types.CommonFields{
-					Name:        data.Name,
-					Description: data.Description,
-					Labels:      data.Labels,
-				},
-			})
+			// build the secret create off the selected secret; update only what can be set
+			var sc types.SecretCreate
+			sc.CommonFields = data.CommonFields
+			sc.CommonFields.Name = data.Name
+			sc.CommonFields.Description = data.Description
+			sc.CommonFields.Labels = data.Labels
+
+			s, err := connection.Client.UpdateSecret(data.ID, sc)
 			return s.ID, err
 		},
 	})

--- a/gwcli/tree/secrets/secrets.go
+++ b/gwcli/tree/secrets/secrets.go
@@ -224,7 +224,7 @@ func edit() action.Pair {
 			sc.CommonFields.Labels = data.Labels
 
 			s, err := connection.Client.UpdateSecret(data.ID, sc)
-			return s.ID, err
+			return s.Name, err
 		},
 	})
 }

--- a/gwcli/utilities/scaffold/scaffoldedit/edit.go
+++ b/gwcli/utilities/scaffold/scaffoldedit/edit.go
@@ -75,8 +75,9 @@ import (
 )
 
 const (
-	listHeightMax  = 40 // lines
-	successStringF = "successfully updated %v %v"
+	listHeightMax   = 40 // lines
+	successStringF  = "successfully updated %v %v"
+	initialMinWidth = 20 // lower clamp for startup width
 )
 
 // NewEditAction composes a usable edit action, returning its action pair.
@@ -338,13 +339,14 @@ func (em *editModel[I, S]) SetArgs(fs *pflag.FlagSet, tokens []string, width, he
 		itms[i] = item{em.funcs.GetTitleSub(s), em.funcs.GetDescriptionSub(s)}
 	}
 
+	// cache term size, apply a minimum on width to ensure everything is rendered
+	em.width = max(width, initialMinWidth)
+	em.height = height
+
 	// generate list
-	em.list = stylesheet.NewList(itms, 80, listHeightMax, em.singular, em.plural)
+	em.list = stylesheet.NewList(itms, em.width, em.height, em.singular, em.plural)
 	em.listInitialized = true
 	em.mode = selecting
-
-	em.width = width
-	em.height = height
 
 	return "", nil, nil
 }
@@ -355,7 +357,8 @@ func (em *editModel[I, S]) Update(msg tea.Msg) tea.Cmd {
 		em.height = wsMsg.Height
 		// if we skipped directly to edit mode, list will be nil
 		if em.listInitialized {
-			em.list.SetHeight(min(wsMsg.Height-2, listHeightMax))
+			em.list.SetHeight(min(wsMsg.Height-6, listHeightMax))
+			em.list.SetWidth(em.width)
 		}
 	} else if _, ok := msg.(tea.KeyMsg); ok {
 		em.updateErr = ""

--- a/gwcli/utilities/scaffold/scaffoldedit/subroutines.go
+++ b/gwcli/utilities/scaffold/scaffoldedit/subroutines.go
@@ -46,11 +46,14 @@ type SetFieldSubroutine[S any] func(item *S, fieldKey, val string) (
 )
 
 // UpdateStructSubroutine defines the function that performs the actual update of the data on the GW instance.
-// The error returned by this subroutine does not kill the action, instead displaying to the user.
+//
+// itemTitle is just identification text displayed on success to notify the user that their selected item was updated.
+// Unless there is a specific need, it should be whatever is returned by GetTitle.
+//
+// The error returned by this subroutine does not kill the action (in interactive mode),
+// instead displaying it to the user and returning to edit mode.
 // In that way, it is closer to an invalid, even though validation errors are assumed to be caught by the SetField sub.
-type UpdateStructSubroutine[S any] func(data *S) (
-	identifier string, err error,
-)
+type UpdateStructSubroutine[S any] func(data *S) (itemTitle string, err error)
 
 // SubroutineSet defines the set of all subroutines required by an implementation of an edit action.
 //


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses https://github.com/gravwell/gravwell/issues/2257

## This PR ensures that all updates made by edit actions provide the complete data set, rather than just what was updated

A couple of actions attempted to update registry using only the updated data, causing registry to clobber untouched values with empty values. This PR fixes that across the board.

## Other fixes

This PR also includes a convenience fix, a tangentially-related fix, and a visual improvement (in that order):

- The `start_delve` command to spin up a headless delve instance for debugging BubbleTea now passes its arguments to gwcli so the script doesn't have to be edited every time I want to test something different.
- edit actions could sometimes fail to list the editable items. This PR fixes that by guaranteeing a default startup width for the list renderer.
- edit actions now state the name of the item that was updated, rather than the ID. A user is less likely to have interacted with an ID during the edit action as IDs are not modifiable. 

## PR Tasks

<!-- Add tasks to this list as needed -->

- [x] e2e and/or unit tests included. If not, please provide an explanation.
- [x] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
