### PR TITLE
azure eventhub crash and bad default on generator

### DIFF
--- a/generators/base/base.go
+++ b/generators/base/base.go
@@ -50,7 +50,7 @@ var (
 	chaos        = flag.Bool("chaos-mode", false, "Chaos mode causes the generator to not do multiline HTTP uploads and sometimes send crazy timestamps")
 	chaosWorkers = flag.Int("chaos-mode-workers", 8, "Maximum number of workers when in chaos mode")
 	tsPsychoMode = flag.Bool("time-is-an-illusion", false, "Ingest with worst-case timestamp ordering (this is a chaos-mode flag)")
-	maxEntrySize = flag.Int("max-entry-size", 16*1024*1024, "Maximum entry size to limit to")
+	maxEntrySize = flag.Int("max-entry-size", 32*1024*1024, "Maximum entry size to limit to") // set to something dumb just so that we know megaJSON will work
 )
 
 var (

--- a/generators/base/base.go
+++ b/generators/base/base.go
@@ -50,7 +50,7 @@ var (
 	chaos        = flag.Bool("chaos-mode", false, "Chaos mode causes the generator to not do multiline HTTP uploads and sometimes send crazy timestamps")
 	chaosWorkers = flag.Int("chaos-mode-workers", 8, "Maximum number of workers when in chaos mode")
 	tsPsychoMode = flag.Bool("time-is-an-illusion", false, "Ingest with worst-case timestamp ordering (this is a chaos-mode flag)")
-	maxEntrySize = flag.Int("max-entry-size", 1024*1024*1024, "Maximum entry size to limit to")
+	maxEntrySize = flag.Int("max-entry-size", 16*1024*1024, "Maximum entry size to limit to")
 )
 
 var (

--- a/ingesters/AzureEventHubs/main.go
+++ b/ingesters/AzureEventHubs/main.go
@@ -213,8 +213,9 @@ func main() {
 			}
 			tg, err := timegrinder.NewTimeGrinder(tcfg)
 			if err != nil {
-				//failed to create a timegrinder object, do not attempt to parse the time off of hub messages
+				// failed to create a timegrinder object, do not attempt to parse the time off of hub messages
 				hubDef.Parse_Time = false
+				lg.Error("timegrinder error", log.KVErr(err))
 			} else {
 				if hubDef.Assume_Local_Timezone {
 					tg.SetLocalTime()

--- a/ingesters/AzureEventHubs/main.go
+++ b/ingesters/AzureEventHubs/main.go
@@ -97,6 +97,8 @@ func main() {
 	var listeners []*eventhubs.ListenerHandle
 	// this is where we keep track of what we're receiving on
 	var readers []readerInfo
+	// protect concurrent appends from multiple hub goroutines
+	var listenerMtx sync.Mutex
 
 	// This little goroutine tries to keep persistence updated in case of catastrophic
 	// failure, without totally smashing the disk like it would if we allowed an update
@@ -211,16 +213,18 @@ func main() {
 			}
 			tg, err := timegrinder.NewTimeGrinder(tcfg)
 			if err != nil {
+				//failed to create a timegrinder object, do not attempt to parse the time off of hub messages
 				hubDef.Parse_Time = false
-			}
-			if hubDef.Assume_Local_Timezone {
-				tg.SetLocalTime()
-			}
-			if hubDef.Timezone_Override != `` {
-				err = tg.SetTimezone(hubDef.Timezone_Override)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "Failed to set timezone to %v: %v\n", hubDef.Timezone_Override, err)
-					return
+			} else {
+				if hubDef.Assume_Local_Timezone {
+					tg.SetLocalTime()
+				}
+				if hubDef.Timezone_Override != `` {
+					err = tg.SetTimezone(hubDef.Timezone_Override)
+					if err != nil {
+						fmt.Fprintf(os.Stderr, "Failed to set timezone to %v: %v\n", hubDef.Timezone_Override, err)
+						return
+					}
 				}
 			}
 
@@ -305,8 +309,10 @@ func main() {
 					lg.Error("failed to start event hub partition receiver", log.KVErr(err))
 					return
 				}
+				listenerMtx.Lock()
 				listeners = append(listeners, handle)
 				readers = append(readers, readerInfo{hubDef.Event_Hubs_Namespace, hubDef.Event_Hub, hubDef.Consumer_Group, partitionID})
+				listenerMtx.Unlock()
 				lg.Info("started receiver for partition", log.KV("consumer-group", cg), log.KV("partition", partitionID))
 			}
 			<-quitSig

--- a/ingesters/AzureEventHubs/main.go
+++ b/ingesters/AzureEventHubs/main.go
@@ -311,7 +311,7 @@ func main() {
 				}
 				listenerMtx.Lock()
 				listeners = append(listeners, handle)
-				readers = append(readers, readerInfo{hubDef.Event_Hubs_Namespace, hubDef.Event_Hub, hubDef.Consumer_Group, partitionID})
+				readers = append(readers, readerInfo{hubDef.Event_Hubs_Namespace, hubDef.Event_Hub, cg, partitionID})
 				listenerMtx.Unlock()
 				lg.Info("started receiver for partition", log.KV("consumer-group", cg), log.KV("partition", partitionID))
 			}

--- a/ingesters/AzureEventHubs/main.go
+++ b/ingesters/AzureEventHubs/main.go
@@ -97,8 +97,8 @@ func main() {
 	var listeners []*eventhubs.ListenerHandle
 	// this is where we keep track of what we're receiving on
 	var readers []readerInfo
-	// protect concurrent appends from multiple hub goroutines
-	var listenerMtx sync.Mutex
+	// protect concurrent appends (Lock) and iterations (RLock) across goroutines
+	var listenerMtx sync.RWMutex
 
 	// This little goroutine tries to keep persistence updated in case of catastrophic
 	// failure, without totally smashing the disk like it would if we allowed an update
@@ -118,7 +118,11 @@ func main() {
 			case <-quitSig:
 				return
 			case <-ticker.C:
-				for _, r := range readers {
+				listenerMtx.RLock()
+				snapshot := make([]readerInfo, len(readers))
+				copy(snapshot, readers)
+				listenerMtx.RUnlock()
+				for _, r := range snapshot {
 					// read it from the memory persister
 					checkpoint, err := memPersist.Read(r.namespace, r.hub, r.consumerGroup, r.partitionID)
 					if err != nil {
@@ -327,7 +331,11 @@ func main() {
 	exitFn()
 
 	// Tell every event handler to close
-	for _, h := range listeners {
+	listenerMtx.RLock()
+	listenerSnapshot := make([]*eventhubs.ListenerHandle, len(listeners))
+	copy(listenerSnapshot, listeners)
+	listenerMtx.RUnlock()
+	for _, h := range listenerSnapshot {
 		cctx, cf := context.WithTimeout(ctx, 2*time.Second)
 		h.Close(cctx)
 		cf()


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses no issue

## This PR proposes...

- set a better default on the gravwellGenerator max entry size
- Fix a crash on the azure eventhubs ingester when a bad timegrinder spec is configured

## PR Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e and/or unit tests included. If not, please provide an explanation.
- [ ] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
