### PR TITLE
ci: poll for query results instead of arbitrary sleeps

### DIFF
--- a/e2e/client.go
+++ b/e2e/client.go
@@ -87,15 +87,25 @@ func RunSearch(t *testing.T, c *client.Client, query string, d time.Duration) []
 	return ents
 }
 
-func WaitForEntries(t *testing.T, c *client.Client, query string, d time.Duration, entries int, timeout time.Duration) ([]types.StringTagEntry, error) {
+func WaitForEntries(t *testing.T, c *client.Client, query string, d time.Duration, entries int, timeout time.Duration) []types.StringTagEntry {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
+	var lasterr error
 	for time.Now().Before(deadline) {
-		results := RunSearch(t, c, query, d)
+		results, s, err := search(c, query, d)
+		if err != nil {
+			lasterr = err
+		} else {
+			if err = c.DeleteSearch(s.ID); err != nil {
+				t.Logf("failed to delete search entry: %v", err)
+			}
+		}
 		if len(results) >= entries {
-			return results, nil
+			WriteQueryResults(t, slug.Make(query), results)
+			return results
 		}
 		time.Sleep(time.Second)
 	}
-	return nil, fmt.Errorf("timed out waiting for results")
+	t.Fatalf("timed out after %s waiting for %v entries for search %q, error: %v", timeout.String(), entries, query, lasterr)
+	return nil
 }

--- a/e2e/hosted/mimecast_test.go
+++ b/e2e/hosted/mimecast_test.go
@@ -75,6 +75,8 @@ func TestMimecast(t *testing.T) {
 			"/opt/gravwell/log/hosted_runner.log",
 			"/opt/gravwell/log/error.log",
 		})
+		// run for the artifact, help debugging
+		_ = e2e.RunSearch(t, e2e.GetClient(t), "tag=gravwell syslog Appname==mimecast", time.Hour)
 		e2e.Terminate(t, fetcher)
 		e2e.Terminate(t, mock)
 	})
@@ -82,16 +84,12 @@ func TestMimecast(t *testing.T) {
 		e2e.Fatal(t, err)
 	}
 
-	time.Sleep(10 * time.Second)
-
 	c := e2e.GetClient(t)
-	// run for the artifact, help debugging
-	_ = e2e.RunSearch(t, c, "tag=gravwell syslog Appname==mimecast", time.Hour)
-	if ent := e2e.RunSearch(t, c, "tag=mimecast-audit", time.Hour*24); len(ent) == 0 {
+	if ent := e2e.WaitForEntries(t, c, "tag=mimecast-audit", time.Hour*24, 1, 30*time.Second); len(ent) == 0 {
 		e2e.Fatal(t, "no audit entries found")
 	}
 
-	if ent := e2e.RunSearch(t, c, "tag=mimecast-mta-delivery", time.Hour*24); len(ent) < 100 {
+	if ent := e2e.WaitForEntries(t, c, "tag=mimecast-mta-delivery", time.Hour*24, 100, 60*time.Second); len(ent) < 100 {
 		e2e.Fatalf(t, "got %d entries, less than expected 100 mta entries ", len(ent))
 	}
 

--- a/e2e/hosted/mimecast_test.go
+++ b/e2e/hosted/mimecast_test.go
@@ -64,7 +64,7 @@ func TestMimecast(t *testing.T) {
 	fetcher, err := tc.Run(t.Context(), "gravwell/hosted:e2e",
 		e2e.WithDefaults(t, "hosted-mimecast",
 			tc.WithWaitStrategyAndDeadline(
-				15*time.Second,
+				35*time.Second,
 				wait.ForLog("Successfully connected to ingesters").WithPollInterval(time.Second),
 			),
 			e2e.WithConfig(t, "testdata/mimecast.conf", "hosted_runner.conf", e2e.DefaultConfig),

--- a/e2e/hosted/mimecast_test.go
+++ b/e2e/hosted/mimecast_test.go
@@ -75,8 +75,6 @@ func TestMimecast(t *testing.T) {
 			"/opt/gravwell/log/hosted_runner.log",
 			"/opt/gravwell/log/error.log",
 		})
-		// run for the artifact, help debugging
-		_ = e2e.RunSearch(t, e2e.GetClient(t), "tag=gravwell syslog Appname==mimecast", time.Hour)
 		e2e.Terminate(t, fetcher)
 		e2e.Terminate(t, mock)
 	})

--- a/e2e/hosted/tester_test.go
+++ b/e2e/hosted/tester_test.go
@@ -30,10 +30,8 @@ func TestTesterPlugin(t *testing.T) {
 		e2e.Fatal(t, err)
 	}
 
-	time.Sleep(10 * time.Second)
-
 	c := e2e.GetClient(t)
-	ent := e2e.RunSearch(t, c, "tag=test", time.Hour)
+	ent := e2e.WaitForEntries(t, c, "tag=test", time.Hour, 1, 30*time.Second)
 
 	if len(ent) == 0 {
 		t.Fatal("No entries found")

--- a/e2e/hosted/tester_test.go
+++ b/e2e/hosted/tester_test.go
@@ -14,8 +14,8 @@ func TestTesterPlugin(t *testing.T) {
 	fetcher, err := tc.Run(t.Context(), "gravwell/hosted:e2e",
 		e2e.WithDefaults(t, "hosted-tester",
 			tc.WithWaitStrategyAndDeadline(
-				10*time.Second,
-				wait.ForLog("Successfully connected to ingesters"),
+				35*time.Second,
+				wait.ForLog("Successfully connected to ingesters").WithPollInterval(time.Second),
 			),
 			e2e.WithConfig(t, "testdata/tester.conf", "hosted_runner.conf", e2e.DefaultConfig),
 		)...,

--- a/e2e/ingesters.go
+++ b/e2e/ingesters.go
@@ -16,7 +16,7 @@ import (
 var DefaultConfig = config.IngestConfig{
 	Cleartext_Backend_Target: []string{"gravwell:4023"},
 	Ingest_Secret:            "IngestSecrets",
-	Connection_Timeout:       "10s",
+	Connection_Timeout:       "30s",
 }
 
 // Ingester will add the default list of container configs for consistency and as an easy way to adjust how we handle the various running containers.
@@ -34,8 +34,8 @@ func Ingester(t *testing.T, name, ingester string, extras ...tc.ContainerCustomi
 			"INGESTER": ingester,
 		}),
 		tc.WithWaitStrategyAndDeadline(
-			10*time.Second,
-			wait.ForLog("Successfully connected to ingesters"),
+			35*time.Second,
+			wait.ForLog("Successfully connected to ingesters").WithPollInterval(time.Second),
 		),
 	}
 	return WithDefaults(t, name, append(defaults, extras...)...)

--- a/e2e/ingesters/HttpIngester/http_test.go
+++ b/e2e/ingesters/HttpIngester/http_test.go
@@ -44,9 +44,8 @@ func TestHttp(t *testing.T) {
 		t.Errorf("got bad http status %d", resp.StatusCode)
 	}
 
-	time.Sleep(5 * time.Second)
 	c := e2e.GetClient(t)
-	ent := e2e.RunSearch(t, c, "tag=http", time.Minute)
+	ent := e2e.WaitForEntries(t, c, "tag=http", time.Minute, 1, 30*time.Second)
 	if len(ent) != 1 {
 		e2e.Fatalf(t, "got %d entries, want 1", len(ent))
 	}


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses https://github.com/gravwell/issues/issues/2476

## This PR proposes...

Polling for query results to reduce test flakes due to runtime delays. 

## PR Tasks

<!-- Add tasks to this list as needed -->

- [x] e2e and/or unit tests included. If not, please provide an explanation.
- [x] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
