### PR TITLE
dx: add go tool for bumping runtime

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,17 @@ Please add tests for new functionality you add to packages in the repo.
 You can run the full set of checks manually by running the following command at the top level:
 
 ```
-bash .github/workflows/run_local_build_checksg.sh
+bash .github/workflows/run_local_build_checks.sh
 ```
 
 Don't submit PRs that modify existing tests without discussing it with Gravwell first.
+
+## Tools
+There are a number of tools within this repo to aid development and simplify maintenance. 
+These are all invokable via `go tool`
+
+### `repo`
+Repos containers most commands related to manging the repo state. Notably the go runtime versions and the small collection of `go.mod` files in the repo. 
+
+- `tidy`: runs `go mod tidy` for all the `go.mod` files. Example: `go tool repo tidy`
+- `bump-runtime`: takes two args `[from]` and `[to]` and updates all go version refs in `from` to `to`. Runs `tidy` after. Example: `go tool repo bump-runtime 1.26.3 1.26.4`

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/gravwell/gravwell/v3
 
 go 1.26.4
 
+tool github.com/gravwell/gravwell/v3/tools/repo
+
 require (
 	cloud.google.com/go/pubsub/v2 v2.5.1
 	collectd.org v0.5.0

--- a/tools/repo/README.md
+++ b/tools/repo/README.md
@@ -1,0 +1,21 @@
+# repo tools
+
+A Go tool for repo-wide operations. Run via:
+
+```
+go tool repo <command> [args]
+```
+
+Must be run from the repo root.
+
+## Adding a new command
+
+1. Add a function with the signature `func myCommand(args []string) error`.
+2. Register it in the `switch` block in `main()`:
+```go
+   case "my-command":
+       err = myCommand(os.Args[2:])
+```
+
+The `mods` slice at the top of `main.go` lists all Go module paths (relative to repo root). Add new modules there if needed.
+Any new go version references should be added to `runtimes` as well to ensure they are updated with the command.

--- a/tools/repo/main.go
+++ b/tools/repo/main.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// mods is a list of all folder paths with a go.mod.
+// Paths are relative to repo root.
+var mods = []string{
+	".",
+	"./e2e",
+	"./tools/mock/mimecast",
+}
+
+// main is expected to be run relative to the repo root.
+// this should only be run via go tool repo [cmd] [args]
+func main() {
+	command := os.Args[1]
+	switch command {
+	case "tidy":
+		tidy(os.Args[2:])
+	case "bump-runtime":
+		bump(os.Args[2:])
+	}
+}
+
+func tidy(args []string) {
+	wd, err := os.Getwd()
+	if err != nil {
+		fmt.Println("error:", err)
+		os.Exit(1)
+	}
+	for _, mod := range mods {
+		cmd := exec.Command("go", "mod", "tidy")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.Dir = filepath.Clean(wd + "/" + mod)
+		err = cmd.Run()
+		if err != nil {
+			fmt.Println("error:", err)
+			os.Exit(1)
+		}
+	}
+}
+
+var runtimes = []string{
+	"./e2e/hosted/Dockerfile",
+	"./e2e/hosted/mimecast_test.go",
+	"./e2e/Dockerfile",
+	"./tools/mock/mimecast/Dockerfile",
+}
+
+func bump(args []string) {
+	if len(args) < 2 {
+		fmt.Println("expected args [from] [to]")
+		os.Exit(1)
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		fmt.Println("error:", err)
+		os.Exit(1)
+	}
+	from := args[0]
+	to := args[1]
+
+	for _, mod := range mods {
+		file := filepath.Clean(fmt.Sprintf("%s/%s/go.mod", wd, mod))
+		if err := replace(file, from, to); err != nil {
+			fmt.Println("error:", err)
+			os.Exit(1)
+		}
+	}
+	for _, ref := range runtimes {
+		file := filepath.Clean(fmt.Sprintf("%s/%s", wd, ref))
+		if err := replace(file, from, to); err != nil {
+			fmt.Println("error:", err)
+			os.Exit(1)
+		}
+	}
+	tidy(os.Args[2:])
+}
+
+func replace(path, from, to string) error {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("could not read file %q: %v\n", path, err)
+	}
+	updated := strings.Replace(string(contents), from, to, 1)
+	err = os.WriteFile(path, []byte(updated), 0644)
+	if err != nil {
+		return fmt.Errorf("could not update file %q: %v\n", path, err)
+	}
+	return nil
+}

--- a/tools/repo/main.go
+++ b/tools/repo/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -16,23 +17,34 @@ var mods = []string{
 	"./tools/mock/mimecast",
 }
 
+var (
+	ErrUnknownCommand = errors.New("unknown command")
+	ErrBadArgs        = errors.New("bad arguments")
+)
+
 // main is expected to be run relative to the repo root.
 // this should only be run via go tool repo [cmd] [args]
 func main() {
 	command := os.Args[1]
+	var err error
 	switch command {
 	case "tidy":
-		tidy(os.Args[2:])
+		err = tidy(os.Args[2:])
 	case "bump-runtime":
-		bump(os.Args[2:])
+		err = bump(os.Args[2:])
+	default:
+		err = ErrUnknownCommand
+	}
+	if err != nil {
+		fmt.Printf("error running command %q: %v\n", command, err)
+		os.Exit(1)
 	}
 }
 
-func tidy(args []string) {
+func tidy(args []string) error {
 	wd, err := os.Getwd()
 	if err != nil {
-		fmt.Println("error:", err)
-		os.Exit(1)
+		return err
 	}
 	for _, mod := range mods {
 		cmd := exec.Command("go", "mod", "tidy")
@@ -41,10 +53,10 @@ func tidy(args []string) {
 		cmd.Dir = filepath.Clean(wd + "/" + mod)
 		err = cmd.Run()
 		if err != nil {
-			fmt.Println("error:", err)
-			os.Exit(1)
+			return err
 		}
 	}
+	return nil
 }
 
 var runtimes = []string{
@@ -54,16 +66,14 @@ var runtimes = []string{
 	"./tools/mock/mimecast/Dockerfile",
 }
 
-func bump(args []string) {
+func bump(args []string) error {
 	if len(args) < 2 {
-		fmt.Println("expected args [from] [to]")
-		os.Exit(1)
+		return fmt.Errorf("%w: expected 2 args: [from] [to]", ErrBadArgs)
 	}
 
 	wd, err := os.Getwd()
 	if err != nil {
-		fmt.Println("error:", err)
-		os.Exit(1)
+		return err
 	}
 	from := args[0]
 	to := args[1]
@@ -71,18 +81,16 @@ func bump(args []string) {
 	for _, mod := range mods {
 		file := filepath.Clean(fmt.Sprintf("%s/%s/go.mod", wd, mod))
 		if err := replace(file, from, to); err != nil {
-			fmt.Println("error:", err)
-			os.Exit(1)
+			return err
 		}
 	}
 	for _, ref := range runtimes {
 		file := filepath.Clean(fmt.Sprintf("%s/%s", wd, ref))
 		if err := replace(file, from, to); err != nil {
-			fmt.Println("error:", err)
-			os.Exit(1)
+			return err
 		}
 	}
-	tidy(os.Args[2:])
+	return tidy(os.Args[2:])
 }
 
 func replace(path, from, to string) error {


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses no issue.

## This PR proposes...

Add a simple `go tool` for bumping the runtime now that we have a handful of files that require it. 

## PR Tasks

<!-- Add tasks to this list as needed -->

- [x] e2e and/or unit tests included. If not, please provide an explanation.
- [x] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
