### PR TITLE
feat(#1863): introduce api version checks on next major

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -246,7 +246,7 @@ func (c *Client) TestLogin() error {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
-	if err := c.CheckApiVersion(); err != nil {
+	if err := c.checkApiVersionNoLock(); err != nil {
 		return err
 	}
 
@@ -273,7 +273,7 @@ func (c *Client) LoginEx(user, pass string) (types.LoginResponse, error) {
 		return loginResp, errors.New("Invalid username")
 	}
 
-	if err := c.CheckApiVersion(); err != nil {
+	if err := c.checkApiVersionNoLock(); err != nil {
 		return loginResp, err
 	}
 
@@ -335,7 +335,7 @@ func (c *Client) MFALogin(user, pass string, authtype types.AuthType, code strin
 	if user == "" {
 		return loginResp, errors.New("Invalid username")
 	}
-	if err := c.CheckApiVersion(); err != nil {
+	if err := c.checkApiVersionNoLock(); err != nil {
 		return loginResp, err
 	}
 
@@ -393,7 +393,7 @@ func (c *Client) LoginWithAPIToken(token string) (err error) {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
-	if err := c.CheckApiVersion(); err != nil {
+	if err := c.checkApiVersionNoLock(); err != nil {
 		return err
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -112,22 +112,6 @@ func New(server string, enforceCertificate, useHttps bool) (*Client, error) {
 	return NewOpts(opts)
 }
 
-// NewClient connects to the specified server and returns a new Client object.
-// The useHttps parameter enables or disables SSL.
-// Setting enforceCertificate to false will disable SSL certificate validation,
-// allowing self-signed certs.
-//
-// Deprecated: Use New() or NewOpts() instead
-func NewClient(server string, enforceCertificate, useHttps bool, objLogger objlog.ObjLog) (*Client, error) {
-	opts := Opts{
-		Server:                 server,
-		InsecureNoEnforceCerts: !enforceCertificate,
-		UseHttps:               useHttps,
-		ObjLogger:              objLogger,
-	}
-	return NewOpts(opts)
-}
-
 func NewOpts(opts Opts) (*Client, error) {
 	var wsScheme string
 	var httpScheme string

--- a/client/client.go
+++ b/client/client.go
@@ -246,6 +246,10 @@ func (c *Client) TestLogin() error {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
+	if err := c.CheckApiVersion(); err != nil {
+		return err
+	}
+
 	return c.getStaticURL(TEST_AUTH_URL, nil)
 }
 
@@ -267,6 +271,10 @@ func (c *Client) LoginEx(user, pass string) (types.LoginResponse, error) {
 	}
 	if user == "" {
 		return loginResp, errors.New("Invalid username")
+	}
+
+	if err := c.CheckApiVersion(); err != nil {
+		return loginResp, err
 	}
 
 	//build up URL we are going to throw at
@@ -327,6 +335,9 @@ func (c *Client) MFALogin(user, pass string, authtype types.AuthType, code strin
 	if user == "" {
 		return loginResp, errors.New("Invalid username")
 	}
+	if err := c.CheckApiVersion(); err != nil {
+		return loginResp, err
+	}
 
 	//build up URL we are going to throw at
 	uri := fmt.Sprintf("%s://%s%s", c.httpScheme, c.server, MFA_LOGIN_URL)
@@ -381,6 +392,11 @@ func (c *Client) MFALogin(user, pass string, authtype types.AuthType, code strin
 func (c *Client) LoginWithAPIToken(token string) (err error) {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
+
+	if err := c.CheckApiVersion(); err != nil {
+		return err
+	}
+
 	c.token = token
 	c.hm.add(apiTokenHeader, token)
 	//assume we are logged in and test

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -15,6 +15,7 @@ import (
 	"net"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/gravwell/gravwell/v4/client"
 	"github.com/gravwell/gravwell/v4/client/types"
@@ -128,34 +129,46 @@ func TestAPIVersionCheck(t *testing.T) {
 		}
 	})
 	go srv.Serve(l)
-	defer srv.Shutdown(context.Background())
+	defer srv.Shutdown(t.Context())
 
 	c, err := client.NewOpts(client.Opts{Server: l.Addr().String()})
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// use a short timeout window, as we don't actually care about anything past the version check.
+	c.SetRequestTimeout(100 * time.Millisecond)
+
 	tests := []struct {
-		name      string
-		major     uint32
-		minor     uint32
-		wantError bool
+		name             string
+		major            uint32
+		minor            uint32
+		wantVersionError bool
 	}{
 		{"exact match major and minor", types.API_VERSION_MAJOR, types.API_VERSION_MINOR, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+
 			// test bare API check
-			if err := c.CheckApiVersion(); (err != nil) != tt.wantError {
-				t.Fatalf("unexpected error state. Wanted Error? %v | Actual Error: %v", tt.wantError, err)
+			if err := c.CheckApiVersion(); errors.Is(err, types.ErrVersionMismatch{}) != tt.wantVersionError {
+				t.Fatalf("unexpected error state. Wanted version error? %v | Actual error: %v", tt.wantVersionError, err)
 			}
+
 			// test u/p login
-			// TODO
+			if err := c.Login("someusername", "somepassword"); errors.Is(err, types.ErrVersionMismatch{}) != tt.wantVersionError {
+				t.Fatalf("unexpected error state. Wanted version error? %v | Actual error: %v", tt.wantVersionError, err)
+			}
 
 			// test mfa login
-			// TODO
+			if _, err := c.MFALogin("someusername", "somepassword", types.AUTH_TYPE_TOTP, "1111"); errors.Is(err, types.ErrVersionMismatch{}) != tt.wantVersionError {
+				t.Fatalf("unexpected error state. Wanted version error? %v | Actual error: %v", tt.wantVersionError, err)
+			}
 
 			// test API key login
-			// TODO
+			if err := c.LoginWithAPIToken("myfancyapitoken"); errors.Is(err, types.ErrVersionMismatch{}) != tt.wantVersionError {
+				t.Fatalf("unexpected error state. Wanted version error? %v | Actual error: %v", tt.wantVersionError, err)
+			}
 		})
 	}
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -112,7 +112,9 @@ func TestAPIVersionCheck(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer l.Close()
+	t.Cleanup(func() {
+		l.Close()
+	})
 	srv := http.Server{}
 	var (
 		mockMajor = types.API_VERSION_MAJOR
@@ -129,7 +131,7 @@ func TestAPIVersionCheck(t *testing.T) {
 		}
 	})
 	go srv.Serve(l)
-	defer srv.Shutdown(t.Context())
+	t.Cleanup(func() { srv.Shutdown(t.Context()) })
 
 	tests := []struct {
 		name             string

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -85,9 +85,9 @@ func TestPing(t *testing.T) {
 	t.Cleanup(func() { l.Close() })
 
 	srv := http.Server{}
-	var failReq bool
+	var failReq atomic.Bool
 	http.HandleFunc(client.TEST_URL, func(w http.ResponseWriter, r *http.Request) {
-		if failReq {
+		if failReq.Load() {
 			w.WriteHeader(500)
 		}
 	})
@@ -101,7 +101,7 @@ func TestPing(t *testing.T) {
 	if err := c.Test(); err != nil {
 		t.Fatal("bad status returned from endpoint, expected 200: ", err)
 	}
-	failReq = true // check that we gracefuly handle
+	failReq.Store(true) // check that we gracefully handle
 	if err := c.Test(); !errors.Is(err, client.ErrInvalidTestStatus) {
 		t.Fatal("expected ErrInvalidTestStatus error; got ", err)
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2021 Gravwell, Inc. All rights reserved.
+ * Copyright 2026 Gravwell, Inc. All rights reserved.
  * Contact: <legal@gravwell.io>
  *
  * This software may be modified and distributed under the terms of the
@@ -84,13 +84,14 @@ func TestPing(t *testing.T) {
 	}
 	t.Cleanup(func() { l.Close() })
 
-	srv := http.Server{}
+	mux := http.NewServeMux()
 	var failReq atomic.Bool
-	http.HandleFunc(client.TEST_URL, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(client.TEST_URL, func(w http.ResponseWriter, r *http.Request) {
 		if failReq.Load() {
 			w.WriteHeader(500)
 		}
 	})
+	srv := http.Server{Handler: mux}
 	go srv.Serve(l)
 	t.Cleanup(func() { srv.Shutdown(t.Context()) })
 	// test we can make a successful ping against a mock
@@ -115,13 +116,13 @@ func TestAPIVersionCheck(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { l.Close() })
-	srv := http.Server{}
 
+	mux := http.NewServeMux()
 	var ( // each tests sets major and minor
 		mockMajor atomic.Uint32
 		mockMinor atomic.Uint32
 	)
-	http.HandleFunc(client.API_VERSION_URL, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(client.API_VERSION_URL, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		vi := types.VersionInfo{
 			API: types.ApiInfo{Major: mockMajor.Load(), Minor: mockMinor.Load()},
@@ -131,6 +132,7 @@ func TestAPIVersionCheck(t *testing.T) {
 			w.WriteHeader(500)
 		}
 	})
+	srv := http.Server{Handler: mux}
 	go srv.Serve(l)
 	t.Cleanup(func() { srv.Shutdown(t.Context()) })
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -9,7 +9,6 @@
 package client_test
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"net"
@@ -83,7 +82,8 @@ func TestPing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer l.Close()
+	t.Cleanup(func() { l.Close() })
+
 	srv := http.Server{}
 	var failReq bool
 	http.HandleFunc(client.TEST_URL, func(w http.ResponseWriter, r *http.Request) {
@@ -92,7 +92,7 @@ func TestPing(t *testing.T) {
 		}
 	})
 	go srv.Serve(l)
-	defer srv.Shutdown(context.Background())
+	t.Cleanup(func() { srv.Shutdown(t.Context()) })
 	// test we can make a successful ping against a mock
 	c, err := client.NewOpts(client.Opts{Server: l.Addr().String()})
 	if err != nil {
@@ -114,9 +114,7 @@ func TestAPIVersionCheck(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() {
-		l.Close()
-	})
+	t.Cleanup(func() { l.Close() })
 	srv := http.Server{}
 
 	var ( // each tests sets major and minor

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -6,16 +6,21 @@
  * BSD 2-clause license. See the LICENSE file for details.
  **************************************************************************/
 
-package client
+package client_test
 
 import (
-	"github.com/gravwell/gravwell/v4/client/objlog"
+	"context"
+	"errors"
+	"net"
+	"net/http"
 	"testing"
+
+	"github.com/gravwell/gravwell/v4/client"
 )
 
 func TestServerIP(t *testing.T) {
 	// Make a client with an IP address
-	c, err := NewClient("1.2.3.4", false, false, &objlog.NilObjLogger{})
+	c, err := client.New("1.2.3.4", false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,7 +28,7 @@ func TestServerIP(t *testing.T) {
 		t.Fatalf("Invalid IP address, expected 1.2.3.4 got %v", c.ServerIP())
 	}
 	// And try with a port
-	c, err = NewClient("1.2.3.4:8080", false, false, &objlog.NilObjLogger{})
+	c, err = client.New("1.2.3.4:8080", false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,7 +36,7 @@ func TestServerIP(t *testing.T) {
 		t.Fatalf("Invalid IP address, expected 1.2.3.4 got %v", c.ServerIP())
 	}
 	// And v6
-	c, err = NewClient("[::2]:8080", false, false, &objlog.NilObjLogger{})
+	c, err = client.New("[::2]:8080", false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,14 +45,14 @@ func TestServerIP(t *testing.T) {
 	}
 
 	// Make a client with a known-valid hostname
-	c, err = NewClient("localhost", false, false, &objlog.NilObjLogger{})
+	c, err = client.New("localhost", false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !c.ServerIP().IsLoopback() {
 		t.Fatalf("Invalid IP address, expected loopback got %v", c.ServerIP())
 	}
-	c, err = NewClient("localhost:80", false, false, &objlog.NilObjLogger{})
+	c, err = client.New("localhost:80", false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,18 +61,45 @@ func TestServerIP(t *testing.T) {
 	}
 
 	// Make a client with a hostname that is guaranteed to fail
-	c, err = NewClient("my.host.INVALIDDOMAIN.INVALIDTLD", false, false, &objlog.NilObjLogger{})
-	if err != nil {
+	if c, err := client.New("my.host.INVALIDDOMAIN.INVALIDTLD", false, false); err != nil {
 		t.Fatal(err)
-	}
-	if !c.ServerIP().IsUnspecified() {
+	} else if !c.ServerIP().IsUnspecified() {
 		t.Fatalf("Invalid IP address, expected unspecified got %v", c.ServerIP())
 	}
-	c, err = NewClient("my.host.INVALIDDOMAIN.INVALIDTLD:443", false, false, &objlog.NilObjLogger{})
-	if err != nil {
+	if c, err := client.New("my.host.INVALIDDOMAIN.INVALIDTLD:443", false, false); err != nil {
 		t.Fatal(err)
-	}
-	if !c.ServerIP().IsUnspecified() {
+	} else if !c.ServerIP().IsUnspecified() {
 		t.Fatalf("Invalid IP address, expected unspecified got %v", c.ServerIP())
 	}
+
+	// check that the client can issue and receive pings (positive and negative)
+	t.Run("TEST ping success against mock", func(t *testing.T) {
+		l, err := net.Listen("tcp", "[::1]:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer l.Close()
+		srv := http.Server{}
+		var failReq bool
+		http.HandleFunc(client.TEST_URL, func(w http.ResponseWriter, r *http.Request) {
+			if failReq {
+				w.WriteHeader(500)
+			}
+		})
+		go srv.Serve(l)
+		defer srv.Shutdown(context.Background())
+		// test we can make a successful ping against a mock
+		c, err := client.NewOpts(client.Opts{Server: l.Addr().String()})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := c.Test(); err != nil {
+			t.Fatal("bad status returned from endpoint, expected 200: ", err)
+		}
+		failReq = true // check that we gracefuly handle
+		if err := c.Test(); !errors.Is(err, client.ErrInvalidTestStatus) {
+			t.Fatal("expected ErrInvalidTestStatus error; got ", err)
+		}
+	})
+
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -77,7 +77,7 @@ func TestServerIP(t *testing.T) {
 }
 
 // check that the client can issue and receive pings (positive and negative)
-func TestMockPing(t *testing.T) {
+func TestPing(t *testing.T) {
 	l, err := net.Listen("tcp", "[::1]:0")
 	if err != nil {
 		t.Fatal(err)
@@ -108,6 +108,7 @@ func TestMockPing(t *testing.T) {
 
 // Ensure major version mismatches are caught prior to login attempts (and that minor mismatches are allowed).
 func TestAPIVersionCheck(t *testing.T) {
+	// spool up a mock endpoint to fire tests against
 	l, err := net.Listen("tcp", "[::1]:0")
 	if err != nil {
 		t.Fatal(err)
@@ -116,9 +117,10 @@ func TestAPIVersionCheck(t *testing.T) {
 		l.Close()
 	})
 	srv := http.Server{}
-	var (
-		mockMajor = types.API_VERSION_MAJOR
-		mockMinor = types.API_VERSION_MINOR
+
+	var ( // each tests sets major and minor
+		mockMajor uint32
+		mockMinor uint32
 	)
 	http.HandleFunc(client.API_VERSION_URL, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -178,6 +180,13 @@ func TestAPIVersionCheck(t *testing.T) {
 
 			// test API key login
 			if err := c.LoginWithAPIToken("myfancyapitoken"); errors.Is(err, types.ErrVersionMismatch{}) != tt.wantVersionError {
+				t.Fatalf("unexpected error state. Wanted version error? %v | Actual error: %v", tt.wantVersionError, err)
+			}
+
+			// test JWT login
+			if err := c.ImportLoginToken("alogintokenImadeup"); err != nil {
+				t.Fatal()
+			} else if err := c.TestLogin(); errors.Is(err, types.ErrVersionMismatch{}) != tt.wantVersionError {
 				t.Fatalf("unexpected error state. Wanted version error? %v | Actual error: %v", tt.wantVersionError, err)
 			}
 		})

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -10,12 +10,14 @@ package client_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net"
 	"net/http"
 	"testing"
 
 	"github.com/gravwell/gravwell/v4/client"
+	"github.com/gravwell/gravwell/v4/client/types"
 )
 
 func TestServerIP(t *testing.T) {
@@ -100,5 +102,60 @@ func TestMockPing(t *testing.T) {
 	failReq = true // check that we gracefuly handle
 	if err := c.Test(); !errors.Is(err, client.ErrInvalidTestStatus) {
 		t.Fatal("expected ErrInvalidTestStatus error; got ", err)
+	}
+}
+
+// Ensure major version mismatches are caught prior to login attempts (and that minor mismatches are allowed).
+func TestAPIVersionCheck(t *testing.T) {
+	l, err := net.Listen("tcp", "[::1]:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+	srv := http.Server{}
+	var (
+		mockMajor = types.API_VERSION_MAJOR
+		mockMinor = types.API_VERSION_MINOR
+	)
+	http.HandleFunc(client.API_VERSION_URL, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		vi := types.VersionInfo{
+			API: types.ApiInfo{Major: mockMajor, Minor: mockMinor},
+		}
+
+		if err := json.NewEncoder(w).Encode(vi); err != nil {
+			w.WriteHeader(500)
+		}
+	})
+	go srv.Serve(l)
+	defer srv.Shutdown(context.Background())
+
+	c, err := client.NewOpts(client.Opts{Server: l.Addr().String()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name      string
+		major     uint32
+		minor     uint32
+		wantError bool
+	}{
+		{"exact match major and minor", types.API_VERSION_MAJOR, types.API_VERSION_MINOR, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// test bare API check
+			if err := c.CheckApiVersion(); (err != nil) != tt.wantError {
+				t.Fatalf("unexpected error state. Wanted Error? %v | Actual Error: %v", tt.wantError, err)
+			}
+			// test u/p login
+			// TODO
+
+			// test mfa login
+			// TODO
+
+			// test API key login
+			// TODO
+		})
 	}
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -71,35 +71,34 @@ func TestServerIP(t *testing.T) {
 	} else if !c.ServerIP().IsUnspecified() {
 		t.Fatalf("Invalid IP address, expected unspecified got %v", c.ServerIP())
 	}
+}
 
-	// check that the client can issue and receive pings (positive and negative)
-	t.Run("TEST ping success against mock", func(t *testing.T) {
-		l, err := net.Listen("tcp", "[::1]:0")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer l.Close()
-		srv := http.Server{}
-		var failReq bool
-		http.HandleFunc(client.TEST_URL, func(w http.ResponseWriter, r *http.Request) {
-			if failReq {
-				w.WriteHeader(500)
-			}
-		})
-		go srv.Serve(l)
-		defer srv.Shutdown(context.Background())
-		// test we can make a successful ping against a mock
-		c, err := client.NewOpts(client.Opts{Server: l.Addr().String()})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := c.Test(); err != nil {
-			t.Fatal("bad status returned from endpoint, expected 200: ", err)
-		}
-		failReq = true // check that we gracefuly handle
-		if err := c.Test(); !errors.Is(err, client.ErrInvalidTestStatus) {
-			t.Fatal("expected ErrInvalidTestStatus error; got ", err)
+// check that the client can issue and receive pings (positive and negative)
+func TestMockPing(t *testing.T) {
+	l, err := net.Listen("tcp", "[::1]:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+	srv := http.Server{}
+	var failReq bool
+	http.HandleFunc(client.TEST_URL, func(w http.ResponseWriter, r *http.Request) {
+		if failReq {
+			w.WriteHeader(500)
 		}
 	})
-
+	go srv.Serve(l)
+	defer srv.Shutdown(context.Background())
+	// test we can make a successful ping against a mock
+	c, err := client.NewOpts(client.Opts{Server: l.Addr().String()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Test(); err != nil {
+		t.Fatal("bad status returned from endpoint, expected 200: ", err)
+	}
+	failReq = true // check that we gracefuly handle
+	if err := c.Test(); !errors.Is(err, client.ErrInvalidTestStatus) {
+		t.Fatal("expected ErrInvalidTestStatus error; got ", err)
+	}
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -131,24 +131,33 @@ func TestAPIVersionCheck(t *testing.T) {
 	go srv.Serve(l)
 	defer srv.Shutdown(t.Context())
 
-	c, err := client.NewOpts(client.Opts{Server: l.Addr().String()})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// use a short timeout window, as we don't actually care about anything past the version check.
-	c.SetRequestTimeout(100 * time.Millisecond)
-
 	tests := []struct {
 		name             string
 		major            uint32
 		minor            uint32
 		wantVersionError bool
 	}{
-		{"exact match major and minor", types.API_VERSION_MAJOR, types.API_VERSION_MINOR, false},
+		{"match major | match minor", types.API_VERSION_MAJOR, types.API_VERSION_MINOR, false},
+		{"match major | mismatch minor", types.API_VERSION_MAJOR, types.API_VERSION_MINOR + 1, false},
+		{"mismatch major | match minor", types.API_VERSION_MAJOR + 1, types.API_VERSION_MINOR, true},
+		{"mismatch major | mismatch minor", types.API_VERSION_MAJOR + 1, types.API_VERSION_MINOR + 1, true},
+		{"higher client version than remote version", 0, 0, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+
+			c, err := client.NewOpts(client.Opts{Server: l.Addr().String()})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// use a short timeout window, as we don't actually care about anything past the version check.
+			c.SetRequestTimeout(100 * time.Millisecond)
+			defer c.Close()
+
+			// update mock server's version
+			mockMajor = tt.major
+			mockMinor = tt.minor
 
 			// test bare API check
 			if err := c.CheckApiVersion(); errors.Is(err, types.ErrVersionMismatch{}) != tt.wantVersionError {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -186,7 +186,7 @@ func TestAPIVersionCheck(t *testing.T) {
 
 			// test JWT login
 			if err := c.ImportLoginToken("alogintokenImadeup"); err != nil {
-				t.Fatal()
+				t.Fatal(err)
 			} else if err := c.TestLogin(); errors.Is(err, types.ErrVersionMismatch{}) != tt.wantVersionError {
 				t.Fatalf("unexpected error state. Wanted version error? %v | Actual error: %v", tt.wantVersionError, err)
 			}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -119,13 +120,13 @@ func TestAPIVersionCheck(t *testing.T) {
 	srv := http.Server{}
 
 	var ( // each tests sets major and minor
-		mockMajor uint32
-		mockMinor uint32
+		mockMajor atomic.Uint32
+		mockMinor atomic.Uint32
 	)
 	http.HandleFunc(client.API_VERSION_URL, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		vi := types.VersionInfo{
-			API: types.ApiInfo{Major: mockMajor, Minor: mockMinor},
+			API: types.ApiInfo{Major: mockMajor.Load(), Minor: mockMinor.Load()},
 		}
 
 		if err := json.NewEncoder(w).Encode(vi); err != nil {
@@ -160,8 +161,8 @@ func TestAPIVersionCheck(t *testing.T) {
 			defer c.Close()
 
 			// update mock server's version
-			mockMajor = tt.major
-			mockMinor = tt.minor
+			mockMajor.Store(tt.major)
+			mockMinor.Store(tt.minor)
 
 			// test bare API check
 			if err := c.CheckApiVersion(); errors.Is(err, types.ErrVersionMismatch{}) != tt.wantVersionError {

--- a/client/info.go
+++ b/client/info.go
@@ -101,14 +101,53 @@ func (c *Client) getMyInfo() (types.UserDetails, error) {
 	return dets, nil
 }
 
-// CheckApiVersion assert the REST API version of the webserver is compatible
+// CheckApiVersion asserts the REST API version of the webserver is compatible
 // with the client.
 func (c *Client) CheckApiVersion() error {
-	var version types.VersionInfo
-	// TODO manually craft the request, as getStaticURL requires login
-	if err := c.getStaticURL(API_VERSION_URL, &version); err != nil {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	// manually operate the request as helper functions like methodStaticURL expect authentication
+
+	//build up URL we are going to throw at
+	uri := fmt.Sprintf("%s://%s%s", c.httpScheme, c.server, API_VERSION_URL)
+
+	//build up the request
+	req, err := http.NewRequest(http.MethodPost, uri, nil)
+	if err != nil {
 		return err
 	}
+
+	c.hm.populateRequest(req.Header) // add in the headers
+
+	resp, err := c.clnt.Do(req)
+	if err != nil {
+		c.objLog.Log("WEB "+req.Method+" Error "+err.Error(), req.URL.String(), nil)
+		return err
+	}
+	if resp == nil {
+		return errors.New("Invalid response")
+	}
+	defer drainResponse(resp)
+	switch resp.StatusCode {
+	case http.StatusOK: // do nothing
+	case http.StatusUnauthorized:
+		c.state = STATE_LOGGED_OFF
+		return ErrNotAuthed
+	case http.StatusFound:
+		return ErrNotFound
+	default:
+		c.objLog.Log("WEB "+req.Method, req.URL.String()+" "+resp.Status, nil)
+		return &ClientError{resp.Status, resp.StatusCode, getBodyErr(resp.Body)}
+	}
+
+	var version types.VersionInfo
+	if err := json.NewDecoder(resp.Body).Decode(&version); err != nil {
+		return err
+	}
+
+	c.objLog.Log("WEB "+req.Method, req.URL.String(), &version)
+
 	if err := types.CheckApiVersion(version.API); err != nil {
 		return err
 	}

--- a/client/info.go
+++ b/client/info.go
@@ -138,7 +138,7 @@ func (c *Client) checkApiVersionNoLock() error {
 	case http.StatusUnauthorized:
 		c.state = STATE_LOGGED_OFF
 		return ErrNotAuthed
-	case http.StatusFound:
+	case http.StatusNotFound:
 		return ErrNotFound
 	default:
 		c.objLog.Log("WEB "+req.Method, req.URL.String()+" "+resp.Status, nil)

--- a/client/info.go
+++ b/client/info.go
@@ -117,7 +117,7 @@ func (c *Client) checkApiVersionNoLock() error {
 	uri := fmt.Sprintf("%s://%s%s", c.httpScheme, c.server, API_VERSION_URL)
 
 	//build up the request
-	req, err := http.NewRequest(http.MethodPost, uri, nil)
+	req, err := http.NewRequest(http.MethodGet, uri, nil)
 	if err != nil {
 		return err
 	}

--- a/client/info.go
+++ b/client/info.go
@@ -105,6 +105,7 @@ func (c *Client) getMyInfo() (types.UserDetails, error) {
 // with the client.
 func (c *Client) CheckApiVersion() error {
 	var version types.VersionInfo
+	// TODO manually craft the request, as getStaticURL requires login
 	if err := c.getStaticURL(API_VERSION_URL, &version); err != nil {
 		return err
 	}

--- a/client/info.go
+++ b/client/info.go
@@ -103,15 +103,15 @@ func (c *Client) getMyInfo() (types.UserDetails, error) {
 
 // CheckApiVersion assert the REST API version of the webserver is compatible
 // with the client.
-func (c *Client) CheckApiVersion() (string, error) {
+func (c *Client) CheckApiVersion() error {
 	var version types.VersionInfo
 	if err := c.getStaticURL(API_VERSION_URL, &version); err != nil {
-		return "", err
+		return err
 	}
 	if err := types.CheckApiVersion(version.API); err != nil {
-		return err.Error(), nil
+		return err
 	}
-	return "", nil
+	return nil
 }
 
 // GetApiVersion returns the REST API version of the webserver.

--- a/client/info.go
+++ b/client/info.go
@@ -107,6 +107,10 @@ func (c *Client) CheckApiVersion() error {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
+	return c.checkApiVersionNoLock()
+}
+
+func (c *Client) checkApiVersionNoLock() error {
 	// manually operate the request as helper functions like methodStaticURL expect authentication
 
 	//build up URL we are going to throw at

--- a/client/types/api.go
+++ b/client/types/api.go
@@ -19,9 +19,9 @@ import (
 )
 
 const (
-	//MAJOR API VERSIONS should always be compatible, there just may be
-	//additional features
+	// Equal major versions should always be compatible
 	API_VERSION_MAJOR uint32 = 1
+	// Minor versions define features sets, but have no bearing on compatibility.
 	API_VERSION_MINOR uint32 = 0
 
 	AUTH_TYPE_NONE     AuthType = `None` // for when you don't have MFA set up at all yet.

--- a/client/types/api.go
+++ b/client/types/api.go
@@ -21,8 +21,8 @@ import (
 const (
 	//MAJOR API VERSIONS should always be compatible, there just may be
 	//additional features
-	API_VERSION_MAJOR uint32 = 0
-	API_VERSION_MINOR uint32 = 2
+	API_VERSION_MAJOR uint32 = 1
+	API_VERSION_MINOR uint32 = 0
 
 	AUTH_TYPE_NONE     AuthType = `None` // for when you don't have MFA set up at all yet.
 	AUTH_TYPE_TOTP     AuthType = `TOTP`

--- a/client/types/api.go
+++ b/client/types/api.go
@@ -89,9 +89,13 @@ func (e ErrVersionMismatch) Error() string {
 }
 
 // Is tests only that the error is a VersionMismatchError without any concern for the numbers themselves.
-func (ErrVersionMismatch) Is(err error) bool {
-	_, ok := err.(ErrVersionMismatch)
-	return ok
+func (ErrVersionMismatch) Is(target error) bool {
+	switch target.(type) {
+	case ErrVersionMismatch, *ErrVersionMismatch:
+		return true
+	default:
+		return false
+	}
 }
 
 func ApiVersion() ApiInfo {

--- a/client/types/api.go
+++ b/client/types/api.go
@@ -76,6 +76,24 @@ type CanonicalVersion struct {
 	Point uint32
 }
 
+// ErrVersionMismatch returns an error stating that the local client and the remote server are running different major API versions and thus
+// are not compatible.
+type ErrVersionMismatch struct {
+	Local  ApiInfo
+	Remote ApiInfo
+}
+
+func (e ErrVersionMismatch) Error() string {
+	return fmt.Sprintf("Version mismatch!\nLocal: %d.%d\nRemote %d.%d\n",
+		e.Local.Major, e.Local.Minor, e.Remote.Major, e.Remote.Minor)
+}
+
+// Is tests only that the error is a VersionMismatchError without any concern for the numbers themselves.
+func (ErrVersionMismatch) Is(err error) bool {
+	_, ok := err.(ErrVersionMismatch)
+	return ok
+}
+
 func ApiVersion() ApiInfo {
 	return ApiInfo{
 		Major: API_VERSION_MAJOR,
@@ -98,13 +116,13 @@ func (bi BuildInfo) NewerVersion(nbi BuildInfo) bool {
 	return bi.CanonicalVersion.NewerVersion(nbi.CanonicalVersion)
 }
 
+// CheckApiVersion returns an error iff the remote's major version != the caller's major version.
 func CheckApiVersion(remote ApiInfo) error {
 	local := ApiVersion()
 	if local.Major == remote.Major {
 		return nil //we match
 	}
-	return fmt.Errorf("Version mismatch!\nLocal: %d.%d\nRemote %d.%d\n",
-		local.Major, local.Minor, remote.Major, remote.Minor)
+	return ErrVersionMismatch{Local: local, Remote: remote}
 
 }
 

--- a/tools/actions/kitmanager/utils.go
+++ b/tools/actions/kitmanager/utils.go
@@ -219,17 +219,12 @@ func getClient() (cli *client.Client, err error) {
 	}
 
 	// login with the API token and check API versions
-	var wrn string // warning message that comes back if we can get the API version but it is not compatible
 	if err = cli.LoginWithAPIToken(authToken); err != nil {
 		cli.Close()
 		cli = nil
-	} else if wrn, err = cli.CheckApiVersion(); err != nil {
+	} else if err = cli.CheckApiVersion(); err != nil {
 		cli.Close()
 		cli = nil
-	} else if wrn != `` {
-		cli.Close()
-		cli = nil
-		err = fmt.Errorf("API version mismatch: %s", wrn)
 	}
 
 	return

--- a/tools/actions/kitmanager/utils.go
+++ b/tools/actions/kitmanager/utils.go
@@ -222,9 +222,6 @@ func getClient() (cli *client.Client, err error) {
 	if err = cli.LoginWithAPIToken(authToken); err != nil {
 		cli.Close()
 		cli = nil
-	} else if err = cli.CheckApiVersion(); err != nil {
-		cli.Close()
-		cli = nil
 	}
 
 	return


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses [#1863](https://github.com/gravwell/issues/issues/1863)

v3 companion PR: https://github.com/gravwell/gravwell/pull/2313

## This PR checks major version equity during login attempts

- All 4 login methods (`LoginEx`, `MFALogin`, `LoginWithAPIToken`, `ImportLoginToken()`+`TestLogin()`) are now gated behind version checks.
- `client.CheckApiVersion()` no longer requires login (matching the logging-only chain on the backend). 
- `client.CheckApiVersion()` now returns only one value; version mismatch is now treated as a real error, rather than a string warning.

## Other Changes

- API version bump to 1.0.
- Retires `client.NewClient()`.
- The client test file is now broken out as `client_test`.

## PR Tasks

<!-- Add tasks to this list as needed -->

- [x] e2e and/or unit tests included. If not, please provide an explanation.
- [x] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
