### PR TITLE
ci: improve e2e test stability

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,5 @@
 .idea
 .github
 _artifacts
-ingesters/test/e2e
-!ingesters/test/e2e/include
-ingesters/test/configs
+e2e
+!e2e/ingesters/include

--- a/e2e/infra.go
+++ b/e2e/infra.go
@@ -151,8 +151,10 @@ func Start() {
 			"DISABLE_simple_relay":   "TRUE",
 		}),
 		tc.WithWaitStrategyAndDeadline(
-			5*time.Second,
+			10*time.Second,
 			wait.ForListeningPort("80/tcp"),
+			// we don't expose the ingest port so eval the listen from within the container
+			wait.ForExec([]string{"nc", "-zv", "127.0.0.1", "4023"}),
 		),
 	)
 	if err != nil {


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses https://github.com/gravwell/issues/issues/2476

## This PR proposes...

Adding a wait for the ingest port to be listened on before starting tests.

## PR Tasks

<!-- Add tasks to this list as needed -->

- [x] e2e and/or unit tests included. If not, please provide an explanation.
- [x] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
