### PR TITLE
fix: some caps missing from tokens even when assigned

### DIFF
--- a/client/types/cbac_templates.go
+++ b/client/types/cbac_templates.go
@@ -25,7 +25,9 @@ var (
 	// fullCapList is used by most cbac related functions to filter available caps
 	// or when listing caps this slice is iterated to ensure only known caps are included.
 	// This MUST include all possible caps or listing caps on a token/user will not return all caps assigned.
-	fullCapList   []Capability
+	fullCapList []Capability
+	// userCapList stores all caps a non-admin user could be assigned
+	userCapList   []Capability
 	templateSet   []CapabilityTemplate
 	capabilitySet = [...]CapabilityDesc{
 		Search.CapabilityDesc(),
@@ -123,7 +125,7 @@ var (
 func init() {
 	fullCapList = make([]Capability, 0, len(capabilitySet))
 	fullCapStringList = make([]string, 0, len(capabilitySet))
-	userCapList := make([]Capability, 0, len(capabilitySet))
+	userCapList = make([]Capability, 0, len(capabilitySet))
 	fullCapabilityState = CapabilityState{
 		Grants: make([]string, 0, len(fullCapList)),
 	}

--- a/client/types/cbac_templates.go
+++ b/client/types/cbac_templates.go
@@ -18,13 +18,16 @@ const (
 )
 
 var (
-	fullTagAccess            = TagAccess{Grants: []string{`*`}}
-	fullCapabilityState      CapabilityState
-	adminOnlyCapabilityState CapabilityState
-	fullCapStringList        []string
-	fullCapList              []Capability
-	templateSet              []CapabilityTemplate
-	capabilitySet            = [...]CapabilityDesc{
+	fullTagAccess = TagAccess{Grants: []string{`*`}}
+	// fullCapabilityState represents the "caps" a user has when cbac is not enabled.
+	fullCapabilityState CapabilityState
+	fullCapStringList   []string
+	// fullCapList is used by most cbac related functions to filter available caps
+	// or when listing caps this slice is iterated to ensure only known caps are included.
+	// This MUST include all possible caps or listing caps on a token/user will not return all caps assigned.
+	fullCapList   []Capability
+	templateSet   []CapabilityTemplate
+	capabilitySet = [...]CapabilityDesc{
 		Search.CapabilityDesc(),
 		Download.CapabilityDesc(),
 		AttachSearch.CapabilityDesc(),
@@ -120,9 +123,17 @@ var (
 func init() {
 	fullCapList = make([]Capability, 0, len(capabilitySet))
 	fullCapStringList = make([]string, 0, len(capabilitySet))
+	userCapList := make([]Capability, 0, len(capabilitySet))
+	fullCapabilityState = CapabilityState{
+		Grants: make([]string, 0, len(fullCapList)),
+	}
 	for _, v := range capabilitySet {
-		if v.TokenOnly || v.AdminOnly {
-			continue
+		if !(v.AdminOnly && v.TokenOnly) {
+			// Both of these lists are represent access for normal users (non-admins)
+			// We don't want AdminOnly or TokenOnly caps in this list to avoid assigning them or saying they have a cap
+			// that in reality they don't have.
+			userCapList = append(userCapList, v.Cap)
+			fullCapabilityState.Grants = append(fullCapabilityState.Grants, v.Cap.Name())
 		}
 		fullCapList = append(fullCapList, v.Cap)
 		fullCapStringList = append(fullCapStringList, v.Cap.Name())
@@ -131,7 +142,7 @@ func init() {
 		CapabilityTemplate{
 			Name: TemplateFullUserName,
 			Desc: "Standard user that can operate all aspects of Gravwell.\nThis user has full access to automations.",
-			Caps: fullCapList,
+			Caps: userCapList,
 		},
 		CapabilityTemplate{
 			Name: TemplateReadOnlyName,
@@ -139,19 +150,6 @@ func init() {
 			Caps: readOnlyCapList,
 		},
 	}
-	fullCapabilityState = CapabilityState{
-		Grants: make([]string, 0, len(fullCapList)),
-	}
-	for _, c := range fullCapList {
-		fullCapabilityState.Grants = append(fullCapabilityState.Grants, c.Name())
-	}
-	adminOnlyCapabilityState = CapabilityState{
-		Grants: make([]string, 0, len(adminOnlyCapList)),
-	}
-	for _, c := range adminOnlyCapList {
-		adminOnlyCapabilityState.Grants = append(adminOnlyCapabilityState.Grants, c.Name())
-	}
-
 }
 
 func AllTagAccess() TagAccess {

--- a/client/types/cbac_test.go
+++ b/client/types/cbac_test.go
@@ -234,7 +234,7 @@ func TestAddRemove(t *testing.T) {
 }
 
 func TestOverlap(t *testing.T) {
-	//setup user with default allow and two groups, all allow
+	//setup user with default allow and two groups
 	ud := UserDetails{
 		CBAC: CBACRules{Capabilities: CapabilitySet{}},
 		Groups: []GroupDetails{
@@ -243,18 +243,18 @@ func TestOverlap(t *testing.T) {
 		},
 	}
 
-	//check that the user cannot do... anything
+	//check that the user cannot do anything
 	for _, c := range fullCapList {
 		if ud.HasCapability(c) {
-			t.Fatal("user does not have capability with all allow")
+			t.Fatalf("user has capability with empty sets: %s", c.String())
 		}
 	}
 
-	//swap the last group to deny and recheck
+	//swap the last to all and check they show
 	ud.Groups[1].CBAC.Capabilities = testGetAllCaps()
-	for _, c := range fullCapList {
+	for _, c := range userCapList {
 		if !ud.HasCapability(c) {
-			t.Fatal("user has capability with group deny")
+			t.Fatalf("user missing capability with all caps: %s", c.String())
 		}
 	}
 }
@@ -293,6 +293,29 @@ func TestOverlapWithUserExplicit(t *testing.T) {
 	}
 }
 
+func TestAdmin(t *testing.T) {
+	adminCap := adminOnlyCapList[0]
+
+	// ensure admin is allowed to have an admin cap
+	admin := UserDetails{
+		Admin: true,
+		CBAC:  CBACRules{Capabilities: CapabilitySet{}},
+	}
+	admin.CBAC.Capabilities.Set(adminCap)
+	if !admin.HasCapability(adminCap) {
+		t.Fatalf("%q capability not set", adminCap)
+	}
+
+	// ensure user is dened admin cap even if assigned
+	ud := UserDetails{
+		CBAC: CBACRules{Capabilities: CapabilitySet{}},
+	}
+	ud.CBAC.Capabilities.Set(adminCap)
+	if ud.HasCapability(adminCap) {
+		t.Fatalf("%q capability not set", adminCap)
+	}
+}
+
 func TestCapabilityList(t *testing.T) {
 	//setup user with default allow and two groups, all allow
 	ud := UserDetails{
@@ -302,17 +325,31 @@ func TestCapabilityList(t *testing.T) {
 			GroupDetails{CBAC: CBACRules{Capabilities: testGetAllCaps()}},
 		},
 	}
-	if lst := ud.CapabilityList(); len(lst) != len(fullCapList) {
+	if lst := ud.CapabilityList(); len(lst) != len(userCapList) {
 		t.Fatalf("wide open user does not have all capabilities: %d != %d", len(lst), _maxCap)
 	}
 
 	ud.Groups[1].CBAC.Capabilities = CapabilitySet{}
-	//allow a few explicite in the group
+	//allow a few explicit in the group
 	ud.Groups[1].CBAC.Capabilities.Set(Download)
 	if lst := ud.CapabilityList(); len(lst) != 1 {
 		t.Fatalf("shut out user has capabilities: %d != 1", len(lst))
 	} else if lst[0].Name != Download.Name() {
 		t.Fatalf("invalid allowed list: %v", lst)
+	}
+
+	// ensure all caps come back in the list if set
+	ud.Groups[1].CBAC.Capabilities = CapabilitySet{}
+	ud.Admin = true
+	for i := Search; i.Valid(); i++ {
+		ud.CBAC.Capabilities = CapabilitySet{}
+		if i == 5 {
+			continue
+		}
+		ud.CBAC.Capabilities.Set(i)
+		if lst := ud.CapabilityList(); len(lst) != 1 {
+			t.Fatalf("user missing cap: %q", i.Name())
+		}
 	}
 }
 
@@ -432,7 +469,7 @@ func TestGlobalTagDenyExplicitAllowGroup(t *testing.T) {
 }
 
 func testGetAllCaps() (cs CapabilitySet) {
-	for _, c := range fullCapList {
+	for _, c := range userCapList {
 		cs.Set(c)
 	}
 	return


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses no issue

## This PR proposes...

Adding all caps back to `fullCapList` and updating filtering for the other derived cap lists instead. Add a few comments around some of the package vars for future us. 

Dropped an extra loop over all caps. Removed unused `adminOnlyCapabilityState`

This is blocking work for the frontend team. 

### Details
 when making a request like 
```http
PUT localhost/api/tokens/token-flippantly-mournfully-boss-murre
Content-Type: application/json
Authorization: Bearer $GW_TOKEN

{
  "capabilities": [
    "ScheduleRead",
    "ScheduleWrite",
    "SOARLibs",
    "SOAREmail",
    "AlertRead",
    "AlertWrite",
    "KitWrite"
  ]
}
```

the server would respond with (trimmed reponse)

```json
{
  "capabilities": [
    "ScheduleRead",
    "ScheduleWrite",
    "SOARLibs",
    "SOAREmail",
    "AlertRead",
    "AlertWrite"
  ]
}
```

The `KitWrite` cap would be correctly saved, but would be filtered out from the response. 

## PR Tasks

<!-- Add tasks to this list as needed -->

- [x] e2e and/or unit tests included. If not, please provide an explanation.
- [x] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
