### PR TITLE
feat(issues#2365): Include ContentType and FileExtension in Files 

### DIFF
--- a/client/file.go
+++ b/client/file.go
@@ -16,7 +16,7 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path"
+	"path/filepath"
 	"strconv"
 
 	"github.com/gravwell/gravwell/v4/client/types"
@@ -110,8 +110,8 @@ func (c *Client) PopulateFile(id string, extension string, data []byte) (types.F
 // Extension is taken verbatim from the path.
 //
 // Returns the metadata of the populated/updated file.
-func (c *Client) PopulateFileFromPath(id string, filepath string) (types.File, error) {
-	f, err := os.Open(filepath)
+func (c *Client) PopulateFileFromPath(id string, pth string) (types.File, error) {
+	f, err := os.Open(pth)
 	if err != nil {
 		return types.File{}, err
 	}
@@ -123,7 +123,7 @@ func (c *Client) PopulateFileFromPath(id string, filepath string) (types.File, e
 		return types.File{}, ErrOversizedFile
 	}
 
-	return c.PopulateFileFromReader(id, path.Ext(filepath), f)
+	return c.PopulateFileFromReader(id, filepath.Ext(pth), f)
 }
 
 // PopulateFileFromReader sets the contents of the specified file to that of the given reader.

--- a/client/file.go
+++ b/client/file.go
@@ -15,6 +15,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"path"
 	"strconv"
 
 	"github.com/gravwell/gravwell/v4/client/types"
@@ -94,20 +96,42 @@ func (c *Client) GetFileMetadata(id string) (types.File, error) {
 
 // PopulateFile sets the content of the specified file to the given data.
 //
+// Extension should include the dot (ex: ".csv").
+//
 // Returns the metadata of the populated/updated file.
-func (c *Client) PopulateFile(id string, data []byte) (types.File, error) {
+func (c *Client) PopulateFile(id string, extension string, data []byte) (types.File, error) {
 	if uint64(len(data)) > maxFileSize {
 		return types.File{}, ErrOversizedFile
 	}
-	return c.PopulateFileFromReader(id, bytes.NewBuffer(data))
+	return c.PopulateFileFromReader(id, extension, bytes.NewBuffer(data))
+}
+
+// PopulateFileFromPath sets the content of the specified file to that of the file at the given path.
+// Extension is taken verbatim from the path.
+//
+// Returns the metadata of the populated/updated file.
+func (c *Client) PopulateFileFromPath(id string, filepath string) (types.File, error) {
+	f, err := os.Open(filepath)
+	if err != nil {
+		return types.File{}, err
+	}
+
+	// sanity check the length
+	if fi, err := f.Stat(); err != nil {
+		return types.File{}, err
+	} else if uint64(fi.Size()) > maxFileSize {
+		return types.File{}, ErrOversizedFile
+	}
+
+	return c.PopulateFileFromReader(id, path.Ext(filepath), f)
 }
 
 // PopulateFileFromReader sets the contents of the specified file to that of the given reader.
 //
+// Extension should include the dot (ex: ".csv").
+//
 // Returns the metadata of the populated/updated file.
-func (c *Client) PopulateFileFromReader(id string, data io.Reader) (types.File, error) {
-	// This is functionally the same as PopulateResourceFromReader
-
+func (c *Client) PopulateFileFromReader(id string, extension string, data io.Reader) (types.File, error) {
 	var resp *http.Response
 
 	//get a pipe rolling with something that always closes it
@@ -116,8 +140,8 @@ func (c *Client) PopulateFileFromReader(id string, data io.Reader) (types.File, 
 	defer rdr.Close()
 
 	mpw := newMpWriter(wtr)
-	//write the file portion (the name is ignored)
-	part, err := mpw.CreateFormFile(fileField, `file`)
+	//write the file portion; we only care about the extension as name is stored in metadata.
+	part, err := mpw.CreateFormFile(fileField, `file`+extension)
 	if err != nil {
 		return types.File{}, err
 	}

--- a/client/resources.go
+++ b/client/resources.go
@@ -18,7 +18,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/gravwell/gravwell/v4/client/types"
 )
@@ -97,13 +97,13 @@ func (mpw *mpWriter) Close() (err error) {
 // Extension is taken verbatim from the path.
 //
 // Returns the metadata of the populated/updated resource.
-func (c *Client) PopulateResourceFromPath(id string, filepath string) (types.Resource, error) {
-	f, err := os.Open(filepath)
+func (c *Client) PopulateResourceFromPath(id string, pth string) (types.Resource, error) {
+	f, err := os.Open(pth)
 	if err != nil {
 		return types.Resource{}, err
 	}
 
-	return c.PopulateResourceFromReader(id, path.Ext(filepath), f)
+	return c.PopulateResourceFromReader(id, filepath.Ext(pth), f)
 }
 
 // PopulateResourceFromReader sets the contents of the specified resource to that of the given reader.

--- a/client/resources.go
+++ b/client/resources.go
@@ -11,11 +11,14 @@ package client
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
+	"os"
+	"path"
 
 	"github.com/gravwell/gravwell/v4/client/types"
 )
@@ -52,9 +55,13 @@ func (c *Client) ListAllResources(opts *types.QueryOptions) (rm types.ResourceLi
 	return
 }
 
-// PopulateResource updates the contents of the resource with the specified ID.
-func (c *Client) PopulateResource(id string, data []byte) error {
-	return c.PopulateResourceFromReader(id, bytes.NewReader(data))
+// PopulateResource sets the content of the specified resource to the given data.
+//
+// Extension should include the dot (ex: ".csv").
+//
+// Returns the metadata of the populated/updated resource.
+func (c *Client) PopulateResource(id string, extension string, data []byte) (types.Resource, error) {
+	return c.PopulateResourceFromReader(id, extension, bytes.NewReader(data))
 }
 
 type mpWriter struct {
@@ -86,10 +93,25 @@ func (mpw *mpWriter) Close() (err error) {
 	return
 }
 
-// PopulateResourceFromReader updates the contents of the specified resource using
-// data read from an io.Reader rather than a slice of bytes.
-func (c *Client) PopulateResourceFromReader(id string, data io.Reader) (err error) {
-	var part io.Writer
+// PopulateResourceFromPath sets the content of the specified resource to that of the file at the given path.
+// Extension is taken verbatim from the path.
+//
+// Returns the metadata of the populated/updated resource.
+func (c *Client) PopulateResourceFromPath(id string, filepath string) (types.Resource, error) {
+	f, err := os.Open(filepath)
+	if err != nil {
+		return types.Resource{}, err
+	}
+
+	return c.PopulateResourceFromReader(id, path.Ext(filepath), f)
+}
+
+// PopulateResourceFromReader sets the contents of the specified resource to that of the given reader.
+//
+// Extension should include the dot (ex: ".csv").
+//
+// Returns the metadata of the populated/updated resource.
+func (c *Client) PopulateResourceFromReader(id string, extension string, data io.Reader) (types.Resource, error) {
 	var resp *http.Response
 
 	//get a pipe rolling with something that always closes it
@@ -98,9 +120,10 @@ func (c *Client) PopulateResourceFromReader(id string, data io.Reader) (err erro
 	defer rdr.Close()
 
 	mpw := newMpWriter(wtr)
-	//write the file portion (the name is ignored)
-	if part, err = mpw.CreateFormFile(fileField, `file`); err != nil {
-		return
+	//write the file portion; we only care about the extension as name is stored in metadata.
+	part, err := mpw.CreateFormFile(fileField, `file`+extension)
+	if err != nil {
+		return types.Resource{}, err
 	}
 	contentType := mpw.FormDataContentType()
 
@@ -117,22 +140,29 @@ func (c *Client) PopulateResourceFromReader(id string, data io.Reader) (err erro
 
 	resp, err = c.methodRequestURL(http.MethodPut, resourcesIdRawUrl(id), contentType, rdr)
 	if err != nil {
-		return err
+		return types.Resource{}, err
 	}
 	defer drainResponse(resp)
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		c.state = STATE_LOGGED_OFF
-		err = ErrNotAuthed
+		return types.Resource{}, ErrNotAuthed
 	} else if resp.StatusCode != http.StatusOK {
 		if s := getBodyErr(resp.Body); len(s) > 0 {
 			err = errors.New(s)
 		} else {
 			err = fmt.Errorf("Bad Status %s(%d)", resp.Status, resp.StatusCode)
 		}
+		return types.Resource{}, err
 	}
 
-	return
+	// decode the metadata response
+	confirmation := types.Resource{}
+	if err := json.NewDecoder(resp.Body).Decode(&confirmation); err != nil {
+		return types.Resource{}, err
+	}
+
+	return confirmation, nil
 }
 
 // DeleteResource removes a resource by ID by marking it deleted in the database.

--- a/client/resources.go
+++ b/client/resources.go
@@ -181,8 +181,9 @@ func (c *Client) CleanupResources() error {
 }
 
 // UpdateResourceMetadata sets the specified resource's metadata.
-func (c *Client) UpdateResourceMetadata(id string, metadata types.Resource) error {
-	return c.putStaticURL(resourcesIdUrl(id), metadata)
+func (c *Client) UpdateResourceMetadata(id string, metadata types.Resource) (updated types.File, err error) {
+	err = c.methodStaticPushURL(http.MethodPut, resourcesIdUrl(id), metadata, &updated, nil, nil)
+	return updated, err
 }
 
 // GetResourceMetadata gets the specified resource's metadata.

--- a/client/types/file.go
+++ b/client/types/file.go
@@ -8,11 +8,6 @@
 
 package types
 
-type FileContentType struct {
-	ContentType string
-	Body        []byte
-}
-
 // File contains metadata about the file, but not the actual bytes.
 type File struct {
 	CommonFields

--- a/client/types/file.go
+++ b/client/types/file.go
@@ -8,12 +8,19 @@
 
 package types
 
+type FileContentType struct {
+	ContentType string
+	Body        []byte
+}
+
 // File contains metadata about the file, but not the actual bytes.
 type File struct {
 	CommonFields
 
-	Size uint64
-	Hash string
+	Size          uint64
+	Hash          string
+	ContentType   string // Guessed at update time if possible
+	FileExtension string // The extension of the uploaded file, with the dot (ex: ".csv").
 }
 
 type FileListResponse struct {

--- a/client/types/resource.go
+++ b/client/types/resource.go
@@ -13,11 +13,6 @@ import (
 	"io"
 )
 
-type ResourceContentType struct {
-	ContentType string
-	Body        []byte
-}
-
 type ResourceUpdate struct {
 	Metadata Resource
 	Data     []byte

--- a/gwcli/tree/files/files.go
+++ b/gwcli/tree/files/files.go
@@ -190,7 +190,7 @@ func create() action.Pair {
 				return 0, "", fmt.Errorf("failed to create empty file: %w", err)
 			}
 			// populate the file
-			if _, err := connection.Client.PopulateFileFromReader(outMeta.ID, f); err != nil {
+			if _, err := connection.Client.PopulateFileFromPath(outMeta.ID, filePath); err != nil {
 				return 0, "", fmt.Errorf("failed to populate file: %w", err)
 			}
 
@@ -305,11 +305,7 @@ func replace() action.Pair {
 		func(ID string, addtlFlags *pflag.FlagSet) (success string, _ error) {
 			// slurp file
 			pth, _ := addtlFlags.GetString(ft.Path.Name())
-			contentF, err := os.Open(pth)
-			if err != nil {
-				return "", err
-			}
-			updatedFile, err := connection.Client.PopulateFileFromReader(ID, contentF)
+			updatedFile, err := connection.Client.PopulateFileFromPath(ID, pth)
 			if err != nil {
 				return "", err
 			}

--- a/gwcli/tree/resources/resources.go
+++ b/gwcli/tree/resources/resources.go
@@ -14,7 +14,6 @@ package resources
 import (
 	"errors"
 	"fmt"
-	"io"
 	filesystem "io/fs"
 	"os"
 	"strings"
@@ -195,20 +194,7 @@ func create() action.Pair {
 
 			resp, err := connection.Client.CreateResource(data)
 			// upload the file
-			f, err := os.Open(filePath)
-			if err != nil {
-				errStr := fmt.Sprintf("created resource, but failed to populate it: %v", err)
-				clilog.Writer.Warn(errStr, rfc5424.SDParam{Name: "stage", Value: "open file"})
-				return resp.ID, "", errors.New(errStr)
-			}
-			defer f.Close()
-			b, err := io.ReadAll(f)
-			if err != nil {
-				errStr := fmt.Sprintf("created resource, but failed to populate it: %v", err)
-				clilog.Writer.Warn(errStr, rfc5424.SDParam{Name: "stage", Value: "slurp file"})
-				return resp.ID, "", errors.New(errStr)
-			}
-			if err := connection.Client.PopulateResource(resp.ID, b); err != nil {
+			if _, err := connection.Client.PopulateResourceFromPath(resp.ID, filePath); err != nil {
 				errStr := fmt.Sprintf("created resource, but failed to populate it: %v", err)
 				clilog.Writer.Warn(errStr, rfc5424.SDParam{Name: "stage", Value: "populate"})
 				return resp.ID, "", errors.New(errStr)
@@ -300,7 +286,8 @@ func edit() action.Pair {
 			return item.Description
 		},
 		UpdateSub: func(data *types.Resource) (identifier string, err error) {
-			return data.Name, connection.Client.UpdateResourceMetadata(data.ID, *data)
+			_, err = connection.Client.UpdateResourceMetadata(data.ID, *data)
+			return data.Name, err
 		},
 	})
 }


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses [issues#2365](https://github.com/gravwell/issues/issues/2365)

Sister PR to https://github.com/gravwell/backend/pull/3974

## This PR adds the ContentType and FileExtension fields to Files

## This PR makes the Resources API conform to that of most other assets

Resource update calls (Metadata or Populates) now return the updated metadata, like most other asset types do. This didn't actually require a change to backend as backend was always shipping over the updated metadata and we just weren't giving it back to the caller.

## This PR enables file extensions to be set into the HTTP request header

Currently, we *always* set 'file' as the file name in the http header for Resources. When backend tried to read the extension from this header, it would always find nothing. Now, both Files and Resources set 'file'+extension. We don't actually care about the name here, only reading the extension off the header. While we could read the extension verbatim from the metadata.... (see next point)

## This PR adds Populate*FromPath functions

These functions are expected to be the primary entry points for populating Files/Resources and set the extension automatically, rather than taking it as a param.

## PR Tasks

<!-- Add tasks to this list as needed -->

- [x] e2e and/or unit tests included. If not, please provide an explanation.
  - tests are included in the backend's testing suite, which has been updated to use the new semantics

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
