### PR TITLE
fix(#2376): Make totalResultCount int64

### DIFF
--- a/client/types/render.go
+++ b/client/types/render.go
@@ -190,7 +190,7 @@ type ResultsTable struct {
 	BinWidth         float64                        `json:"binWidth"`
 	Columns          []string                       `json:"columns"`
 	Rows             []map[string]*ResultsTableCell `json:"rows"`
-	TotalResultCount int                            `json:"totalResultCount"`
+	TotalResultCount int64                          `json:"totalResultCount"`
 }
 
 type ResultsTableCell struct {


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses https://github.com/gravwell/issues/issues/2376

!! DON'T MERGE UNTIL https://github.com/gravwell/backend/pull/3917 IS REVIEWED AND APPROVED TOO !!

## This PR proposes...

- Changing the type of `TotalResultCount` to int64 to match the renderer limits

## PR Tasks

<!-- Add tasks to this list as needed -->

- [x] ~~e2e and/or unit tests included. If not, please provide an explanation.~~
- [x] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
