### PR TITLE
fix(issues#2307): correctly handle zero timestamps when converting from standard (v3)

### DIFF
--- a/ingest/entry/entry_test.go
+++ b/ingest/entry/entry_test.go
@@ -206,9 +206,9 @@ func TestGOBEncodeDecodeEnumeratedValues(t *testing.T) {
 	//check that we got things back out cleanly
 	if err := e.Compare(&out1); err != nil {
 		t.Fatalf("decoded gob entry did not come out the same: %v", err)
-	} else if e.Compare(&out2); err != nil {
+	} else if err := e.Compare(&out2); err != nil {
 		t.Fatalf("decoded gob entry did not come out the same: %v", err)
-	} else if out1.Compare(&out2); err != nil {
+	} else if err := out1.Compare(&out2); err != nil {
 		t.Fatalf("decoded entries did not come out the same: %v", err)
 	}
 }

--- a/ingest/entry/time.go
+++ b/ingest/entry/time.go
@@ -77,6 +77,9 @@ func UnixTime(s, ns int64) Timestamp {
 
 // StandardTime converts our Timestamp format to the golang time.Time datatype
 func (t Timestamp) StandardTime() time.Time {
+	if t.IsZero() { // if timestamp is empty, return Zero time
+		return time.Time{}
+	}
 	return time.Unix(t.Sec-unixToInternal, t.Nsec)
 }
 

--- a/ingest/entry/time.go
+++ b/ingest/entry/time.go
@@ -61,6 +61,10 @@ func Now() Timestamp {
 
 // FromStandard converts the time.Time datatype to our Timestamp format
 func FromStandard(ts time.Time) Timestamp {
+	if ts.IsZero() {
+		return Timestamp{}
+	}
+
 	ts = ts.UTC()
 	return Timestamp{
 		Sec:  ts.Unix() + unixToInternal,

--- a/ingest/entry/time_test.go
+++ b/ingest/entry/time_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gravwell/gravwell/v4/ingest/entry"
+	"github.com/gravwell/gravwell/v3/ingest/entry"
 )
 
 func TestTimestamp_IsZero(t *testing.T) {

--- a/ingest/entry/time_test.go
+++ b/ingest/entry/time_test.go
@@ -54,7 +54,7 @@ func TestTimestamp_StandardTime(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.ts.StandardTime()
-			if got != tt.want {
+			if got.Equal(tt.want) {
 				t.Errorf("StandardTime() = %v, want %v", got, tt.want)
 			}
 		})
@@ -80,7 +80,7 @@ func TestFromStandard(t *testing.T) {
 		})
 	}
 
-	t.Run("duration equity across multiple calls", func(t *testing.T) {
+	t.Run("duration equality across multiple calls", func(t *testing.T) {
 		tmBD := time.Date(1997, 10, 05, 10, 04, 02, 00, time.UTC)
 		tsBD := entry.FromStandard(tmBD)
 

--- a/ingest/entry/time_test.go
+++ b/ingest/entry/time_test.go
@@ -60,3 +60,38 @@ func TestTimestamp_StandardTime(t *testing.T) {
 		})
 	}
 }
+
+func TestFromStandard(t *testing.T) {
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for receiver constructor.
+		tm   time.Time
+		want entry.Timestamp
+	}{
+		{"zero", time.Time{}, entry.Timestamp{}},
+		{"unix", time.Unix(0, 0), entry.UnixTime(0, 0)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := entry.FromStandard(tt.tm)
+			if got != tt.want {
+				t.Errorf("StandardTime() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+	t.Run("duration equity across multiple calls", func(t *testing.T) {
+		tmBD := time.Date(1997, 10, 05, 10, 04, 02, 00, time.UTC)
+		tsBD := entry.FromStandard(tmBD)
+
+		tmNow := time.Now().Round(time.Nanosecond)
+		tsNow := entry.FromStandard(tmNow)
+
+		tmSince := tmBD.Sub(tmNow)
+		tsSince := tsBD.Sub(tsNow)
+		if tmSince != tsSince {
+			t.Errorf("since mismatch! tm: %v | ts: %v", tmSince, tsSince)
+		}
+	})
+
+}

--- a/ingest/entry/time_test.go
+++ b/ingest/entry/time_test.go
@@ -54,7 +54,7 @@ func TestTimestamp_StandardTime(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.ts.StandardTime()
-			if got.Equal(tt.want) {
+			if !got.Equal(tt.want) {
 				t.Errorf("StandardTime() = %v, want %v", got, tt.want)
 			}
 		})

--- a/ingest/entry/time_test.go
+++ b/ingest/entry/time_test.go
@@ -1,0 +1,62 @@
+/*************************************************************************
+ * Copyright 2017 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
+package entry_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gravwell/gravwell/v4/ingest/entry"
+)
+
+func TestTimestamp_IsZero(t *testing.T) {
+	t.Run("new", func(t *testing.T) {
+		ts := entry.Timestamp{}
+		if !ts.IsZero() {
+			t.Fatal("new timestamp is not zero")
+		}
+	})
+	t.Run("add resulting in zero", func(t *testing.T) {
+		ts := entry.Timestamp{Sec: 100}.Add(-100 * time.Second)
+		if !ts.IsZero() {
+			t.Fatalf("ts (%+v) is not considered zero.", ts)
+		}
+	})
+	t.Run("from standard", func(t *testing.T) {
+		ts := entry.FromStandard(time.Time{})
+		if !ts.IsZero() {
+			t.Fatalf("ts (%+v) is not considered zero.", ts)
+		}
+	})
+}
+
+func TestTimestamp_StandardTime(t *testing.T) {
+	now := time.Now()
+	// entry.Timestamp operates in nanosecond precision
+	now = now.Round(time.Nanosecond)
+
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for receiver constructor.
+		ts   entry.Timestamp
+		want time.Time
+	}{
+		{"zero", entry.Timestamp{}, time.Time{}},
+		{"unix", entry.UnixTime(0, 0), time.Unix(0, 0)},
+		{"from -> to", entry.FromStandard(now), now},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.ts.StandardTime()
+			if got != tt.want {
+				t.Errorf("StandardTime() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses [issues#2307](https://github.com/gravwell/issues/issues/2307).

v4 companion PR: https://github.com/gravwell/gravwell/pull/2324

## This PR makes entry.Timestamp aware of time.Time zero values

- `entry.FromStandard()` and `entry.Timestamp.StandardTime()` now guard for zero time values and return the equivalent zero value rather than performing conversion operations that mangle zero values.

## Other fixes

- fixes two tests in ingest/entry/entry_test.go that were not properly checking errors.

## PR Tasks

<!-- Add tasks to this list as needed -->

- [x] e2e and/or unit tests included. If not, please provide an explanation.
- [x] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
