### PR TITLE
Implement changes for alerts in the registry

### DIFF
--- a/client/alerts.go
+++ b/client/alerts.go
@@ -39,30 +39,6 @@ func (c *Client) ListAllAlerts(opts *types.QueryOptions) (result types.AlertList
 	return
 }
 
-// GetAlertsByDispatcher returns a list of alerts who refer to the specified dispatcher.
-// dispatcherID should be the *ID* of the a scheduled search, not the *GUID*.
-// Basically, this lets you ask: which alerts will be invoked by *this specific scheduled search*.
-// func (c *Client) GetAlertsByDispatcher(dispatcherID string, dispatcherType types.AlertDispatcherType) (result []types.Alert, err error) {
-// 	c.qm.set("dispatcher", dispatcherID)
-// 	c.qm.set("type", string(dispatcherType))
-// 	err = c.getStaticURL(alertsUrl(), &result)
-// 	c.qm.remove("type")
-// 	c.qm.remove("dispatcher")
-// 	return
-// }
-
-// GetAlertsByConsumer returns a list of alerts who refer to the specified consumer.
-// consumerID should be the *ID* of the a flow, not the *GUID*.
-// Basically, this lets you ask: which alerts will launch *this specific flow*.
-// func (c *Client) GetAlertsByConsumer(consumerID string, consumerType types.AlertConsumerType) (result []types.Alert, err error) {
-// 	c.qm.set("consumer", consumerID)
-// 	c.qm.set("type", string(consumerType))
-// 	err = c.getStaticURL(alertsUrl(), &result)
-// 	c.qm.remove("type")
-// 	c.qm.remove("consumer")
-// 	return
-// }
-
 // GetAlert returns the definition for a specific alert.
 func (c *Client) GetAlert(id string) (result types.Alert, err error) {
 	err = c.getStaticURL(alertsIdUrl(id), &result)

--- a/client/alerts.go
+++ b/client/alerts.go
@@ -11,72 +11,96 @@ package client
 import (
 	"net/http"
 
-	"github.com/google/uuid"
 	"github.com/gravwell/gravwell/v4/client/types"
 )
 
-// NewAlert creates a new alert.
-func (c *Client) NewAlert(def types.AlertDefinition) (result types.AlertDefinition, err error) {
+// CreateAlert creates a new alert.
+func (c *Client) CreateAlert(def types.Alert) (result types.Alert, err error) {
 	err = c.methodStaticPushURL(http.MethodPost, alertsUrl(), def, &result, nil, nil)
 	return
 }
 
-// GetAlerts returns a list of alerts the user has access to.
-// As admin, set the admin flag (c.SetAdminMode) to get a list of all alerts
-// on the system.
-func (c *Client) GetAlerts() (result []types.AlertDefinition, err error) {
-	err = c.getStaticURL(alertsUrl(), &result)
+// ListAlerts returns a list of alerts the user has access to.
+func (c *Client) ListAlerts(opts *types.QueryOptions) (result types.AlertListResponse, err error) {
+	if opts == nil {
+		opts = &types.QueryOptions{}
+	}
+	err = c.postStaticURL(ALERTS_LIST_URL, opts, &result)
+	return
+}
+
+// ListAllAlerts (admin-only) returns all alerts on the system.
+func (c *Client) ListAllAlerts(opts *types.QueryOptions) (result types.AlertListResponse, err error) {
+	if opts == nil {
+		opts = &types.QueryOptions{}
+	}
+	opts.AdminMode = true
+	err = c.postStaticURL(ALERTS_LIST_URL, opts, &result)
 	return
 }
 
 // GetAlertsByDispatcher returns a list of alerts who refer to the specified dispatcher.
 // dispatcherID should be the *ID* of the a scheduled search, not the *GUID*.
 // Basically, this lets you ask: which alerts will be invoked by *this specific scheduled search*.
-func (c *Client) GetAlertsByDispatcher(dispatcherID string, dispatcherType types.AlertDispatcherType) (result []types.AlertDefinition, err error) {
-	c.qm.set("dispatcher", dispatcherID)
-	c.qm.set("type", string(dispatcherType))
-	err = c.getStaticURL(alertsUrl(), &result)
-	c.qm.remove("type")
-	c.qm.remove("dispatcher")
-	return
-}
+// func (c *Client) GetAlertsByDispatcher(dispatcherID string, dispatcherType types.AlertDispatcherType) (result []types.Alert, err error) {
+// 	c.qm.set("dispatcher", dispatcherID)
+// 	c.qm.set("type", string(dispatcherType))
+// 	err = c.getStaticURL(alertsUrl(), &result)
+// 	c.qm.remove("type")
+// 	c.qm.remove("dispatcher")
+// 	return
+// }
 
 // GetAlertsByConsumer returns a list of alerts who refer to the specified consumer.
 // consumerID should be the *ID* of the a flow, not the *GUID*.
 // Basically, this lets you ask: which alerts will launch *this specific flow*.
-func (c *Client) GetAlertsByConsumer(consumerID string, consumerType types.AlertConsumerType) (result []types.AlertDefinition, err error) {
-	c.qm.set("consumer", consumerID)
-	c.qm.set("type", string(consumerType))
-	err = c.getStaticURL(alertsUrl(), &result)
-	c.qm.remove("type")
-	c.qm.remove("consumer")
-	return
-}
+// func (c *Client) GetAlertsByConsumer(consumerID string, consumerType types.AlertConsumerType) (result []types.Alert, err error) {
+// 	c.qm.set("consumer", consumerID)
+// 	c.qm.set("type", string(consumerType))
+// 	err = c.getStaticURL(alertsUrl(), &result)
+// 	c.qm.remove("type")
+// 	c.qm.remove("consumer")
+// 	return
+// }
 
-// GetAlert returns the definition for a specific alert. The id passed can be
-// either a ThingUUID, which will always return a specific alert, or a GUID, in
-// which case the webserver will attempt to resolve the "most appropriate" alert
-// with that GUID.
-func (c *Client) GetAlert(id uuid.UUID) (result types.AlertDefinition, err error) {
+// GetAlert returns the definition for a specific alert.
+func (c *Client) GetAlert(id string) (result types.Alert, err error) {
 	err = c.getStaticURL(alertsIdUrl(id), &result)
 	return
 }
 
-// UpdateAlert modifies an alert. Make sure to have ThingUUID set, as this is used to resolve
-// the appropriate alert to modify.
-func (c *Client) UpdateAlert(def types.AlertDefinition) (result types.AlertDefinition, err error) {
-	err = c.methodStaticPushURL(http.MethodPut, alertsIdUrl(def.ThingUUID), def, &result, nil, nil)
+// GetAlertEx returns the definition for a specific alert, applying
+// parameters from QueryOptions if appropriate. Currently only
+// IncludeDeleted is supported.
+func (c *Client) GetAlertEx(id string, opts *types.QueryOptions) (result types.Alert, err error) {
+	if opts == nil {
+		opts = &types.QueryOptions{}
+	}
+	err = c.getStaticURL(alertsIdUrl(id), &result, ezParam("include_deleted", opts.IncludeDeleted))
 	return
 }
 
-// DeleteAlert deletes an alert. The id must be the ThingUUID, for precision.
-func (c *Client) DeleteAlert(id uuid.UUID) (err error) {
+// UpdateAlert modifies an alert. Make sure to have ID set, as this is used to resolve
+// the appropriate alert to modify.
+func (c *Client) UpdateAlert(def types.Alert) (result types.Alert, err error) {
+	err = c.methodStaticPushURL(http.MethodPut, alertsIdUrl(def.ID), def, &result, nil, nil)
+	return
+}
+
+// DeleteAlert marks an alert as deleted.
+func (c *Client) DeleteAlert(id string) (err error) {
 	err = c.deleteStaticURL(alertsIdUrl(id), nil)
 	return
 }
 
+// PurgeAlert deletes an alert completely from the database
+func (c *Client) PurgeAlert(id string) (err error) {
+	err = c.deleteStaticURL(alertsIdUrl(id), nil, ezParam("purge", "true"))
+	return
+}
+
 // GetAlertSampleEvent asks the webserver to generate a sample event for the given alert.
-func (c *Client) GetAlertSampleEvent(id uuid.UUID) (result types.Event, err error) {
+func (c *Client) GetAlertSampleEvent(id string) (result types.Event, err error) {
 	err = c.getStaticURL(alertsIdSampleEventUrl(id), &result)
 	return
 }
@@ -100,7 +124,7 @@ func (c *Client) ValidateAlertScheduledSearchDispatcher(ssearchID string, schema
 // ValidateAlertFlowConsumer validates an existing flow against
 // a given alert, making sure it does not consume any fields not
 // provided by the schema.
-func (c *Client) ValidateAlertFlowConsumer(flowID string, alert types.AlertDefinition) (resp types.AlertConsumerValidateResponse, err error) {
+func (c *Client) ValidateAlertFlowConsumer(flowID string, alert types.Alert) (resp types.AlertConsumerValidateResponse, err error) {
 	// build the request
 	req := types.AlertConsumerValidateRequest{
 		Consumer: types.AlertConsumer{
@@ -112,4 +136,9 @@ func (c *Client) ValidateAlertFlowConsumer(flowID string, alert types.AlertDefin
 	err = c.methodStaticPushURL(http.MethodPost, alertsValidateConsumerUrl(), req, &resp, nil, nil)
 	return
 
+}
+
+// CleanupAlerts (admin-only) purges all deleted alerts for all users.
+func (c *Client) CleanupAlerts() error {
+	return c.deleteStaticURL(ALERTS_URL, nil)
 }

--- a/client/types/alert.go
+++ b/client/types/alert.go
@@ -10,9 +10,6 @@ package types
 
 import (
 	"encoding/json"
-	"time"
-
-	"github.com/google/uuid"
 )
 
 // AlertConsumerType : Possible types for an Alert Consumer
@@ -28,44 +25,27 @@ type AlertDispatcherType string
 
 // List of AlertDispatcherType
 const (
-	ALERTDISPATCHERTYPE_SCHEDULEDSEARCH AlertDispatcherType = "scheduledsearch"
+	ALERTDISPATCHERTYPE_SCHEDULEDSEARCH AlertDispatcherType = "scheduled_search"
 )
 
-// AlertDefinition - A Gravwell Alert specification
-type AlertDefinition struct {
-	// The actions the user is allowed to take on this definition.
-	// Derived by the backend when requested by the user; any
-	// value sent in a request will be ignored.
-	Can Actions `json:"Can"`
+// Alert - A Gravwell Alert specification
+type Alert struct {
+	CommonFields
+
+	Disabled bool `json:"Disabled"`
 
 	// A list of flows which will be run when alerts are generated.
 	Consumers []AlertConsumer `json:"Consumers"`
 
-	Description string `json:"Description"`
-
-	Disabled bool `json:"Disabled"`
-
 	// A list of things which create alerts (currently only scheduled searches).
 	Dispatchers []AlertDispatcher `json:"Dispatchers"`
 
-	GIDs []int32 `json:"GIDs"`
-
-	GUID uuid.UUID `json:"GUID"`
-
-	Global bool `json:"Global"`
-
 	IngestBlocked bool `json:"IngestBlocked"`
-
-	Labels []string `json:"Labels"`
-
-	LastUpdated time.Time `json:"LastUpdated"`
 
 	// Maximum number of events allowed per firing of the alert. This is
 	// intended as a safety valve to avoid thousands of emails. If zero,
 	// a (low) default value will be used.
 	MaxEvents int `json:"MaxEvents"`
-
-	Name string `json:"Name"`
 
 	// How long, in seconds, we should save searches which trigger this alert.
 	SaveSearchDuration int32 `json:"SaveSearchDuration"`
@@ -79,16 +59,8 @@ type AlertDefinition struct {
 	// The tag into which alerts will be ingested
 	TargetTag string `json:"TargetTag"`
 
-	ThingUUID uuid.UUID `json:"ThingUUID"`
-
-	// The owner of the Alert
-	UID int32 `json:"UID"`
-
 	// Arbitrary user-defined metadata which will be injected into the events
 	UserMetadata map[string]interface{} `json:"UserMetadata"`
-
-	// Sharing rules for this alert.
-	WriteAccess Access `json:"WriteAccess"`
 }
 
 // AlertConsumer - Something which consumes alerts.
@@ -171,7 +143,7 @@ type AlertDispatcherValidateResponse struct {
 type AlertConsumerValidateRequest struct {
 	Consumer AlertConsumer
 
-	Alert AlertDefinition
+	Alert Alert
 }
 
 // AlertConsumerValidateResponse - Indicates whether a consumer is valid for a given alert or not.
@@ -181,18 +153,23 @@ type AlertConsumerValidateResponse struct {
 	Error string
 }
 
-func (alert *AlertDefinition) JSONMetadata() (json.RawMessage, error) {
+func (alert *Alert) JSONMetadata() (json.RawMessage, error) {
 	st := &struct {
-		UUID        string
+		ID          string
 		Name        string
 		Description string
 	}{
-		UUID:        alert.GUID.String(),
+		ID:          alert.ID,
 		Name:        alert.Name,
 		Description: alert.Description,
 	}
 	b, err := json.Marshal(st)
 	return json.RawMessage(b), err
+}
+
+type AlertListResponse struct {
+	BaseListResponse
+	Results []Alert `json:"results"`
 }
 
 // FindMostRelevantAutomation resolves the appropriate automation

--- a/client/types/event.go
+++ b/client/types/event.go
@@ -50,7 +50,7 @@ type EventMetadata struct {
 	UID                int32
 	Username           string
 	Created            time.Time
-	AlertID            string // ThingUUID of the Alert
+	AlertID            string // ID of the Alert that triggered
 	AlertName          string
 	AlertActivation    string   // uniquely identify the particular activation of the alert
 	EventIndex         int      // this event's index within the dispatcher results for the alert activation
@@ -92,12 +92,12 @@ type ValidationProblem struct {
 
 // BuildEventMetadata builds up a generic EventMetadata to be used with
 // events for a specific firing of the given Alert via the given Dispatcher.
-func BuildEventMetadata(created time.Time, ud User, alertDef AlertDefinition, dispatcher EventDispatcherInfo) EventMetadata {
+func BuildEventMetadata(created time.Time, ud User, alertDef Alert, dispatcher EventDispatcherInfo) EventMetadata {
 	meta := EventMetadata{
 		UID:             ud.ID,
 		Username:        ud.Username,
 		Created:         created,
-		AlertID:         alertDef.ThingUUID.String(),
+		AlertID:         alertDef.ID,
 		AlertLabels:     alertDef.Labels,
 		AlertName:       alertDef.Name,
 		AlertActivation: uuid.New().String(),

--- a/client/types/kits.go
+++ b/client/types/kits.go
@@ -146,7 +146,7 @@ type KitBuildRequest struct {
 	Files             []uuid.UUID       `json:",omitempty"`
 	SearchLibraries   []string          `json:",omitempty"` // Saved Queries go here... compatibility for now.
 	Playbooks         []uuid.UUID       `json:",omitempty"`
-	Alerts            []uuid.UUID       `json:",omitempty"`
+	Alerts            []string          `json:",omitempty"`
 	EmbeddedItems     []KitEmbeddedItem `json:",omitempty"`
 	Icon              string            `json:",omitempty"`
 	Banner            string            `json:",omitempty"`
@@ -298,8 +298,8 @@ func (pbr *KitBuildRequest) Validate() error {
 		}
 	}
 	for i := range pbr.Alerts {
-		if pbr.Alerts[i] == uuid.Nil {
-			return errors.New("zero UUID in alert list")
+		if pbr.Alerts[i] == "" {
+			return errors.New("empty alert ID")
 		}
 	}
 

--- a/client/types/kits/reader.go
+++ b/client/types/kits/reader.go
@@ -342,7 +342,7 @@ func GetKitItem(name string, tp ItemType, rdr io.Reader) (itm types.KitItem, err
 			}
 		}
 	case Alert:
-		var def types.AlertDefinition
+		var def types.Alert
 		if err = json.NewDecoder(rdr).Decode(&def); err == nil {
 			itm.AdditionalInfo, err = def.JSONMetadata()
 		}

--- a/client/urls.go
+++ b/client/urls.go
@@ -209,6 +209,7 @@ const (
 	CBAC_DEFAULT_CAPABILITIES_URL    = `/api/cbac/default/capabilities`
 	CBAC_DEFAULT_TAGS_URL            = `/api/cbac/default/tags`
 	ALERTS_URL                       = `/api/alerts`
+	ALERTS_LIST_URL                  = `/api/alerts/list`
 	ALERTS_ID_URL                    = `/api/alerts/%s`
 	ALERTS_ID_SAMPLE_URL             = `/api/alerts/%s/sample`
 	ALERTS_VALIDATE_DISPATCHER_URL   = `/api/alerts/validate/dispatcher`
@@ -703,12 +704,12 @@ func alertsUrl() string {
 	return ALERTS_URL
 }
 
-func alertsIdUrl(id uuid.UUID) string {
-	return fmt.Sprintf(ALERTS_ID_URL, id.String())
+func alertsIdUrl(id string) string {
+	return fmt.Sprintf(ALERTS_ID_URL, id)
 }
 
-func alertsIdSampleEventUrl(id uuid.UUID) string {
-	return fmt.Sprintf(ALERTS_ID_SAMPLE_URL, id.String())
+func alertsIdSampleEventUrl(id string) string {
+	return fmt.Sprintf(ALERTS_ID_SAMPLE_URL, id)
 }
 
 func alertsValidateDispatcherUrl() string {

--- a/gwcli/tree/alerts/alerts.go
+++ b/gwcli/tree/alerts/alerts.go
@@ -12,11 +12,9 @@ package alerts
 import (
 	"fmt"
 	"slices"
-	"strconv"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/google/uuid"
 	"github.com/gravwell/gravwell/v4/client/types"
 	"github.com/gravwell/gravwell/v4/gwcli/action"
 	"github.com/gravwell/gravwell/v4/gwcli/clilog"
@@ -59,16 +57,35 @@ func alertsList() action.Pair {
 		long  string = "lists alerts associated to your user. If admin mode is active, returns all alerts for all users."
 	)
 
-	return scaffoldlist.NewListAction(short, long, types.AlertDefinition{},
-		func(fs *pflag.FlagSet) ([]types.AlertDefinition, error) {
+	return scaffoldlist.NewListAction(short, long, types.Alert{},
+		func(fs *pflag.FlagSet) ([]types.Alert, error) {
 			if listConsumerID != "" {
-				return connection.Client.GetAlertsByConsumer(listConsumerID, types.ALERTCONSUMERTYPE_FLOW) // there is currently only 1 type
+				resp, err := connection.Client.ListAlerts(&types.QueryOptions{
+					Filters: []types.Filter{
+						types.Filter{
+							Key:       "Consumers.ID",
+							Operation: "=",
+							Values:    []any{listConsumerID},
+						},
+					},
+				})
+				return resp.Results, err
 
 			} else if listDispatcherID != "" {
-				return connection.Client.GetAlertsByDispatcher(listDispatcherID, types.ALERTDISPATCHERTYPE_SCHEDULEDSEARCH) // there is currently only 1 type
+				resp, err := connection.Client.ListAlerts(&types.QueryOptions{
+					Filters: []types.Filter{
+						types.Filter{
+							Key:       "Dispatchers.ID",
+							Operation: "=",
+							Values:    []any{listDispatcherID},
+						},
+					},
+				})
+				return resp.Results, err
 			}
 
-			return connection.Client.GetAlerts()
+			resp, err := connection.Client.ListAlerts(nil)
+			return resp.Results, err
 		},
 		scaffoldlist.Options{
 			CommonOptions: scaffold.CommonOptions{
@@ -109,17 +126,10 @@ func alertsList() action.Pair {
 }
 
 // helper function for list's ValidateArgs.
-// Tests that, if the flag was set, it is a valid uint.
 func validateListID(flagName string, fs *pflag.FlagSet) (id string, invalid string) {
 	s, err := fs.GetString(flagName)
 	if err != nil {
 		clilog.LogFlagFailedGet(flagName, err)
-	} else if s != "" {
-		if _, err := uuid.Parse(s); err == nil {
-			return "", "--" + flagName + " expects a numeric id, not a UUID"
-		} else if _, err := strconv.ParseUint(s, 10, 64); err != nil {
-			return "", "--" + flagName + " must be a valid number > 0"
-		}
 	}
 	return s, ""
 }
@@ -131,11 +141,7 @@ func toggle() action.Pair {
 		func(fs *pflag.FlagSet) (output string, addtlCmds tea.Cmd) {
 			// find the alert in question
 			id := fs.Arg(0)
-			uid, err := uuid.Parse(id)
-			if err != nil {
-				return err.Error(), nil
-			}
-			alert, err := connection.Client.GetAlert(uid)
+			alert, err := connection.Client.GetAlert(id)
 			if err != nil {
 				return err.Error(), nil
 			}
@@ -163,7 +169,7 @@ func toggle() action.Pair {
 				state = "disabled"
 			}
 
-			return fmt.Sprintf("alert '%s' (ID: %s) %s", alert.Name, uid.String(), state), nil
+			return fmt.Sprintf("alert '%s' (ID: %s) %s", alert.Name, id, state), nil
 		},
 		scaffold.BasicOptions{
 			CommonOptions: scaffold.CommonOptions{
@@ -190,26 +196,26 @@ func toggle() action.Pair {
 
 func delete() action.Pair {
 	return scaffolddelete.NewDeleteAction("alert", "alerts",
-		func(dryrun bool, id uuid.UUID) error {
+		func(dryrun bool, id string) error {
 			if dryrun {
 				_, err := connection.Client.GetAlert(id)
 				return err
 			}
 			return connection.Client.DeleteAlert(id)
 		},
-		func() ([]scaffolddelete.Item[uuid.UUID], error) {
-			alerts, err := connection.Client.GetAlerts()
+		func() ([]scaffolddelete.Item[string], error) {
+			alerts, err := connection.Client.ListAlerts(nil)
 			if err != nil {
 				return nil, err
 			}
 			// sort on name
-			slices.SortStableFunc(alerts,
-				func(a, b types.AlertDefinition) int {
+			slices.SortStableFunc(alerts.Results,
+				func(a, b types.Alert) int {
 					return strings.Compare(a.Name, b.Name)
 				})
-			var items = make([]scaffolddelete.Item[uuid.UUID], len(alerts))
-			for i, a := range alerts {
-				items[i] = scaffolddelete.NewItem(a.Name, a.Description, a.ThingUUID)
+			var items = make([]scaffolddelete.Item[string], len(alerts.Results))
+			for i, a := range alerts.Results {
+				items[i] = scaffolddelete.NewItem(a.Name, a.Description, a.ID)
 			}
 			return items, nil
 		})

--- a/gwcli/tree/alerts/alerts.go
+++ b/gwcli/tree/alerts/alerts.go
@@ -91,8 +91,8 @@ func alertsList() action.Pair {
 			CommonOptions: scaffold.CommonOptions{
 				AddtlFlags: func() *pflag.FlagSet {
 					fs := &pflag.FlagSet{}
-					fs.String("consumer", "", "Filter to alerts that refer to this consumer. Should be the ID of the a flow, not the GUID. Used to answer: which alerts will launch this specific flow")
-					fs.String("dispatcher", "", "Filter to alerts that refer to this dispatcher. Should be the ID of the a scheduled search, not the GUID. Used to answer: which alerts will be invoked by this specific scheduled search")
+					fs.String("consumer", "", "Filter to alerts that refer to this consumer. Should be the ID of the a flow. Used to answer: which alerts will launch this specific flow")
+					fs.String("dispatcher", "", "Filter to alerts that refer to this dispatcher. Should be the ID of the a scheduled search. Used to answer: which alerts will be invoked by this specific scheduled search")
 					return fs
 				},
 			},
@@ -102,12 +102,10 @@ func alertsList() action.Pair {
 				"Disabled",
 				"Consumers",
 				"Dispatchers",
-				"GUID",
-				"Global",
+				"ID",
 				"Labels",
 				"TargetTag",
-				"ThingUUID",
-				"UID",
+				"OwnerID",
 			},
 			ValidateArgs: func(fs *pflag.FlagSet) (invalid string, _ error) {
 				if listConsumerID, invalid = validateListID("consumer", fs); invalid != "" {

--- a/gwcli/tree/alerts/create/base.go
+++ b/gwcli/tree/alerts/create/base.go
@@ -125,7 +125,7 @@ func createFlagSet() *pflag.FlagSet {
 }
 
 // validateFlagValues validates the given state, returning on the first invalidity found.
-// If no invalidities are found, returns an alert definition suitable for NewAlert().
+// If no invalidities are found, it returns a validated types.Alert definition.
 func validateFlagValues(availableConsumers map[string]types.Flow, availableDispatchers map[string]types.ScheduledSearch, flagVals alertFlags) (invalid string, alert types.Alert) {
 	// check that mandatory flags have values
 	if flagVals.name == "" {

--- a/gwcli/tree/alerts/create/base.go
+++ b/gwcli/tree/alerts/create/base.go
@@ -49,12 +49,12 @@ func Action() action.Pair {
 				return
 			}
 
-			res, err := connection.Client.NewAlert(ad)
+			res, err := connection.Client.CreateAlert(ad)
 			if err != nil {
 				clilog.Tee(clilog.ERROR, c.ErrOrStderr(), "failed to create alert: "+err.Error()+"\n")
 				return
 			}
-			fmt.Fprint(c.OutOrStdout(), phrases.SuccessfullyCreatedItem("alert", res.ThingUUID.String()))
+			fmt.Fprint(c.OutOrStdout(), phrases.SuccessfullyCreatedItem("alert", res.ID))
 		},
 		treeutils.GenerateActionOptions{
 			Usage: ft.Mandatory("--name=NAME") + ft.Optional("FLAGS"),
@@ -126,10 +126,10 @@ func createFlagSet() *pflag.FlagSet {
 
 // validateFlagValues validates the given state, returning on the first invalidity found.
 // If no invalidities are found, returns an alert definition suitable for NewAlert().
-func validateFlagValues(availableConsumers map[string]types.Flow, availableDispatchers map[string]types.ScheduledSearch, flagVals alertFlags) (invalid string, alert types.AlertDefinition) {
+func validateFlagValues(availableConsumers map[string]types.Flow, availableDispatchers map[string]types.ScheduledSearch, flagVals alertFlags) (invalid string, alert types.Alert) {
 	// check that mandatory flags have values
 	if flagVals.name == "" {
-		return "you must provide a name for the new alert", types.AlertDefinition{}
+		return "you must provide a name for the new alert", types.Alert{}
 	}
 
 	// validate that all given IDs are known and transmute the IDs
@@ -137,7 +137,7 @@ func validateFlagValues(availableConsumers map[string]types.Flow, availableDispa
 	for i, ID := range flagVals.dispatcherIDs {
 		_, found := availableDispatchers[ID]
 		if !found {
-			return ID + " is not a known scheduled search", types.AlertDefinition{}
+			return ID + " is not a known scheduled search", types.Alert{}
 		}
 		dispatchers[i] = types.AlertDispatcher{
 			ID:   ID,
@@ -147,18 +147,20 @@ func validateFlagValues(availableConsumers map[string]types.Flow, availableDispa
 	consumers := make([]types.AlertConsumer, len(flagVals.consumerIDs))
 	for i, ID := range flagVals.consumerIDs {
 		if _, found := availableConsumers[ID]; !found {
-			return ID + " is not a known flow", types.AlertDefinition{}
+			return ID + " is not a known flow", types.Alert{}
 		}
 		consumers[i] = types.AlertConsumer{
 			ID:   ID,
 			Type: types.ALERTCONSUMERTYPE_FLOW,
 		}
 	}
-	return "", types.AlertDefinition{
-		Name:        flagVals.name,
-		Description: flagVals.description,
-		TargetTag:   flagVals.tag,
-		UID:         connection.CurrentUser().ID,
+	return "", types.Alert{
+		CommonFields: types.CommonFields{
+			OwnerID:     connection.CurrentUser().ID,
+			Name:        flagVals.name,
+			Description: flagVals.description,
+		},
+		TargetTag: flagVals.tag,
 
 		Consumers:          consumers,
 		Dispatchers:        dispatchers,

--- a/gwcli/tree/alerts/create/interactive.go
+++ b/gwcli/tree/alerts/create/interactive.go
@@ -104,9 +104,11 @@ func (c *createModel) Update(msg tea.Msg) tea.Cmd {
 
 				consumers = append(consumers, types.AlertConsumer{ID: cns.ID, Type: types.ALERTCONSUMERTYPE_FLOW})
 			}
-			ad := types.AlertDefinition{
-				Name:               c.metadata.name.Value(),
-				Description:        c.metadata.description.Value(),
+			ad := types.Alert{
+				CommonFields: types.CommonFields{
+					Name:        c.metadata.name.Value(),
+					Description: c.metadata.description.Value(),
+				},
 				TargetTag:          c.metadata.tag.Value(),
 				Disabled:           !c.metadata.enable,
 				MaxEvents:          int(maxEvents),
@@ -118,13 +120,13 @@ func (c *createModel) Update(msg tea.Msg) tea.Cmd {
 			}
 
 			// try to submit
-			res, err := connection.Client.NewAlert(ad)
+			res, err := connection.Client.CreateAlert(ad)
 			if err != nil {
 				c.metadata.submitErr = err.Error()
 				return nil
 			}
 			c.stage = quitting
-			return tea.Println(phrases.SuccessfullyCreatedItem("alert", res.GUID.String()))
+			return tea.Println(phrases.SuccessfullyCreatedItem("alert", res.ID))
 		} else if backToDispatchers {
 			c.stage = stageDispatchers
 			c.dispatchersModel.Undone()
@@ -187,12 +189,12 @@ func (c *createModel) SetArgs(_ *pflag.FlagSet, tokens []string, width, height i
 	}
 	// check if we can complete this request without interactivity
 	if inv, alert := validateFlagValues(availConsumers, availDispatchers, flagVals); inv == "" {
-		res, err := connection.Client.NewAlert(alert)
+		res, err := connection.Client.CreateAlert(alert)
 		if err != nil {
 			return "", nil, err
 		}
 		c.stage = quitting
-		return "", tea.Println(phrases.SuccessfullyCreatedItem("alert", res.ThingUUID.String())), nil
+		return "", tea.Println(phrases.SuccessfullyCreatedItem("alert", res.ID)), nil
 	}
 
 	// push dispatchers into their respective lists by wrapping each entry as an item

--- a/kitctl/main.go
+++ b/kitctl/main.go
@@ -498,7 +498,7 @@ func packKit(args []string) {
 				log.Fatal(err)
 			}
 		case kits.Alert:
-			var x types.AlertDefinition
+			var x types.Alert
 			if err = genericRead(wd, itm, &x); err != nil {
 				log.Fatalf("Could not read %v %v: %v", itm.Type.String(), itm.Name, err)
 			}
@@ -807,7 +807,7 @@ func unpackKitItems(wd string, rdr *kits.Reader) error {
 				return fmt.Errorf("Failed to write out %v %v: %v", tp.String(), name, err)
 			}
 		case kits.Alert:
-			var p types.AlertDefinition
+			var p types.Alert
 			if err = json.NewDecoder(rdr).Decode(&p); err != nil {
 				return fmt.Errorf("Failed to decode %v %v: %v", tp.String(), name, err)
 			}

--- a/tools/actions/kitmanager/kitwork.go
+++ b/tools/actions/kitmanager/kitwork.go
@@ -16,7 +16,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-  	"slices"
+	"slices"
 
 	"github.com/google/uuid"
 	"github.com/gravwell/gravwell/v4/client"
@@ -328,14 +328,14 @@ func getKitFlows(cli *client.Client, label string, orig types.KitBuildRequest, k
 }
 
 func getKitAlerts(cli *client.Client, label string, orig types.KitBuildRequest, kbr *types.KitBuildRequest) (err error) {
-	var alerts []types.AlertDefinition
-	if alerts, err = cli.GetAlerts(); err != nil {
+	var alerts types.AlertListResponse
+	if alerts, err = cli.ListAllAlerts(nil); err != nil {
 		err = fmt.Errorf("failed to get alerts: %w", err)
 		return
 	}
-	for _, a := range alerts {
-		if slices.Contains(a.Labels, label) || slices.Contains(orig.Alerts, a.ThingUUID) {
-			kbr.Alerts = append(kbr.Alerts, a.ThingUUID)
+	for _, a := range alerts.Results {
+		if slices.Contains(a.Labels, label) || slices.Contains(orig.Alerts, a.ID) {
+			kbr.Alerts = append(kbr.Alerts, a.ID)
 		}
 	}
 	return


### PR DESCRIPTION
Implements types and APIs for the new-style alerts in the registry.

Better listing means we can get rid of special functions to fetch all alerts with a specific consumer/dispatcher, thankfully.