### PR TITLE
feat(#1138) Feature Parity part 3

### DIFF
--- a/gwcli/clilog/clilog.go
+++ b/gwcli/clilog/clilog.go
@@ -228,6 +228,14 @@ func GetFlag(err error) ErrInternal {
 	return ErrInternal{}
 }
 
+// CloseFile closes the give file and logs the error if one occurred.
+func CloseFile(f *os.File) {
+	if err := f.Close(); err != nil {
+		Writer.Warn("failed to close file", log.KV("parent", log.CallLoc(1)), log.KVErr(err))
+	}
+
+}
+
 // TypeAssert logs an error that an assertion failed.
 // Most commonly used when asserting list.Item to a local, enriched type.
 //

--- a/gwcli/internal/state/state.go
+++ b/gwcli/internal/state/state.go
@@ -17,4 +17,29 @@ func Interactive() bool {
 
 const Version string = "v0.8"
 
-// TODO move debug mode into here rather than repeatedly checking on clilog.Level
+var directInvoked bool
+
+// DirectInvoked means that an action was launched directly, but -x was not specified.
+// This implies that mother was booted, therefore interactivity is allowed, and that we'll die after this action invocation.
+func DirectInvoked() bool {
+	return directInvoked
+}
+
+// SetDirectInvoked notes that an action was launched directly and that Mother will execute it, then die.
+// It should only be called once if/when Mother has deemed that the call was a direct invocation and that gwcli will exit on action completion.
+func SetDirectInvoked() {
+	directInvoked = true
+}
+
+var debug bool
+
+// DebugMode authorizes additional run-time sanity checks.
+// It is currently set at startup time if --loglevel=DEBUG.
+func DebugMode() bool {
+	return debug
+}
+
+// SetDebugMode enables additional checks and verbose logging.
+func SetDebugMode() {
+	debug = true
+}

--- a/gwcli/internal/testsupport/testsupport.go
+++ b/gwcli/internal/testsupport/testsupport.go
@@ -17,16 +17,17 @@ import (
 	"io"
 	"maps"
 	"os"
+	"path"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/Pallinder/go-randomdata"
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/exp/teatest"
 	ft "github.com/gravwell/gravwell/v4/gwcli/stylesheet/flagtext"
-	"github.com/gravwell/gravwell/v4/gwcli/utilities/cfgdir"
 	"github.com/spf13/pflag"
 )
 
@@ -363,11 +364,14 @@ func MetaArgs(t *testing.T, allowInteractive bool, opts ...func(t *testing.T) []
 	return meta
 }
 
-// WithUsernamePassword includes -u and sets the given password into the test environment.
+// WithUsernamePassword includes -u and the password via a passfile.
 func WithUsernamePassword(u, p string) func(t *testing.T) []string {
 	return func(t *testing.T) []string {
-		t.Setenv(cfgdir.EnvKeyPassword, p)
-		return []string{"-u", u}
+		pth := path.Join(t.TempDir(), "pass-"+randomdata.Alphanumeric(10)+".txt")
+		if err := os.WriteFile(pth, []byte(p), 0755); err != nil {
+			t.Fatalf("failed to create passfile for login: %v", err)
+		}
+		return []string{"-u", u, "--passfile=" + pth}
 	}
 }
 

--- a/gwcli/stylesheet/flagtext/ft.go
+++ b/gwcli/stylesheet/flagtext/ft.go
@@ -32,8 +32,6 @@ import (
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/cfgdir"
 	"github.com/gravwell/gravwell/v4/ingest/log"
 	"github.com/spf13/pflag"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 // a flag is the minimum required for accessing and registering a flag for use in other actions.
@@ -267,78 +265,12 @@ var (
 		typ:   types.Int32,
 	}
 
-	//#region scaffoldlist/columns
-
-	// ShowColumns (--show-columns) is a local flag used by scaffold list to display all known columns.
-	// Unlikely to be used outside of actions that implement scaffold list.
-	ShowColumns = simple{
-		name:  "show-columns",
-		usage: "display the list of fully qualified column names and exit",
+	IncludeDeleted = simple{
+		name:  "include-deleted",
+		usage: "include data marked for deletion",
 		typ:   types.Bool,
 	}
-
-	// SelectColumns (--columns) is a local flag used by scaffold list to select which columns to display, overriding the default.
-	// Unlikely to be used outside of actions that implement scaffold list.
-	SelectColumns = stringSliceRegister{
-		name: "columns",
-		usage: "comma-separated list of columns to include in the results.\n" +
-			"Use --" + ShowColumns.name + " to see the full list of columns",
-	}
-
-	// AllColumns (--all-columns) is a local flag used by scaffold list to force the action to display data from all available columns.
-	// Unlikely to be used outside of actions that implement scaffold list.
-	AllColumns = simple{
-		name: "all-columns",
-		usage: "displays data from all columns, ignoring the default column set.\n" +
-			"Overrides --" + SelectColumns.name,
-		typ: types.Bool,
-	}
-
-	// #endregion scaffoldlist/columns
 )
-
-// need custom handling for GetAll.
-// Does not fit the flag interface, but it has similar enough usage so what's it matter?
-type getAllFlag struct {
-}
-
-// GetAll is a local flag that tells the implementing action to fetch all items, rather than just the current user's items (or something to that effect).
-// For example, providing this to macros should fetch all macros on the instance, rather than just your macros.
-var GetAll = getAllFlag{}
-
-func (gaf getAllFlag) Name() string { return "all" }
-
-// Register installs this flag in the given flagset.
-//
-// requiresAdmin prefixes "ADMIN ONLY" to the usage.
-//
-// plural is the plural form of the thing being fetched.
-//
-// usageSuffixLines an optional set of ordered sentences to be attached (separated by newlines) to the usage of this flag.
-// Each line will be titled cased and have a period appended.
-func (gaf getAllFlag) Register(fs *pflag.FlagSet, requiresAdmin bool, plural string, usageSuffixLines ...string) {
-	usage := "Lists all " + plural + " on the system."
-	if requiresAdmin {
-		usage = "ADMIN ONLY." + usage
-	}
-	// append each extra line
-	if usageSuffixLines != nil {
-		usage += "\n"
-		var (
-			sb  strings.Builder
-			ttl = cases.Title(language.English)
-		)
-		for _, line := range usageSuffixLines {
-			l := ttl.String(line)
-			if !strings.HasSuffix(l, ".") {
-				l += "."
-			}
-			sb.WriteString(l)
-		}
-	}
-
-	fs.Bool("all", false, strings.TrimSuffix(strings.TrimSpace(usage), "."))
-}
 
 // Frequency is a local flag for defining a cron-style interval in which something occurs.
 var Frequency = simple{
@@ -367,6 +299,9 @@ var Path = singular{
 	shorthand:   'f',
 	usagePrefix: "path to the",
 }
+
+const DirName = "dir"
+const DirUsagePrefix = "directory to "
 
 // WarnFlagIgnore returns a string about ignoring ignoredFlag due to causeFlag's existence.
 func WarnFlagIgnore(ignoredFlag, causeFlag string) string {

--- a/gwcli/stylesheet/helpers.go
+++ b/gwcli/stylesheet/helpers.go
@@ -231,3 +231,10 @@ func RequiredTitle(s string) string {
 func OptionalTitle(s string) string {
 	return Cur.SecondaryText.Render(s + ":")
 }
+
+var italics = lipgloss.NewStyle().Italic(true)
+
+// Italicize makes the text a little drunk.
+func Italicize(s string) string {
+	return italics.Render(s)
+}

--- a/gwcli/tree/actionables/actionables.go
+++ b/gwcli/tree/actionables/actionables.go
@@ -11,6 +11,7 @@ package actionables
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -32,6 +33,7 @@ import (
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldlist"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldselect"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/treeutils"
+	"github.com/gravwell/gravwell/v4/ingest/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -113,10 +115,9 @@ func get() action.Pair {
 }
 
 func create() action.Pair {
-	path := scaffoldcreate.FieldPath("")
+	path := scaffoldcreate.FieldPath("", false)
 	path.Flag.Usage = "path to the JSON file containing the actionable's contents. " +
 		"If not provided, the actionable will be created empty."
-	path.Required = false
 	return scaffoldcreate.NewCreateAction("actionable",
 		map[string]scaffoldcreate.Field{
 			"name":        scaffoldcreate.FieldName("actionable"),
@@ -130,14 +131,8 @@ func create() action.Pair {
 				CommonFields: types.CommonFields{
 					Name:        fields["name"].Provider.Get(),
 					Description: fields["description"].Provider.Get(),
+					Labels:      scaffoldcreate.GetLabelsFromField(fields["labels"]),
 				},
-			}
-			for lbl := range strings.SplitSeq(fields["labels"].Provider.Get(), ",") {
-				lbl = strings.TrimSpace(lbl)
-				if lbl == "" {
-					continue
-				}
-				spec.CommonFields.Labels = append(spec.CommonFields.Labels, lbl)
 			}
 
 			// attempt to read from the given JSON, if provided
@@ -232,31 +227,42 @@ func replace() action.Pair {
 			}
 			return items, nil
 		},
-		func(ID string, fs *pflag.FlagSet) (success string, _ error) {
+		func(IDs []string, fs *pflag.FlagSet) (_ []scaffold.Result, _ error) {
+			// This is an exactly1 function
+			if len(IDs) != 1 {
+				clilog.Writer.Warn("exactly1 function with incorrect number of IDs made it to operate()",
+					log.KV("count", len(IDs)),
+					scaffold.IdentifyCaller())
+				if len(IDs) == 0 {
+					return nil, errors.New(phrases.Exactly1ArgRequired("playbook ID"))
+				}
+			}
 			// fetch the actionables existing metadata; we only want to update the contents
-			a, err := connection.Client.GetActionable(ID)
+			a, err := connection.Client.GetActionable(IDs[0])
 			if err != nil {
 				if phrases.IsNotFoundErr(err) {
-					return "", phrases.ErrUnknownIdentifier(ID, "actionable ID")
+					return nil, phrases.ErrUnknownIdentifier(IDs[0], "actionable ID")
 				}
-				return "", err
+				return nil, err
 			}
 			// unmarshal the given json as contents
 			pth, _ := fs.GetString(ft.Path.Name())
 			f, err := os.Open(pth)
 			if err != nil {
-				return "", err
+				return nil, err
 			}
 			defer f.Close()
 			dcdr := json.NewDecoder(f)
 			if err := dcdr.Decode(&a.Contents); err != nil {
-				return "", err
+				return nil, err
 			}
 			a, err = connection.Client.UpdateActionable(a)
 			if err != nil {
-				return "", err
+				return nil, err
 			}
-			return fmt.Sprintf("replaced actionable definition of %s (ID: %s)", a.Name, a.ID), nil
+			return []scaffold.Result{
+				{Output: fmt.Sprintf("replaced actionable definition of %s (ID: %s)", a.Name, a.ID), Success: true},
+			}, nil
 		},
 		scaffoldselect.Options{
 			CommonOptions: scaffold.CommonOptions{

--- a/gwcli/tree/actionables/actionables.go
+++ b/gwcli/tree/actionables/actionables.go
@@ -234,7 +234,7 @@ func replace() action.Pair {
 					log.KV("count", len(IDs)),
 					scaffold.IdentifyCaller())
 				if len(IDs) == 0 {
-					return nil, errors.New(phrases.Exactly1ArgRequired("playbook ID"))
+					return nil, errors.New(phrases.Exactly1ArgRequired("actionable ID"))
 				}
 			}
 			// fetch the actionables existing metadata; we only want to update the contents

--- a/gwcli/tree/actionables/actionables.go
+++ b/gwcli/tree/actionables/actionables.go
@@ -57,8 +57,8 @@ func listAction() action.Pair {
 	return scaffoldlist.NewListAction("list actionables",
 		"List actionables available to your user.",
 		types.Actionable{},
-		func(fs *pflag.FlagSet) ([]types.Actionable, error) {
-			lr, err := connection.Client.ListActionables(&types.QueryOptions{AdminMode: connection.AdminMode()})
+		func(fs *pflag.FlagSet, params scaffoldlist.DataParameters) ([]types.Actionable, error) {
+			lr, err := connection.Client.ListActionables(params.QueryOpts)
 			if err != nil {
 				return nil, err
 			}

--- a/gwcli/tree/admin/admin.go
+++ b/gwcli/tree/admin/admin.go
@@ -13,7 +13,6 @@ package admin
 import (
 	"errors"
 	"fmt"
-	"gravwell/pkg/utils"
 	"maps"
 	"os"
 	"slices"
@@ -66,7 +65,7 @@ func NewNav() *cobra.Command {
 			restore(),
 			Status("status"),
 			listUserSearchStorage(),
-			validateBackup(),
+			//validateBackup(),
 			massChown(),
 			chown(),
 		},
@@ -492,7 +491,7 @@ func listUserSearchStorage() action.Pair {
 	)
 }
 
-func validateBackup() action.Pair {
+/*func validateBackup() action.Pair {
 	return scaffold.NewBasicAction("validate-backup", "validate backup files",
 		"Test that local gravwell backups are valid.",
 		func(fs *pflag.FlagSet) (output string, addtlCmds tea.Cmd) {
@@ -531,7 +530,7 @@ func validateBackup() action.Pair {
 				return "", nil
 			},
 		})
-}
+}*/
 
 func massChown() action.Pair {
 	return scaffold.NewBasicAction("mass-chown", "transfer all items to another user",

--- a/gwcli/tree/admin/admin.go
+++ b/gwcli/tree/admin/admin.go
@@ -630,7 +630,7 @@ func massChown() action.Pair {
 				for _, res := range lr.Results {
 					res.CommonFields.OwnerID = to
 					if _, err := connection.Client.UpdateActionable(res); err != nil {
-						fmt.Fprintf(&sb, "failed to chown actionables %s: %v", res.ID, err)
+						fmt.Fprintf(&sb, "failed to chown actionable %s: %v", res.ID, err)
 						if !noFail {
 							return sb.String(), nil
 						}
@@ -651,7 +651,7 @@ func massChown() action.Pair {
 				for _, res := range lr.Results {
 					res.CommonFields.OwnerID = to
 					if _, err := connection.Client.UpdatePlaybook(res); err != nil {
-						fmt.Fprintf(&sb, "failed to chown playbooks %s: %v", res.ID, err)
+						fmt.Fprintf(&sb, "failed to chown playbook %s: %v", res.ID, err)
 						if !noFail {
 							return sb.String(), nil
 						}
@@ -735,7 +735,7 @@ func massChown() action.Pair {
 				for _, res := range lr.Results {
 					res.CommonFields.OwnerID = to
 					if _, err := connection.Client.UpdateTemplate(res); err != nil {
-						fmt.Fprintf(&sb, "failed to chown templates %s: %v", res.ID, err)
+						fmt.Fprintf(&sb, "failed to chown template %s: %v", res.ID, err)
 						if !noFail {
 							return sb.String(), nil
 						}
@@ -841,7 +841,7 @@ func massChown() action.Pair {
 				for _, res := range lr.Results {
 					res.CommonFields.OwnerID = to
 					if _, err := connection.Client.UpdateSecret(res.ID, types.SecretCreate{CommonFields: res.CommonFields}); err != nil {
-						fmt.Fprintf(&sb, "failed to chown alert %s: %v", res.ID, err)
+						fmt.Fprintf(&sb, "failed to chown secret %s: %v", res.ID, err)
 						if !noFail {
 							return sb.String(), nil
 						}
@@ -849,7 +849,7 @@ func massChown() action.Pair {
 						success += 1
 					}
 				}
-				chownedString(&sb, success, "alert")
+				chownedString(&sb, success, "secret")
 			}
 			// tokens
 			sb.WriteString(stylesheet.Italicize("NOTE: tokens do not support owner reassignment"))
@@ -957,7 +957,7 @@ func chown() action.Pair {
 			// TODO currently being skipped, as they were skipped pre-6.0.0
 			// extractions
 			if lr, err := connection.Client.ListAllExtractions(qo); err != nil {
-				clilog.Writer.Error("failed to get dashboards", log.KVErr(err))
+				clilog.Writer.Error("failed to get extractions", log.KVErr(err))
 				return nil, err
 			} else {
 				for _, res := range lr.Results {
@@ -970,7 +970,7 @@ func chown() action.Pair {
 			}
 			// actionables
 			if lr, err := connection.Client.ListAllActionables(qo); err != nil {
-				clilog.Writer.Error("failed to get dashboards", log.KVErr(err))
+				clilog.Writer.Error("failed to get actionables", log.KVErr(err))
 				return nil, err
 			} else {
 				for _, res := range lr.Results {
@@ -983,7 +983,7 @@ func chown() action.Pair {
 			}
 			// playbooks
 			if lr, err := connection.Client.ListAllPlaybooks(qo); err != nil {
-				clilog.Writer.Error("failed to get dashboards", log.KVErr(err))
+				clilog.Writer.Error("failed to get playbooks", log.KVErr(err))
 				return nil, err
 			} else {
 				for _, res := range lr.Results {
@@ -996,7 +996,7 @@ func chown() action.Pair {
 			}
 			// scheduled searches
 			if lr, err := connection.Client.ListAllScheduledSearches(qo); err != nil {
-				clilog.Writer.Error("failed to get dashboards", log.KVErr(err))
+				clilog.Writer.Error("failed to get scheduled searches", log.KVErr(err))
 				return nil, err
 			} else {
 				for _, res := range lr.Results {
@@ -1009,7 +1009,7 @@ func chown() action.Pair {
 			}
 			// scheduled scripts
 			if lr, err := connection.Client.ListAllScheduledScripts(qo); err != nil {
-				clilog.Writer.Error("failed to get dashboards", log.KVErr(err))
+				clilog.Writer.Error("failed to get scheduled scripts", log.KVErr(err))
 				return nil, err
 			} else {
 				for _, res := range lr.Results {
@@ -1022,7 +1022,7 @@ func chown() action.Pair {
 			}
 			// files
 			if lr, err := connection.Client.ListAllFiles(qo); err != nil {
-				clilog.Writer.Error("failed to get dashboards", log.KVErr(err))
+				clilog.Writer.Error("failed to get files", log.KVErr(err))
 				return nil, err
 			} else {
 				for _, res := range lr.Results {
@@ -1035,7 +1035,7 @@ func chown() action.Pair {
 			}
 			// templates
 			if lr, err := connection.Client.ListAllTemplates(qo); err != nil {
-				clilog.Writer.Error("failed to get dashboards", log.KVErr(err))
+				clilog.Writer.Error("failed to get templates", log.KVErr(err))
 				return nil, err
 			} else {
 				for _, res := range lr.Results {
@@ -1048,7 +1048,7 @@ func chown() action.Pair {
 			}
 			// resources
 			if lr, err := connection.Client.ListAllResources(qo); err != nil {
-				clilog.Writer.Error("failed to get dashboards", log.KVErr(err))
+				clilog.Writer.Error("failed to get resources", log.KVErr(err))
 				return nil, err
 			} else {
 				for _, res := range lr.Results {
@@ -1061,7 +1061,7 @@ func chown() action.Pair {
 			}
 			// macros
 			if lr, err := connection.Client.ListAllMacros(qo); err != nil {
-				clilog.Writer.Error("failed to get dashboards", log.KVErr(err))
+				clilog.Writer.Error("failed to get macros", log.KVErr(err))
 				return nil, err
 			} else {
 				for _, res := range lr.Results {
@@ -1074,7 +1074,7 @@ func chown() action.Pair {
 			}
 			// flows
 			if lr, err := connection.Client.ListAllFlows(qo); err != nil {
-				clilog.Writer.Error("failed to get dashboards", log.KVErr(err))
+				clilog.Writer.Error("failed to get flows", log.KVErr(err))
 				return nil, err
 			} else {
 				for _, res := range lr.Results {
@@ -1087,7 +1087,7 @@ func chown() action.Pair {
 			}
 			// alerts
 			if lr, err := connection.Client.ListAllAlerts(qo); err != nil {
-				clilog.Writer.Error("failed to get dashboards", log.KVErr(err))
+				clilog.Writer.Error("failed to get alerts", log.KVErr(err))
 				return nil, err
 			} else {
 				for _, res := range lr.Results {

--- a/gwcli/tree/admin/admin.go
+++ b/gwcli/tree/admin/admin.go
@@ -755,7 +755,7 @@ func massChown() action.Pair {
 				var success uint
 				for _, res := range lr.Results {
 					res.CommonFields.OwnerID = from
-					if err := connection.Client.UpdateResourceMetadata(res.ID, res); err != nil {
+					if _, err := connection.Client.UpdateResourceMetadata(res.ID, res); err != nil {
 						fmt.Fprintf(&sb, "failed to chown resource %s: %v", res.ID, err)
 						if !noFail {
 							return sb.String(), nil
@@ -830,8 +830,7 @@ func massChown() action.Pair {
 				chownedString(&sb, success, "alert")
 			}
 
-			// TODO update if secrets and tokens can *now* be updated
-			// secrets
+			// secrets // TODO test
 			if lr, err := connection.Client.ListAllSecrets(qo); err != nil {
 				clilog.Tee(clilog.ERROR, &sb, "failed to get secrets: "+err.Error()+"\n")
 				if !noFail {
@@ -1322,7 +1321,7 @@ func transferEntity(ID string, from, to int32) error {
 			return fmt.Errorf("resource (ID: %s) does not belong to from-user (ID: %d)", ID, from)
 		}
 		itm.OwnerID = to
-		if err := connection.Client.UpdateResourceMetadata(ID, itm); phrases.IsNotFoundErr(err) {
+		if _, err := connection.Client.UpdateResourceMetadata(ID, itm); phrases.IsNotFoundErr(err) {
 			return phrases.ErrUnknownIdentifier(ID, "resource")
 		} else if err != nil {
 			return err

--- a/gwcli/tree/admin/admin.go
+++ b/gwcli/tree/admin/admin.go
@@ -539,6 +539,7 @@ func massChown() action.Pair {
 			"Please note that tokens and kits do not current support owner reassignment and will be skipped.",
 		func(fs *pflag.FlagSet) (output string, addtlCmds tea.Cmd) {
 			from, _ := fs.GetInt32("from")
+			to, _ := fs.GetInt32("to")
 			noFail, _ := fs.GetBool("no-fail")
 			// ensure we are in admin mode to ensure we get all data
 			if !connection.Client.AdminMode() {
@@ -562,7 +563,7 @@ func massChown() action.Pair {
 			} else {
 				var success uint
 				for _, res := range lr.Results {
-					res.CommonFields.OwnerID = from
+					res.CommonFields.OwnerID = to
 					if _, err := connection.Client.UpdateSavedQuery(res); err != nil {
 						fmt.Fprintf(&sb, "failed to chown saved query %s: %v", res.ID, err)
 						if !noFail {
@@ -583,7 +584,7 @@ func massChown() action.Pair {
 			} else {
 				var success uint
 				for _, res := range lr.Results {
-					res.CommonFields.OwnerID = from
+					res.CommonFields.OwnerID = to
 					if _, err := connection.Client.UpdateDashboard(res); err != nil {
 						fmt.Fprintf(&sb, "failed to chown dashboard %s: %v", res.ID, err)
 						if !noFail {
@@ -596,7 +597,7 @@ func massChown() action.Pair {
 				chownedString(&sb, success, "dashboard")
 			}
 			// kits
-			sb.WriteString("chowning kits is not currently supported")
+			sb.WriteString("chowning kits is not currently supported\n")
 
 			// extractions
 			if lr, err := connection.Client.ListAllExtractions(qo); err != nil {
@@ -607,7 +608,7 @@ func massChown() action.Pair {
 			} else {
 				var success uint
 				for _, res := range lr.Results {
-					res.CommonFields.OwnerID = from
+					res.CommonFields.OwnerID = to
 					if _, err := connection.Client.UpdateExtraction(res); err != nil {
 						fmt.Fprintf(&sb, "failed to chown extraction %s: %v", res.ID, err)
 						if !noFail {
@@ -628,7 +629,7 @@ func massChown() action.Pair {
 			} else {
 				var success uint
 				for _, res := range lr.Results {
-					res.CommonFields.OwnerID = from
+					res.CommonFields.OwnerID = to
 					if _, err := connection.Client.UpdateActionable(res); err != nil {
 						fmt.Fprintf(&sb, "failed to chown actionables %s: %v", res.ID, err)
 						if !noFail {
@@ -649,7 +650,7 @@ func massChown() action.Pair {
 			} else {
 				var success uint
 				for _, res := range lr.Results {
-					res.CommonFields.OwnerID = from
+					res.CommonFields.OwnerID = to
 					if _, err := connection.Client.UpdatePlaybook(res); err != nil {
 						fmt.Fprintf(&sb, "failed to chown playbooks %s: %v", res.ID, err)
 						if !noFail {
@@ -670,7 +671,7 @@ func massChown() action.Pair {
 			} else {
 				var success uint
 				for _, res := range lr.Results {
-					res.CommonFields.OwnerID = from
+					res.CommonFields.OwnerID = to
 					if err := connection.Client.UpdateScheduledSearch(res); err != nil {
 						fmt.Fprintf(&sb, "failed to chown scheduled search %s: %v", res.ID, err)
 						if !noFail {
@@ -691,7 +692,7 @@ func massChown() action.Pair {
 			} else {
 				var success uint
 				for _, res := range lr.Results {
-					res.CommonFields.OwnerID = from
+					res.CommonFields.OwnerID = to
 					if err := connection.Client.UpdateScheduledScript(res); err != nil {
 						fmt.Fprintf(&sb, "failed to chown scheduled script %s: %v", res.ID, err)
 						if !noFail {
@@ -712,7 +713,7 @@ func massChown() action.Pair {
 			} else {
 				var success uint
 				for _, res := range lr.Results {
-					res.CommonFields.OwnerID = from
+					res.CommonFields.OwnerID = to
 					if _, err := connection.Client.UpdateFileMetadata(res.ID, res); err != nil {
 						fmt.Fprintf(&sb, "failed to chown file %s: %v", res.ID, err)
 						if !noFail {
@@ -733,7 +734,7 @@ func massChown() action.Pair {
 			} else {
 				var success uint
 				for _, res := range lr.Results {
-					res.CommonFields.OwnerID = from
+					res.CommonFields.OwnerID = to
 					if _, err := connection.Client.UpdateTemplate(res); err != nil {
 						fmt.Fprintf(&sb, "failed to chown templates %s: %v", res.ID, err)
 						if !noFail {
@@ -754,7 +755,7 @@ func massChown() action.Pair {
 			} else {
 				var success uint
 				for _, res := range lr.Results {
-					res.CommonFields.OwnerID = from
+					res.CommonFields.OwnerID = to
 					if _, err := connection.Client.UpdateResourceMetadata(res.ID, res); err != nil {
 						fmt.Fprintf(&sb, "failed to chown resource %s: %v", res.ID, err)
 						if !noFail {
@@ -775,7 +776,7 @@ func massChown() action.Pair {
 			} else {
 				var success uint
 				for _, res := range lr.Results {
-					res.CommonFields.OwnerID = from
+					res.CommonFields.OwnerID = to
 					if err := connection.Client.UpdateMacro(res); err != nil {
 						fmt.Fprintf(&sb, "failed to chown macro %s: %v", res.ID, err)
 						if !noFail {
@@ -796,7 +797,7 @@ func massChown() action.Pair {
 			} else {
 				var success uint
 				for _, res := range lr.Results {
-					res.CommonFields.OwnerID = from
+					res.CommonFields.OwnerID = to
 					if err := connection.Client.UpdateFlow(res); err != nil {
 						fmt.Fprintf(&sb, "failed to chown flow %s: %v", res.ID, err)
 						if !noFail {
@@ -817,7 +818,7 @@ func massChown() action.Pair {
 			} else {
 				var success uint
 				for _, res := range lr.Results {
-					res.CommonFields.OwnerID = from
+					res.CommonFields.OwnerID = to
 					if _, err := connection.Client.UpdateAlert(res); err != nil {
 						fmt.Fprintf(&sb, "failed to chown alert %s: %v", res.ID, err)
 						if !noFail {
@@ -839,7 +840,7 @@ func massChown() action.Pair {
 			} else {
 				var success uint
 				for _, res := range lr.Results {
-					res.CommonFields.OwnerID = from
+					res.CommonFields.OwnerID = to
 					if _, err := connection.Client.UpdateSecret(res.ID, types.SecretCreate{CommonFields: res.CommonFields}); err != nil {
 						fmt.Fprintf(&sb, "failed to chown alert %s: %v", res.ID, err)
 						if !noFail {

--- a/gwcli/tree/admin/admin.go
+++ b/gwcli/tree/admin/admin.go
@@ -858,6 +858,7 @@ func massChown() action.Pair {
 		},
 		scaffold.BasicOptions{
 			CommonOptions: scaffold.CommonOptions{
+				Usage: "mass-chown --from=<UID> --to=<UID>",
 				AddtlFlags: func() *pflag.FlagSet {
 					fs := &pflag.FlagSet{}
 					fs.Int32("to", 0, "user ID  to transfer ownership to")

--- a/gwcli/tree/admin/admin.go
+++ b/gwcli/tree/admin/admin.go
@@ -11,24 +11,35 @@
 package admin
 
 import (
+	"errors"
 	"fmt"
+	"gravwell/pkg/utils"
 	"maps"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/dustin/go-humanize/english"
 	"github.com/gravwell/gravwell/v4/client/types"
 	"github.com/gravwell/gravwell/v4/gwcli/action"
+	"github.com/gravwell/gravwell/v4/gwcli/bubbles/multiselectlist"
 	"github.com/gravwell/gravwell/v4/gwcli/clilog"
 	"github.com/gravwell/gravwell/v4/gwcli/connection"
+	"github.com/gravwell/gravwell/v4/gwcli/internal/listitem"
+	"github.com/gravwell/gravwell/v4/gwcli/internal/state"
+	"github.com/gravwell/gravwell/v4/gwcli/stylesheet"
 	ft "github.com/gravwell/gravwell/v4/gwcli/stylesheet/flagtext"
 	"github.com/gravwell/gravwell/v4/gwcli/stylesheet/phrases"
 	"github.com/gravwell/gravwell/v4/gwcli/tree/admin/groups"
 	"github.com/gravwell/gravwell/v4/gwcli/tree/admin/license"
 	admin_users "github.com/gravwell/gravwell/v4/gwcli/tree/admin/users"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold"
+	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldlist"
+	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldselect"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/treeutils"
+	"github.com/gravwell/gravwell/v4/ingest"
 	"github.com/gravwell/gravwell/v4/ingest/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -53,6 +64,11 @@ func NewNav() *cobra.Command {
 			addIndexer(),
 			backup(),
 			restore(),
+			Status("status"),
+			listUserSearchStorage(),
+			validateBackup(),
+			massChown(),
+			chown(),
 		},
 	)
 }
@@ -336,4 +352,1037 @@ func restore() action.Pair {
 				return "", nil
 			},
 		})
+}
+
+// Status displays if your account is an administrator and if you are currently in admin mode.
+// NOTE: this action is provided to both the `admin` nav (as `status`) and the `self` nav. Hence the export.
+func Status(use string) action.Pair {
+	return scaffold.NewBasicAction(use, "display your admin status or toggle admin mode", "Displays whether or not you are an admin.\n"+
+		"In interactive mode, -t can be used to toggle "+stylesheet.Cur.ErrorText.Render("admin mode")+" which will attach admin=true to future request.\n"+
+		"For the most part, this just implies --all in calls that support it, resulting in lists displaying results from all users.\n"+
+		"\n"+
+		"Exercise caution in admin mode, as it gives access to objects belonging to other users and makes it easy to break things.\n"+
+		"Admin mode does not persist between sessions and has no effect if invoked non-interactively.",
+		func(fs *pflag.FlagSet) (string, tea.Cmd) {
+			isAdministrator, err := connection.Client.IsAdmin()
+			if err != nil {
+				return "failed to fetch administrator status: " + err.Error(), nil
+			}
+			var statusSB strings.Builder
+			if isAdministrator {
+				statusSB.WriteString("You are an administrator.\n")
+			} else {
+				statusSB.WriteString("You are not an administrator.\n")
+			}
+			// if we are not spinning up a full, interactive shell, admin mode doesn't matter.
+			if !state.Interactive() && !state.DirectInvoked() {
+				return statusSB.String(), nil
+			}
+
+			{ // branch on toggle flag
+				t, err := fs.GetBool("toggle")
+				clilog.GetFlag(err)
+				if t {
+					return toggle(isAdministrator)
+				}
+			}
+
+			// attach admin mode to the output string
+			if inAdminMode := connection.AdminMode(); inAdminMode {
+				statusSB.WriteString("You are in admin mode.\n")
+				if isAdministrator {
+					statusSB.WriteString("Yet, you are somehow in admin mode.\n" +
+						"Admin mode will be ineffectual.\n")
+				}
+			} else {
+				statusSB.WriteString("You are not in admin mode.\n")
+			}
+			return statusSB.String(), nil
+		},
+		scaffold.BasicOptions{
+			CommonOptions: scaffold.CommonOptions{
+				Usage: use + " " + ft.Optional("--toggle"),
+				AddtlFlags: func() *pflag.FlagSet {
+					fs := &pflag.FlagSet{}
+					fs.BoolP("toggle", "t", false, ft.InteractiveOnly()+" Toggle admin mode for this session.")
+					return fs
+				},
+			},
+		})
+}
+
+func toggle(isAdministrator bool) (string, tea.Cmd) {
+	if !isAdministrator {
+		return "Only administrators can toggle admin mode", nil
+	}
+	if !connection.Client.AdminMode() {
+		connection.Client.SetAdminMode()
+		return "You are now in admin mode", nil
+	}
+	connection.Client.ClearAdminMode()
+	return "You are no longer in admin mode", nil
+
+}
+
+type userSearchStorage struct {
+	UID      int32
+	Username string // username
+	Stored   string // humanized int64
+}
+
+func listUserSearchStorage() action.Pair {
+	return scaffoldlist.NewListAction("show the storage of each user's searches",
+		"Display the cumulative storage space consumed by each user's active searches.\n"+
+			"This does not factor in other items related to this user that are stored on the system.",
+		userSearchStorage{},
+		func(addtlFlags *pflag.FlagSet, params scaffoldlist.DataParameters) ([]userSearchStorage, error) {
+			statuses, err := connection.Client.ListAllSearchStatuses()
+			if err != nil {
+				return nil, err
+			} else if len(statuses) < 1 {
+				return nil, nil
+			}
+			storageMap := map[int32]int64{}
+			for _, s := range statuses {
+				if s.StoredData > 0 {
+					storageMap[s.UID] += s.StoredData // starts as bytes
+				}
+			}
+			if len(storageMap) < 1 {
+				return nil, nil
+			}
+
+			// map usernames to their IDs and humanize storage costs
+			userMap, err := connection.Client.GetUserMap()
+			if err != nil { // failing to fetch usernames is fine, just make sure the map is initialized
+				clilog.Writer.Warn("failed to fetch list of users", log.KVErr(err))
+			} else if userMap == nil {
+				userMap = map[int32]string{}
+			}
+			storage := make([]userSearchStorage, len(storageMap))
+			// sort by size, descending
+			sorted := slices.Collect(maps.Keys(storageMap))
+			slices.SortStableFunc(sorted, func(uidA, uidB int32) int {
+				if storageMap[uidA] < storageMap[uidB] {
+					return 1
+				} else if storageMap[uidA] > storageMap[uidB] {
+					return -1
+				}
+				return 0
+			})
+			for i, uid := range sorted {
+				username := "[unknown]"
+				if u, found := userMap[uid]; found {
+					username = u
+				}
+				storage[i] = userSearchStorage{
+					UID:      uid,
+					Username: username,
+					Stored:   ingest.HumanSize(uint64(storageMap[uid])),
+				}
+			}
+			return storage, nil
+		},
+		nil, scaffoldlist.Options{
+			CommonOptions: scaffold.CommonOptions{
+				Use: "search-storage",
+			},
+			DefaultColumns: []string{"Username", "UID", "Stored"},
+			EmptyMessage:   "There are no active searches currently storing data."},
+	)
+}
+
+func validateBackup() action.Pair {
+	return scaffold.NewBasicAction("validate-backup", "validate backup files",
+		"Test that local gravwell backups are valid.",
+		func(fs *pflag.FlagSet) (output string, addtlCmds tea.Cmd) {
+			var sb strings.Builder
+			for _, path := range fs.Args() {
+				f, err := os.Open(path)
+				if err != nil {
+					sb.WriteString(stylesheet.Cur.ErrorText.Render(err.Error()))
+					sb.WriteString("\n")
+					continue
+				}
+				// the load does a full validation of the underlying
+				ht, err := utils.LoadHashingTar(f, types.CanonicalVersion{}, types.CanonicalVersion{})
+				if err != nil {
+					fmt.Fprintf(&sb, "backup %s is invalid: %v\n", path, err)
+					f.Close()
+					continue
+				}
+				objCount, version, err := ht.Info()
+				if err != nil {
+					fmt.Fprintf(&sb, "backup %s is invalid: %v\n", path, err)
+					f.Close()
+					continue
+				}
+				fmt.Fprintf(&sb, "backup %s validated with %d objects (created by Gravwell version %s)\n",
+					path, objCount, version.Build.CanonicalVersion.String())
+				f.Close()
+			}
+			return sb.String(), nil
+		},
+		scaffold.BasicOptions{
+			ValidateArgs: func(fs *pflag.FlagSet) (invalid string, err error) {
+				if fs.NArg() < 1 {
+					return phrases.AtLeast1ArgRequired("path to backup file"), nil
+				}
+				return "", nil
+			},
+		})
+}
+
+func massChown() action.Pair {
+	return scaffold.NewBasicAction("mass-chown", "transfer all items to another user",
+		"Mass transfer all items owned by one user to another user.\n"+
+			"Please note that tokens and kits do not current support owner reassignment and will be skipped.",
+		func(fs *pflag.FlagSet) (output string, addtlCmds tea.Cmd) {
+			from, _ := fs.GetInt32("from")
+			noFail, _ := fs.GetBool("no-fail")
+			// ensure we are in admin mode to ensure we get all data
+			if !connection.Client.AdminMode() {
+				connection.Client.SetAdminMode()
+				defer connection.Client.ClearAdminMode()
+			}
+			qo := &types.QueryOptions{
+				Filters: []types.Filter{
+					{Key: "OwnerID", Operation: "=", Values: []any{from}},
+				},
+			}
+
+			var sb strings.Builder
+
+			// saved queries
+			if lr, err := connection.Client.ListAllSavedQueries(qo); err != nil {
+				clilog.Tee(clilog.ERROR, &sb, "failed to get saved queries: "+err.Error()+"\n")
+				if !noFail {
+					return sb.String(), nil
+				}
+			} else {
+				var success uint
+				for _, res := range lr.Results {
+					res.CommonFields.OwnerID = from
+					if _, err := connection.Client.UpdateSavedQuery(res); err != nil {
+						fmt.Fprintf(&sb, "failed to chown saved query %s: %v", res.ID, err)
+						if !noFail {
+							return sb.String(), nil
+						}
+					} else {
+						success += 1
+					}
+				}
+				chownedString(&sb, success, "saved query")
+			}
+			// dashboards
+			if lr, err := connection.Client.ListAllDashboards(qo); err != nil {
+				clilog.Tee(clilog.ERROR, &sb, "failed to get dashboards: "+err.Error()+"\n")
+				if !noFail {
+					return sb.String(), nil
+				}
+			} else {
+				var success uint
+				for _, res := range lr.Results {
+					res.CommonFields.OwnerID = from
+					if _, err := connection.Client.UpdateDashboard(res); err != nil {
+						fmt.Fprintf(&sb, "failed to chown dashboard %s: %v", res.ID, err)
+						if !noFail {
+							return sb.String(), nil
+						}
+					} else {
+						success += 1
+					}
+				}
+				chownedString(&sb, success, "dashboard")
+			}
+			// kits
+			sb.WriteString("chowning kits is not currently supported")
+
+			// extractions
+			if lr, err := connection.Client.ListAllExtractions(qo); err != nil {
+				clilog.Tee(clilog.ERROR, &sb, "failed to get extractions: "+err.Error()+"\n")
+				if !noFail {
+					return sb.String(), nil
+				}
+			} else {
+				var success uint
+				for _, res := range lr.Results {
+					res.CommonFields.OwnerID = from
+					if _, err := connection.Client.UpdateExtraction(res); err != nil {
+						fmt.Fprintf(&sb, "failed to chown extraction %s: %v", res.ID, err)
+						if !noFail {
+							return sb.String(), nil
+						}
+					} else {
+						success += 1
+					}
+				}
+				chownedString(&sb, success, "extraction")
+			}
+			// actionables
+			if lr, err := connection.Client.ListAllActionables(qo); err != nil {
+				clilog.Tee(clilog.ERROR, &sb, "failed to get actionables: "+err.Error()+"\n")
+				if !noFail {
+					return sb.String(), nil
+				}
+			} else {
+				var success uint
+				for _, res := range lr.Results {
+					res.CommonFields.OwnerID = from
+					if _, err := connection.Client.UpdateActionable(res); err != nil {
+						fmt.Fprintf(&sb, "failed to chown actionables %s: %v", res.ID, err)
+						if !noFail {
+							return sb.String(), nil
+						}
+					} else {
+						success += 1
+					}
+				}
+				chownedString(&sb, success, "actionable")
+			}
+			// playbooks
+			if lr, err := connection.Client.ListAllPlaybooks(qo); err != nil {
+				clilog.Tee(clilog.ERROR, &sb, "failed to get playbooks: "+err.Error()+"\n")
+				if !noFail {
+					return sb.String(), nil
+				}
+			} else {
+				var success uint
+				for _, res := range lr.Results {
+					res.CommonFields.OwnerID = from
+					if _, err := connection.Client.UpdatePlaybook(res); err != nil {
+						fmt.Fprintf(&sb, "failed to chown playbooks %s: %v", res.ID, err)
+						if !noFail {
+							return sb.String(), nil
+						}
+					} else {
+						success += 1
+					}
+				}
+				chownedString(&sb, success, "playbook")
+			}
+			// scheduled searches
+			if lr, err := connection.Client.ListAllScheduledSearches(qo); err != nil {
+				clilog.Tee(clilog.ERROR, &sb, "failed to get scheduled searches: "+err.Error()+"\n")
+				if !noFail {
+					return sb.String(), nil
+				}
+			} else {
+				var success uint
+				for _, res := range lr.Results {
+					res.CommonFields.OwnerID = from
+					if err := connection.Client.UpdateScheduledSearch(res); err != nil {
+						fmt.Fprintf(&sb, "failed to chown scheduled search %s: %v", res.ID, err)
+						if !noFail {
+							return sb.String(), nil
+						}
+					} else {
+						success += 1
+					}
+				}
+				chownedString(&sb, success, "scheduled search")
+			}
+			// scheduled scripts
+			if lr, err := connection.Client.ListAllScheduledScripts(qo); err != nil {
+				clilog.Tee(clilog.ERROR, &sb, "failed to get scheduled scripts: "+err.Error()+"\n")
+				if !noFail {
+					return sb.String(), nil
+				}
+			} else {
+				var success uint
+				for _, res := range lr.Results {
+					res.CommonFields.OwnerID = from
+					if err := connection.Client.UpdateScheduledScript(res); err != nil {
+						fmt.Fprintf(&sb, "failed to chown scheduled script %s: %v", res.ID, err)
+						if !noFail {
+							return sb.String(), nil
+						}
+					} else {
+						success += 1
+					}
+				}
+				chownedString(&sb, success, "scheduled script")
+			}
+			// files
+			if lr, err := connection.Client.ListAllFiles(qo); err != nil {
+				clilog.Tee(clilog.ERROR, &sb, "failed to get files: "+err.Error()+"\n")
+				if !noFail {
+					return sb.String(), nil
+				}
+			} else {
+				var success uint
+				for _, res := range lr.Results {
+					res.CommonFields.OwnerID = from
+					if _, err := connection.Client.UpdateFileMetadata(res.ID, res); err != nil {
+						fmt.Fprintf(&sb, "failed to chown file %s: %v", res.ID, err)
+						if !noFail {
+							return sb.String(), nil
+						}
+					} else {
+						success += 1
+					}
+				}
+				chownedString(&sb, success, "file")
+			}
+			// templates
+			if lr, err := connection.Client.ListAllTemplates(qo); err != nil {
+				clilog.Tee(clilog.ERROR, &sb, "failed to get templates: "+err.Error()+"\n")
+				if !noFail {
+					return sb.String(), nil
+				}
+			} else {
+				var success uint
+				for _, res := range lr.Results {
+					res.CommonFields.OwnerID = from
+					if _, err := connection.Client.UpdateTemplate(res); err != nil {
+						fmt.Fprintf(&sb, "failed to chown templates %s: %v", res.ID, err)
+						if !noFail {
+							return sb.String(), nil
+						}
+					} else {
+						success += 1
+					}
+				}
+				chownedString(&sb, success, "template")
+			}
+			// resources
+			if lr, err := connection.Client.ListAllResources(qo); err != nil {
+				clilog.Tee(clilog.ERROR, &sb, "failed to get resources: "+err.Error()+"\n")
+				if !noFail {
+					return sb.String(), nil
+				}
+			} else {
+				var success uint
+				for _, res := range lr.Results {
+					res.CommonFields.OwnerID = from
+					if err := connection.Client.UpdateResourceMetadata(res.ID, res); err != nil {
+						fmt.Fprintf(&sb, "failed to chown resource %s: %v", res.ID, err)
+						if !noFail {
+							return sb.String(), nil
+						}
+					} else {
+						success += 1
+					}
+				}
+				chownedString(&sb, success, "resource")
+			}
+			// macros
+			if lr, err := connection.Client.ListAllMacros(qo); err != nil {
+				clilog.Tee(clilog.ERROR, &sb, "failed to get macros: "+err.Error()+"\n")
+				if !noFail {
+					return sb.String(), nil
+				}
+			} else {
+				var success uint
+				for _, res := range lr.Results {
+					res.CommonFields.OwnerID = from
+					if err := connection.Client.UpdateMacro(res); err != nil {
+						fmt.Fprintf(&sb, "failed to chown macro %s: %v", res.ID, err)
+						if !noFail {
+							return sb.String(), nil
+						}
+					} else {
+						success += 1
+					}
+				}
+				chownedString(&sb, success, "macro")
+			}
+			// flows
+			if lr, err := connection.Client.ListAllFlows(qo); err != nil {
+				clilog.Tee(clilog.ERROR, &sb, "failed to get flows: "+err.Error()+"\n")
+				if !noFail {
+					return sb.String(), nil
+				}
+			} else {
+				var success uint
+				for _, res := range lr.Results {
+					res.CommonFields.OwnerID = from
+					if err := connection.Client.UpdateFlow(res); err != nil {
+						fmt.Fprintf(&sb, "failed to chown flow %s: %v", res.ID, err)
+						if !noFail {
+							return sb.String(), nil
+						}
+					} else {
+						success += 1
+					}
+				}
+				chownedString(&sb, success, "flow")
+			}
+			// alerts
+			if lr, err := connection.Client.ListAllAlerts(qo); err != nil {
+				clilog.Tee(clilog.ERROR, &sb, "failed to get alerts: "+err.Error()+"\n")
+				if !noFail {
+					return sb.String(), nil
+				}
+			} else {
+				var success uint
+				for _, res := range lr.Results {
+					res.CommonFields.OwnerID = from
+					if _, err := connection.Client.UpdateAlert(res); err != nil {
+						fmt.Fprintf(&sb, "failed to chown alert %s: %v", res.ID, err)
+						if !noFail {
+							return sb.String(), nil
+						}
+					} else {
+						success += 1
+					}
+				}
+				chownedString(&sb, success, "alert")
+			}
+
+			// TODO update if secrets and tokens can *now* be updated
+			// secrets
+			if lr, err := connection.Client.ListAllSecrets(qo); err != nil {
+				clilog.Tee(clilog.ERROR, &sb, "failed to get secrets: "+err.Error()+"\n")
+				if !noFail {
+					return sb.String(), nil
+				}
+			} else {
+				var success uint
+				for _, res := range lr.Results {
+					res.CommonFields.OwnerID = from
+					if _, err := connection.Client.UpdateSecret(res.ID, types.SecretCreate{CommonFields: res.CommonFields}); err != nil {
+						fmt.Fprintf(&sb, "failed to chown alert %s: %v", res.ID, err)
+						if !noFail {
+							return sb.String(), nil
+						}
+					} else {
+						success += 1
+					}
+				}
+				chownedString(&sb, success, "alert")
+			}
+			// tokens
+			sb.WriteString(stylesheet.Italicize("NOTE: tokens do not support owner reassignment"))
+
+			return sb.String(), nil
+		},
+		scaffold.BasicOptions{
+			CommonOptions: scaffold.CommonOptions{
+				AddtlFlags: func() *pflag.FlagSet {
+					fs := &pflag.FlagSet{}
+					fs.Int32("to", 0, "user ID  to transfer ownership to")
+					fs.Int32("from", 0, "user ID to transfer ownership from")
+					fs.Bool("no-fail", false, "continue on failures, rather than immediately failing out")
+					return fs
+				},
+			},
+			ValidateArgs: func(fs *pflag.FlagSet) (invalid string, err error) {
+				to, err := fs.GetInt32("to")
+				clilog.GetFlag(err)
+				from, err := fs.GetInt32("from")
+				clilog.GetFlag(err)
+				if to == 0 && from == 0 {
+					return "--to and --from are required", nil
+				} else if to == 0 {
+					return "--to is required", nil
+				} else if from == 0 {
+					return "--from is required", nil
+				} else if to == from {
+					return "refusing to transfer items from and to the same user", nil
+				}
+				// make sure both from and to exist
+				users, err := connection.Client.GetUserMap()
+				if err != nil {
+					return "", err
+				}
+				if _, found := users[to]; !found {
+					return strconv.FormatInt(int64(to), 10) + " is not a valid uid", nil
+				} else if _, found := users[from]; !found {
+					return strconv.FormatInt(int64(from), 10) + " is not a valid uid", nil
+				}
+				return "", nil
+			},
+		})
+}
+
+func chownedString(out *strings.Builder, successes uint, noun string) {
+	if successes < 1 {
+		return
+	}
+	out.WriteString("successfully chowned ")
+	out.WriteString(english.Plural(int(successes), noun, ""))
+
+	out.WriteString("\n")
+}
+
+func chown() action.Pair {
+	return scaffoldselect.NewSelectAction("change individual data ownership",
+		"Transfer ownership of specific data from one user to another."+
+			"Chowning kits and secrets is not currently supported, but all other asset types are.",
+		"item",
+		func(addtlFlags *pflag.FlagSet) ([]multiselectlist.SelectableItem[string], error) {
+			from, _ := addtlFlags.GetInt32("from")
+
+			// ensure we are in admin mode to ensure we get all data
+			if !connection.Client.AdminMode() {
+				connection.Client.SetAdminMode()
+				defer connection.Client.ClearAdminMode()
+			}
+			// fetch ALL items owned by the FROM user
+			data := make([]multiselectlist.SelectableItem[string], 0)
+			qo := &types.QueryOptions{
+				Filters: []types.Filter{
+					{Key: "OwnerID", Operation: "=", Values: []any{from}},
+				},
+			}
+
+			// saved queries
+			if lr, err := connection.Client.ListAllSavedQueries(qo); err != nil {
+				clilog.Writer.Error("failed to get saved queries", log.KVErr(err))
+				return nil, err
+			} else {
+				for _, res := range lr.Results {
+					data = append(data, &listitem.Generic{
+						ID_:        res.ID,
+						Name:       res.Name,
+						SecondLine: res.Description,
+					})
+				}
+			}
+			// dashboards
+			if lr, err := connection.Client.ListAllDashboards(qo); err != nil {
+				clilog.Writer.Error("failed to get dashboards", log.KVErr(err))
+				return nil, err
+			} else {
+				for _, res := range lr.Results {
+					data = append(data, &listitem.Generic{
+						ID_:        res.ID,
+						Name:       res.Name,
+						SecondLine: res.Description,
+					})
+				}
+			}
+			// kits
+			// TODO currently being skipped, as they were skipped pre-6.0.0
+			// extractions
+			if lr, err := connection.Client.ListAllExtractions(qo); err != nil {
+				clilog.Writer.Error("failed to get dashboards", log.KVErr(err))
+				return nil, err
+			} else {
+				for _, res := range lr.Results {
+					data = append(data, &listitem.Generic{
+						ID_:        res.ID,
+						Name:       res.Name,
+						SecondLine: res.Description,
+					})
+				}
+			}
+			// actionables
+			if lr, err := connection.Client.ListAllActionables(qo); err != nil {
+				clilog.Writer.Error("failed to get dashboards", log.KVErr(err))
+				return nil, err
+			} else {
+				for _, res := range lr.Results {
+					data = append(data, &listitem.Generic{
+						ID_:        res.ID,
+						Name:       res.Name,
+						SecondLine: res.Description,
+					})
+				}
+			}
+			// playbooks
+			if lr, err := connection.Client.ListAllPlaybooks(qo); err != nil {
+				clilog.Writer.Error("failed to get dashboards", log.KVErr(err))
+				return nil, err
+			} else {
+				for _, res := range lr.Results {
+					data = append(data, &listitem.Generic{
+						ID_:        res.ID,
+						Name:       res.Name,
+						SecondLine: res.Description,
+					})
+				}
+			}
+			// scheduled searches
+			if lr, err := connection.Client.ListAllScheduledSearches(qo); err != nil {
+				clilog.Writer.Error("failed to get dashboards", log.KVErr(err))
+				return nil, err
+			} else {
+				for _, res := range lr.Results {
+					data = append(data, &listitem.Generic{
+						ID_:        res.ID,
+						Name:       res.Name,
+						SecondLine: res.Description,
+					})
+				}
+			}
+			// scheduled scripts
+			if lr, err := connection.Client.ListAllScheduledScripts(qo); err != nil {
+				clilog.Writer.Error("failed to get dashboards", log.KVErr(err))
+				return nil, err
+			} else {
+				for _, res := range lr.Results {
+					data = append(data, &listitem.Generic{
+						ID_:        res.ID,
+						Name:       res.Name,
+						SecondLine: res.Description,
+					})
+				}
+			}
+			// files
+			if lr, err := connection.Client.ListAllFiles(qo); err != nil {
+				clilog.Writer.Error("failed to get dashboards", log.KVErr(err))
+				return nil, err
+			} else {
+				for _, res := range lr.Results {
+					data = append(data, &listitem.Generic{
+						ID_:        res.ID,
+						Name:       res.Name,
+						SecondLine: res.Description,
+					})
+				}
+			}
+			// templates
+			if lr, err := connection.Client.ListAllTemplates(qo); err != nil {
+				clilog.Writer.Error("failed to get dashboards", log.KVErr(err))
+				return nil, err
+			} else {
+				for _, res := range lr.Results {
+					data = append(data, &listitem.Generic{
+						ID_:        res.ID,
+						Name:       res.Name,
+						SecondLine: res.Description,
+					})
+				}
+			}
+			// resources
+			if lr, err := connection.Client.ListAllResources(qo); err != nil {
+				clilog.Writer.Error("failed to get dashboards", log.KVErr(err))
+				return nil, err
+			} else {
+				for _, res := range lr.Results {
+					data = append(data, &listitem.Generic{
+						ID_:        res.ID,
+						Name:       res.Name,
+						SecondLine: res.Description,
+					})
+				}
+			}
+			// macros
+			if lr, err := connection.Client.ListAllMacros(qo); err != nil {
+				clilog.Writer.Error("failed to get dashboards", log.KVErr(err))
+				return nil, err
+			} else {
+				for _, res := range lr.Results {
+					data = append(data, &listitem.Generic{
+						ID_:        res.ID,
+						Name:       res.Name,
+						SecondLine: res.Description,
+					})
+				}
+			}
+			// flows
+			if lr, err := connection.Client.ListAllFlows(qo); err != nil {
+				clilog.Writer.Error("failed to get dashboards", log.KVErr(err))
+				return nil, err
+			} else {
+				for _, res := range lr.Results {
+					data = append(data, &listitem.Generic{
+						ID_:        res.ID,
+						Name:       res.Name,
+						SecondLine: res.Description,
+					})
+				}
+			}
+			// alerts
+			if lr, err := connection.Client.ListAllAlerts(qo); err != nil {
+				clilog.Writer.Error("failed to get dashboards", log.KVErr(err))
+				return nil, err
+			} else {
+				for _, res := range lr.Results {
+					data = append(data, &listitem.Generic{
+						ID_:        res.ID,
+						Name:       res.Name,
+						SecondLine: res.Description,
+					})
+				}
+			}
+			return data, nil
+		},
+		func(IDs []string, addtlFlags *pflag.FlagSet) (results []scaffold.Result, _ error) {
+			from, _ := addtlFlags.GetInt32("from")
+			to, _ := addtlFlags.GetInt32("to")
+			noFail, _ := addtlFlags.GetBool("no-fail")
+
+			results = make([]scaffold.Result, len(IDs))
+			for i, ID := range IDs {
+				err := transferEntity(ID, from, to)
+				if err != nil {
+					results[i] = scaffold.Result{
+						Output: err.Error(),
+					}
+					if !noFail {
+						return results, nil // we already made changes, so we want to make sure they get printed too
+					}
+				} else {
+					results[i] = scaffold.Result{
+						Success: true,
+						Output:  "chowned " + ID,
+					}
+				}
+			}
+			return results, nil
+		},
+		scaffoldselect.Options{
+			CommonOptions: scaffold.CommonOptions{
+				Use: "chown",
+				Usage: fmt.Sprintf("chown %s %s %s %s",
+					ft.Mandatory("--to <UID>"), ft.Mandatory("--from <UID>"),
+					ft.Optional("--no-fail"),
+					ft.VariadicArgs("entity ID", true)),
+				Example: "chown --to=1 --from 5 dashboard-abc-def-ghi scheduled-search-one-two-three",
+				AddtlFlags: func() *pflag.FlagSet {
+					fs := &pflag.FlagSet{}
+					fs.Int32("to", 0, "user ID  to transfer ownership to")
+					fs.Int32("from", 0, "user ID to transfer ownership from")
+					fs.Bool("no-fail", false, "continue on failures, rather than immediately failing out")
+					return fs
+				},
+			},
+			ValidateArgs: func(fs *pflag.FlagSet) (invalid string, err error) {
+				to, err := fs.GetInt32("to")
+				clilog.GetFlag(err)
+				from, err := fs.GetInt32("from")
+				clilog.GetFlag(err)
+				if to == 0 && from == 0 {
+					return "--to and --from are required", nil
+				} else if to == 0 {
+					return "--to is required", nil
+				} else if from == 0 {
+					return "--from is required", nil
+				} else if to == from {
+					return "refusing to transfer items from and to the same user", nil
+				}
+				return "", nil
+			},
+		})
+}
+
+func transferEntity(ID string, from, to int32) error {
+	// IDs are always prefixed with their type, but that type may span two words.
+	exploded := strings.Split(ID, "-")
+	if len(exploded) < 2 { // this should never be true
+		return errors.New("failed to parse ID " + ID)
+	}
+	one, two := exploded[0], exploded[1]
+	// check against 1 word types
+	switch one {
+	case "dashboard":
+		itm, err := connection.Client.GetDashboard(ID)
+		if phrases.IsNotFoundErr(err) {
+			return phrases.ErrUnknownIdentifier(ID, "dashboard")
+		} else if err != nil {
+			return err
+		} else if from != itm.OwnerID {
+			return fmt.Errorf("dashboard (ID: %s) does not belong to from-user (ID: %d)", ID, from)
+		}
+		itm.OwnerID = to
+		if _, err := connection.Client.UpdateDashboard(itm); phrases.IsNotFoundErr(err) {
+			return phrases.ErrUnknownIdentifier(ID, "dashboard")
+		} else if err != nil {
+			return err
+		}
+		return nil
+	case "extraction":
+		itm, err := connection.Client.GetExtraction(ID)
+		if phrases.IsNotFoundErr(err) {
+			return phrases.ErrUnknownIdentifier(ID, "extraction")
+		} else if err != nil {
+			return err
+		} else if from != itm.OwnerID {
+			return fmt.Errorf("extraction (ID: %s) does not belong to from-user (ID: %d)", ID, from)
+		}
+		itm.OwnerID = to
+		if _, err := connection.Client.UpdateExtraction(itm); phrases.IsNotFoundErr(err) {
+			return phrases.ErrUnknownIdentifier(ID, "extraction")
+		} else if err != nil {
+			return err
+		}
+		return nil
+	case "actionable":
+		itm, err := connection.Client.GetActionable(ID)
+		if phrases.IsNotFoundErr(err) {
+			return phrases.ErrUnknownIdentifier(ID, "actionable")
+		} else if err != nil {
+			return err
+		} else if from != itm.OwnerID {
+			return fmt.Errorf("actionable (ID: %s) does not belong to from-user (ID: %d)", ID, from)
+		}
+		itm.OwnerID = to
+		if _, err := connection.Client.UpdateActionable(itm); phrases.IsNotFoundErr(err) {
+			return phrases.ErrUnknownIdentifier(ID, "actionable")
+		} else if err != nil {
+			return err
+		}
+		return nil
+	case "playbook":
+		itm, err := connection.Client.GetPlaybook(ID)
+		if phrases.IsNotFoundErr(err) {
+			return phrases.ErrUnknownIdentifier(ID, "playbook")
+		} else if err != nil {
+			return err
+		} else if from != itm.OwnerID {
+			return fmt.Errorf("playbook (ID: %s) does not belong to from-user (ID: %d)", ID, from)
+		}
+		itm.OwnerID = to
+		if _, err := connection.Client.UpdatePlaybook(itm); phrases.IsNotFoundErr(err) {
+			return phrases.ErrUnknownIdentifier(ID, "playbook")
+		} else if err != nil {
+			return err
+		}
+		return nil
+	case "template":
+		itm, err := connection.Client.GetTemplate(ID)
+		if phrases.IsNotFoundErr(err) {
+			return phrases.ErrUnknownIdentifier(ID, "template")
+		} else if err != nil {
+			return err
+		} else if from != itm.OwnerID {
+			return fmt.Errorf("template (ID: %s) does not belong to from-user (ID: %d)", ID, from)
+		}
+		itm.OwnerID = to
+		if _, err := connection.Client.UpdateTemplate(itm); phrases.IsNotFoundErr(err) {
+			return phrases.ErrUnknownIdentifier(ID, "template")
+		} else if err != nil {
+			return err
+		}
+		return nil
+	case "macro":
+		itm, err := connection.Client.GetMacro(ID)
+		if phrases.IsNotFoundErr(err) {
+			return phrases.ErrUnknownIdentifier(ID, "macro")
+		} else if err != nil {
+			return err
+		} else if from != itm.OwnerID {
+			return fmt.Errorf("macro (ID: %s) does not belong to from-user (ID: %d)", ID, from)
+		}
+		itm.OwnerID = to
+		if err := connection.Client.UpdateMacro(itm); phrases.IsNotFoundErr(err) {
+			return phrases.ErrUnknownIdentifier(ID, "macro")
+		} else if err != nil {
+			return err
+		}
+		return nil
+	case "flow":
+		itm, err := connection.Client.GetFlow(ID)
+		if phrases.IsNotFoundErr(err) {
+			return phrases.ErrUnknownIdentifier(ID, "flow")
+		} else if err != nil {
+			return err
+		} else if from != itm.OwnerID {
+			return fmt.Errorf("flow (ID: %s) does not belong to from-user (ID: %d)", ID, from)
+		}
+		itm.OwnerID = to
+		if err := connection.Client.UpdateFlow(itm); phrases.IsNotFoundErr(err) {
+			return phrases.ErrUnknownIdentifier(ID, "flow")
+		} else if err != nil {
+			return err
+		}
+		return nil
+	case "alert":
+		itm, err := connection.Client.GetAlert(ID)
+		if phrases.IsNotFoundErr(err) {
+			return phrases.ErrUnknownIdentifier(ID, "alert")
+		} else if err != nil {
+			return err
+		} else if from != itm.OwnerID {
+			return fmt.Errorf("alert (ID: %s) does not belong to from-user (ID: %d)", ID, from)
+		}
+		itm.OwnerID = to
+		if _, err := connection.Client.UpdateAlert(itm); phrases.IsNotFoundErr(err) {
+			return phrases.ErrUnknownIdentifier(ID, "alert")
+		} else if err != nil {
+			return err
+		}
+		return nil
+	case "file":
+		itm, err := connection.Client.GetFileMetadata(ID)
+		if phrases.IsNotFoundErr(err) {
+			return phrases.ErrUnknownIdentifier(ID, "file")
+		} else if err != nil {
+			return err
+		} else if from != itm.OwnerID {
+			return fmt.Errorf("file (ID: %s) does not belong to from-user (ID: %d)", ID, from)
+		}
+		itm.OwnerID = to
+		if _, err := connection.Client.UpdateFileMetadata(ID, itm); phrases.IsNotFoundErr(err) {
+			return phrases.ErrUnknownIdentifier(ID, "file")
+		} else if err != nil {
+			return err
+		}
+		return nil
+	case "resource":
+		itm, err := connection.Client.GetResourceMetadata(ID)
+		if phrases.IsNotFoundErr(err) {
+			return phrases.ErrUnknownIdentifier(ID, "resource")
+		} else if err != nil {
+			return err
+		} else if from != itm.OwnerID {
+			return fmt.Errorf("resource (ID: %s) does not belong to from-user (ID: %d)", ID, from)
+		}
+		itm.OwnerID = to
+		if err := connection.Client.UpdateResourceMetadata(ID, itm); phrases.IsNotFoundErr(err) {
+			return phrases.ErrUnknownIdentifier(ID, "resource")
+		} else if err != nil {
+			return err
+		}
+		return nil
+	}
+	// check against 2 word types
+	switch one + "-" + two {
+	case "saved-query":
+		itm, err := connection.Client.GetSavedQuery(ID)
+		if phrases.IsNotFoundErr(err) {
+			return phrases.ErrUnknownIdentifier(ID, "saved query")
+		} else if err != nil {
+			return err
+		} else if from != itm.OwnerID {
+			return fmt.Errorf("saved query (ID: %s) does not belong to from-user (ID: %d)", ID, from)
+		}
+		itm.OwnerID = to
+		if _, err := connection.Client.UpdateSavedQuery(itm); phrases.IsNotFoundErr(err) {
+			return phrases.ErrUnknownIdentifier(ID, "saved query")
+		} else if err != nil {
+			return err
+		}
+		return nil
+	case "scheduled-search":
+		itm, err := connection.Client.GetScheduledSearch(ID)
+		if phrases.IsNotFoundErr(err) {
+			return phrases.ErrUnknownIdentifier(ID, "scheduled search")
+		} else if err != nil {
+			return err
+		} else if from != itm.OwnerID {
+			return fmt.Errorf("scheduled search (ID: %s) does not belong to from-user (ID: %d)", ID, from)
+		}
+		itm.OwnerID = to
+		if err := connection.Client.UpdateScheduledSearch(itm); phrases.IsNotFoundErr(err) {
+			return phrases.ErrUnknownIdentifier(ID, "scheduled search")
+		} else if err != nil {
+			return err
+		}
+		return nil
+	case "scheduled-script":
+		itm, err := connection.Client.GetScheduledScript(ID)
+		if phrases.IsNotFoundErr(err) {
+			return phrases.ErrUnknownIdentifier(ID, "scheduled script")
+		} else if err != nil {
+			return err
+		} else if from != itm.OwnerID {
+			return fmt.Errorf("scheduled script (ID: %s) does not belong to from-user (ID: %d)", ID, from)
+		}
+		itm.OwnerID = to
+		if err := connection.Client.UpdateScheduledScript(itm); phrases.IsNotFoundErr(err) {
+			return phrases.ErrUnknownIdentifier(ID, "scheduled script")
+		} else if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// if we made it this far, we failed to identify the entity type
+	err := fmt.Errorf("failed to map ID %s to an entity type", ID)
+	clilog.Writer.Warn(err.Error())
+	return err
 }

--- a/gwcli/tree/admin/admin_noci_test.go
+++ b/gwcli/tree/admin/admin_noci_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Pallinder/go-randomdata"
 	"github.com/gravwell/gravwell/v4/gwcli/internal/testsupport"
 	"github.com/gravwell/gravwell/v4/gwcli/tree"
 	"github.com/stretchr/testify/assert"
@@ -67,4 +68,45 @@ func TestLogLevelGetSet(t *testing.T) {
 		curLevel = strings.ToLower(strings.TrimSpace(after))
 		require.Equal(t, setLevel, curLevel)
 	})
+}
+
+func TestMassChown(t *testing.T) {
+	var sbOut, sbErr strings.Builder
+	// create a second user
+	var (
+		u2Username string = randomdata.SillyName()
+		u2Password string = randomdata.Month()
+	)
+	args := append(testsupport.MetaArgs(t, false, testsupport.WithDefaults()), "admin", "users", "create",
+		"--new-email="+randomdata.Email(),
+		"--new-username="+u2Username,
+		"--new-password="+u2Password,
+		"--new-name="+randomdata.FirstName(0),
+	)
+	require.Zero(t, tree.Execute(args, &sbOut, &sbErr), sbErr.String())
+	sbOut.Reset()
+	sbErr.Reset()
+
+	// create a bunch of data under a second user
+	u2Meta := testsupport.MetaArgs(t, false, testsupport.WithUsernamePassword(u2Username, u2Password))
+	// saved query
+	executeTree(t, &sbOut, &sbErr, u2Meta, "queries", "saved", "create", "--name="+u2Username+"saved", "--query=\"tag=gravwell | limit 2\"")
+	// dashboards
+	// the TUI doesn't have the ability to create dashboards, so we are just skipping this for now.
+	// kits
+	// kit chowning isn't supported
+	// extractions
+
+	executeTree(t, &sbOut, &sbErr, u2Meta, "queries", "saved", "create", "--name="+u2Username+"saved", "--query=\"tag=gravwell | limit 2\"")
+	// take ownership of all of it
+	// TODO
+}
+
+// helper function.
+// Calls tree.Execute, dies if a non-zero EC is returned, and resets the string builders.
+func executeTree(t *testing.T, sbOut, sbErr *strings.Builder, meta []string, args ...string) {
+	t.Helper()
+	require.Zero(t, tree.Execute(append(meta, args...), sbOut, sbErr), sbErr.String())
+	sbOut.Reset()
+	sbErr.Reset()
 }

--- a/gwcli/tree/admin/admin_noci_test.go
+++ b/gwcli/tree/admin/admin_noci_test.go
@@ -1,3 +1,5 @@
+//go:build noci
+
 /*************************************************************************
  * Copyright 2026 Gravwell, Inc. All rights reserved.
  * Contact: <legal@gravwell.io>

--- a/gwcli/tree/admin/admin_noci_test.go
+++ b/gwcli/tree/admin/admin_noci_test.go
@@ -1,5 +1,3 @@
-//go:build noci
-
 /*************************************************************************
  * Copyright 2026 Gravwell, Inc. All rights reserved.
  * Contact: <legal@gravwell.io>

--- a/gwcli/tree/admin/admin_noci_test.go
+++ b/gwcli/tree/admin/admin_noci_test.go
@@ -9,6 +9,9 @@
 package admin_test
 
 import (
+	"encoding/csv"
+	"slices"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -74,10 +77,11 @@ func TestMassChown(t *testing.T) {
 	var sbOut, sbErr strings.Builder
 	// create a second user
 	var (
-		u2Username string = randomdata.SillyName()
-		u2Password string = randomdata.Month()
+		u2Username = randomdata.SillyName()
+		u2Password = randomdata.Month()
 	)
-	args := append(testsupport.MetaArgs(t, false, testsupport.WithDefaults()), "admin", "users", "create",
+	adminMeta := testsupport.MetaArgs(t, false, testsupport.WithDefaults())
+	args := append(adminMeta, "admin", "users", "create",
 		"--new-email="+randomdata.Email(),
 		"--new-username="+u2Username,
 		"--new-password="+u2Password,
@@ -87,19 +91,89 @@ func TestMassChown(t *testing.T) {
 	sbOut.Reset()
 	sbErr.Reset()
 
-	// create a bunch of data under a second user
-	u2Meta := testsupport.MetaArgs(t, false, testsupport.WithUsernamePassword(u2Username, u2Password))
+	{ // create a bunch of data under a second user
+		u2Meta := testsupport.MetaArgs(t, false, testsupport.WithServer(false, ""), testsupport.WithUsernamePassword(u2Username, u2Password))
+		// saved query
+		executeTree(t, &sbOut, &sbErr, u2Meta, "queries", "saved", "create", "--name="+u2Username+"_saved", "--query=\"tag=gravwell | limit 2\"")
+		// dashboards
+		// the TUI doesn't have the ability to create dashboards, so we are just skipping this for now.
+		// kits
+		// kit chowning isn't supported
+		// extractors
+		require.Zero(t, tree.Execute(append(adminMeta, "extractors", "find", "default"), &sbOut, &sbErr), sbErr.String()) // make sure we don't have a pre-existing extractor
+		_, ID, found := strings.Cut(sbOut.String(), "ID: ")
+		if found {
+			ID, _, found = strings.Cut(ID, "\n")
+			if found {
+				require.Zero(t, tree.Execute(append(adminMeta, "extractors", "delete", ID), &sbOut, &sbErr), sbErr.String()) // kill the preexisting ax
+			}
+		}
+		sbOut.Reset()
+		sbErr.Reset()
+		executeTree(t, &sbOut, &sbErr, u2Meta, "extractors", "create", "--name="+u2Username+"_extractor", "--module=csv", "--tags=default", "--params='babs'")
+		// actionables
+		executeTree(t, &sbOut, &sbErr, u2Meta, "actionables", "create", "--name="+u2Username+"_actionable")
+		// playbooks
+		executeTree(t, &sbOut, &sbErr, u2Meta, "playbook", "create", "--name="+u2Username+"_playbook_1")
+		// scheduled searches
+		executeTree(t, &sbOut, &sbErr, u2Meta, "queries", "scheduled", "create", "--name="+u2Username+"_saved",
+			"--frequency=1 1 * * *",
+			"--query=\"tag=gravwell | limit 2\"",
+			"--duration", "1h",
+		)
+		// TODO add more asset types
+	}
+
+	var u2ID uint32
+	{ // find second user's ID
+		args := append(testsupport.MetaArgs(t, false, testsupport.WithDefaults()), "admin", "users", "list", "--csv", "--columns=ID,Username")
+		require.Zero(t, tree.Execute(args, &sbOut, &sbErr), sbErr.String())
+		out := sbOut.String()
+		rdr := csv.NewReader(strings.NewReader(out))
+		hdr, err := rdr.Read()
+		require.Nil(t, err)
+		require.True(t, slices.Equal(hdr, []string{"ID", "Username"}))
+		records, err := rdr.ReadAll()
+		require.Nil(t, err)
+		for _, record := range records {
+			if record[1] == u2Username {
+				uid, err := strconv.ParseUint(record[0], 10, 32)
+				require.Nil(t, err)
+				u2ID = uint32(uid)
+			}
+		}
+		sbOut.Reset()
+		sbErr.Reset()
+		require.NotZero(t, u2ID, "failed to read second user's ID from users list")
+	}
+
+	// take ownership of all of it
+	args = append(testsupport.MetaArgs(t, false, testsupport.WithDefaults()), "admin", "mass-chown",
+		"--to=1", "--from="+strconv.FormatUint(uint64(u2ID), 10))
+	require.Zero(t, tree.Execute(args, &sbOut, &sbErr), sbErr.String())
+	t.Log(sbOut.String())
+	require.Empty(t, sbErr.String())
+	sbOut.Reset()
+	sbErr.Reset()
+	// confirm we now own every item
 	// saved query
-	executeTree(t, &sbOut, &sbErr, u2Meta, "queries", "saved", "create", "--name="+u2Username+"saved", "--query=\"tag=gravwell | limit 2\"")
+	findName(t, &sbOut, &sbErr, u2Username+"_saved", adminMeta, []string{"queries", "saved"}, []string{"ID", "Name"})
 	// dashboards
 	// the TUI doesn't have the ability to create dashboards, so we are just skipping this for now.
 	// kits
 	// kit chowning isn't supported
-	// extractions
-
-	executeTree(t, &sbOut, &sbErr, u2Meta, "queries", "saved", "create", "--name="+u2Username+"saved", "--query=\"tag=gravwell | limit 2\"")
-	// take ownership of all of it
-	// TODO
+	// extractors
+	findName(t, &sbOut, &sbErr, u2Username+"_extractor", adminMeta, []string{"extractors"}, []string{"ID", "Name"})
+	// actionables
+	findName(t, &sbOut, &sbErr, u2Username+"_actionable", adminMeta, []string{"actionables"}, []string{"ID", "Name"})
+	// playbooks
+	findName(t, &sbOut, &sbErr, u2Username+"_playbook_1", adminMeta, []string{"playbooks"}, []string{"ID", "Name"})
+	// scheduled searches
+	/*	executeTree(t, &sbOut, &sbErr, adminMeta, "queries", "scheduled", "create", "--name="+u2Username+"_saved",
+		"--frequency=1 1 * * *",
+		"--query=\"tag=gravwell | limit 2\"",
+		"--duration", "1h",
+	)*/
 }
 
 // helper function.
@@ -107,6 +181,37 @@ func TestMassChown(t *testing.T) {
 func executeTree(t *testing.T, sbOut, sbErr *strings.Builder, meta []string, args ...string) {
 	t.Helper()
 	require.Zero(t, tree.Execute(append(meta, args...), sbOut, sbErr), sbErr.String())
+	require.Empty(t, sbErr.String())
 	sbOut.Reset()
 	sbErr.Reset()
+}
+
+// automatically prefixes --csv and --columns to args
+func findName(t *testing.T, sbOut, sbErr *strings.Builder, expectedName string, meta, parentNavPath, columns []string) {
+	t.Helper()
+	defer sbOut.Reset()
+	defer sbErr.Reset()
+	// compose args
+	args := slices.Concat(meta, parentNavPath, []string{"list", "--csv", "--columns=" + strings.Join(columns, ",")})
+	t.Log("findName args: ", args)
+	require.Zero(t, tree.Execute(args, sbOut, sbErr), sbErr.String(), sbErr.String())
+	require.Empty(t, sbErr.String())
+	// check each column for the name
+	rdr := csv.NewReader(strings.NewReader(sbOut.String()))
+	t.Logf("parsing out:\n%v", sbOut.String())
+	{ // check header length
+		hdr, err := rdr.Read()
+		require.Nil(t, err)
+		assert.Len(t, hdr, len(hdr))
+	}
+	{ // find the name
+		records, err := rdr.ReadAll()
+		require.NoError(t, err)
+		for _, record := range records {
+			if slices.Contains(record, expectedName) {
+				return
+			}
+		}
+		t.Fatalf("failed to find item name %s in records %v", expectedName, records)
+	}
 }

--- a/gwcli/tree/admin/groups/groups.go
+++ b/gwcli/tree/admin/groups/groups.go
@@ -57,8 +57,8 @@ func NewNav() *cobra.Command {
 func listGroups() action.Pair {
 	return scaffoldlist.NewListAction("list groups", "Retrieves the list of groups available on the system",
 		types.Group{},
-		func(fs *pflag.FlagSet) ([]types.Group, error) {
-			resp, err := connection.Client.ListGroups(nil)
+		func(_ *pflag.FlagSet, params scaffoldlist.DataParameters) ([]types.Group, error) {
+			resp, err := connection.Client.ListGroups(params.QueryOpts)
 			return resp.Results, err
 		},
 		nil,
@@ -161,7 +161,7 @@ var listUsersGID int32
 func listUsers() action.Pair {
 	return scaffoldlist.NewListAction("list users in a group", "Display the users that are members of a given group.",
 		types.User{},
-		func(fs *pflag.FlagSet) ([]types.User, error) {
+		func(_ *pflag.FlagSet, _ scaffoldlist.DataParameters) ([]types.User, error) {
 			return connection.Client.GetGroupUsers(listUsersGID)
 		},
 		nil,
@@ -193,5 +193,6 @@ func listUsers() action.Pair {
 				return "", nil
 			},
 			EmptyMessage: "this group has no users",
+			Omit:         scaffold.OmitFlags{Everything: true},
 		})
 }

--- a/gwcli/tree/admin/license/license.go
+++ b/gwcli/tree/admin/license/license.go
@@ -85,7 +85,7 @@ func licenseInfo() action.Pair {
 		"display information about the current license",
 		"Displays details about the currently installed Gravwell license.",
 		wrappedLicenseInfo{},
-		func(fs *pflag.FlagSet) ([]wrappedLicenseInfo, error) {
+		func(_ *pflag.FlagSet, _ scaffoldlist.DataParameters) ([]wrappedLicenseInfo, error) {
 			li, err := connection.Client.GetLicenseInfo()
 			if err != nil {
 				return nil, err
@@ -102,7 +102,7 @@ func licenseInfo() action.Pair {
 				"Version",
 				"Expiration",
 			},
-			Pretty: func(_ []string, _ map[string]string) (string, error) {
+			Pretty: func(_ *pflag.FlagSet, _ []string, _ map[string]string, _ scaffoldlist.DataParameters) (string, error) {
 				li, err := connection.Client.GetLicenseInfo()
 				if err != nil {
 					return "", err
@@ -137,6 +137,7 @@ func licenseInfo() action.Pair {
 					},
 				)
 			},
+			Omit: scaffold.OmitFlags{Everything: true},
 		},
 	)
 }

--- a/gwcli/tree/admin/license/license.go
+++ b/gwcli/tree/admin/license/license.go
@@ -222,7 +222,7 @@ func licenseSerial() action.Pair {
 func licenseUpdate() action.Pair {
 	return scaffoldcreate.NewCreateAction("license",
 		map[string]scaffoldcreate.Field{
-			"path": scaffoldcreate.FieldPath("license file"),
+			"path": scaffoldcreate.FieldPath("license file", true),
 		},
 		func(fields map[string]scaffoldcreate.Field, fs *pflag.FlagSet) (id any, invalid string, err error) {
 			path := fields["path"].Provider.Get()

--- a/gwcli/tree/admin/users/users.go
+++ b/gwcli/tree/admin/users/users.go
@@ -55,8 +55,8 @@ func NewNav() *cobra.Command {
 
 func listAction() action.Pair {
 	return scaffoldlist.NewListAction("list users", "Retrieves cursory information about every user in the system", types.User{},
-		func(fs *pflag.FlagSet) ([]types.User, error) {
-			resp, err := connection.Client.ListUsers(nil)
+		func(fs *pflag.FlagSet, param scaffoldlist.DataParameters) ([]types.User, error) {
+			resp, err := connection.Client.ListUsers(param.QueryOpts)
 			return resp.Results, err
 		}, nil, scaffoldlist.Options{DefaultColumns: []string{"ID", "Username", "Name", "Email", "Admin"}})
 }
@@ -274,7 +274,7 @@ func sessionsAction() action.Pair {
 		"Get all active sessions for the specified user IDs.\n"+
 			"If --since is not set, it will default to fetching all records for the past 48 hours.",
 		session{},
-		func(fs *pflag.FlagSet) ([]session, error) {
+		func(fs *pflag.FlagSet, _ scaffoldlist.DataParameters) ([]session, error) {
 			allSessions := []types.Session{}
 			for _, uid := range sessionUIDs {
 				userSessions, err := connection.Client.Sessions(uid)
@@ -385,6 +385,7 @@ func sessionsAction() action.Pair {
 				}
 				return "", nil
 			},
+			Omit: scaffold.OmitFlags{Everything: true},
 		},
 	)
 }

--- a/gwcli/tree/admin/users/users.go
+++ b/gwcli/tree/admin/users/users.go
@@ -410,11 +410,16 @@ func lock() action.Pair {
 			items = slices.Clip(items)
 			return items, nil
 		},
-		func(ID int32, _ *pflag.FlagSet) (success string, _ error) {
-			if err := connection.Client.LockUserAccount(ID); err != nil {
-				return "", fmt.Errorf("failed to lock user account %d: %v", ID, err)
+		func(IDs []int32, _ *pflag.FlagSet) (results []scaffold.Result, _ error) {
+			results = make([]scaffold.Result, len(IDs))
+			for i, id := range IDs {
+				if err := connection.Client.LockUserAccount(id); err != nil {
+					results[i] = scaffold.Result{Success: false, Output: fmt.Sprintf("failed to lock user account %d: %v", id, err)}
+				} else {
+					results[i] = scaffold.Result{Success: true, Output: fmt.Sprintf("User %d locked", id)}
+				}
 			}
-			return fmt.Sprintf("User %v locked", ID), nil
+			return results, nil
 		},
 		scaffoldselect.Options{
 			CommonOptions: scaffold.CommonOptions{
@@ -441,11 +446,16 @@ func unlock() action.Pair {
 			items = slices.Clip(items)
 			return items, nil
 		},
-		func(ID int32, _ *pflag.FlagSet) (success string, _ error) {
-			if err := connection.Client.UnlockUserAccount(ID); err != nil {
-				return "", fmt.Errorf("failed to unlock user account %d: %v", ID, err)
+		func(IDs []int32, _ *pflag.FlagSet) (results []scaffold.Result, _ error) {
+			results = make([]scaffold.Result, len(IDs))
+			for i, ID := range IDs {
+				if err := connection.Client.UnlockUserAccount(ID); err != nil {
+					results[i] = scaffold.Result{Success: false, Output: fmt.Sprintf("failed to unlock user account %d: %v", ID, err)}
+				} else {
+					results[i] = scaffold.Result{Success: true, Output: fmt.Sprintf("User %d unlocked", ID)}
+				}
 			}
-			return fmt.Sprintf("User %v unlocked", ID), nil
+			return results, nil
 		},
 		scaffoldselect.Options{
 			CommonOptions: scaffold.CommonOptions{

--- a/gwcli/tree/alerts/alerts.go
+++ b/gwcli/tree/alerts/alerts.go
@@ -211,25 +211,38 @@ func toggle() action.Pair {
 			}
 			return items, nil
 		},
-		func(ID string, addtlFlags *pflag.FlagSet) (success string, _ error) {
-			alert, err := connection.Client.GetAlert(ID)
-			if err != nil {
-				return "", err
+		func(IDs []string, addtlFlags *pflag.FlagSet) (results []scaffold.Result, _ error) {
+			results = make([]scaffold.Result, len(IDs))
+			for i, ID := range IDs {
+				alert, err := connection.Client.GetAlert(ID)
+				if err != nil {
+					results[i] = scaffold.Result{
+						Output: fmt.Sprintf("failed to fetch base alert %s (ID: %s)", alert.Name, alert.ID),
+					}
+					continue
+				}
+				alert.Disabled = !alert.Disabled
+				if toggleEnable {
+					alert.Disabled = false
+				} else if toggleDisable {
+					alert.Disabled = true
+				}
+				if _, err := connection.Client.UpdateAlert(alert); err != nil {
+					results[i] = scaffold.Result{
+						Output: fmt.Sprintf("failed to update alert %s (ID: %s) (to Disabled=%v)", alert.Name, alert.ID, alert.Disabled),
+					}
+					continue
+				}
+				verb := "enabled"
+				if alert.Disabled {
+					verb = "disabled"
+				}
+				results[i] = scaffold.Result{
+					Output:  fmt.Sprintf("Alert %s (ID: %s) %s", alert.Name, alert.ID, verb),
+					Success: true,
+				}
 			}
-			alert.Disabled = !alert.Disabled
-			if toggleEnable {
-				alert.Disabled = false
-			} else if toggleDisable {
-				alert.Disabled = true
-			}
-			if _, err := connection.Client.UpdateAlert(alert); err != nil {
-				return "", err
-			}
-			verb := "enabled"
-			if alert.Disabled {
-				verb = "disabled"
-			}
-			return fmt.Sprintf("Alert \"%s\" %s", alert.Name, verb), nil
+			return results, nil
 		},
 		scaffoldselect.Options{
 			CommonOptions: scaffold.CommonOptions{
@@ -280,58 +293,71 @@ func dispatchers() action.Pair {
 			return alertsToGeneric(a), nil
 
 		},
-		func(ID string, fs *pflag.FlagSet) (success string, _ error) {
+		func(IDs []string, fs *pflag.FlagSet) (results []scaffold.Result, _ error) {
 			// we've already checked all flags
 			dIDs, _ := fs.GetStringSlice("dispatcher-ids")
 			add, _ := fs.GetBool("add")
 			remove, _ := fs.GetBool("remove")
-			a, err := connection.Client.GetAlert(ID)
-			if err != nil {
-				return "", err
-			}
-			if add {
-				clilog.Writer.Info("adding dispatchers to alert", log.KV("alert ID", ID), log.KV("dispatcher IDs", dIDs))
-				added, duplicate := 0, 0
-				for _, dID := range dIDs {
-					if !slices.ContainsFunc(a.Dispatchers, func(d types.AlertDispatcher) bool { return d.ID == dID }) {
-						a.Dispatchers = append(a.Dispatchers, types.AlertDispatcher{ID: dID, Type: types.ALERTDISPATCHERTYPE_SCHEDULEDSEARCH})
-						added += 1
-					} else {
-						duplicate += 1
-					}
+
+			results = make([]scaffold.Result, len(IDs))
+			for i, ID := range IDs {
+				a, err := connection.Client.GetAlert(ID)
+				if err != nil {
+					results[i] = scaffold.Result{Output: fmt.Sprintf("failed to get alert %s (ID: %s): %v", a.Name, ID, err)}
 				}
-				success = fmt.Sprintf("added %s to alert %s (ID: %s)", english.Plural(added, "dispatcher", ""), a.Name, a.ID)
-				if duplicate > 0 {
-					success += fmt.Sprintf("; skipped %d duplicates", duplicate)
-				}
-			} else if remove {
-				found := 0
-				clilog.Writer.Info("removing dispatchers from alert", log.KV("alert ID", ID), log.KV("dispatcher IDs", dIDs))
-				a.Dispatchers = slices.DeleteFunc(a.Dispatchers, func(ad types.AlertDispatcher) bool {
+				// add or remove each specified dispatcher
+				if add {
+					clilog.Writer.Info("adding dispatchers to alert", log.KV("alert ID", ID), log.KV("dispatcher IDs", dIDs))
+					added, duplicate := 0, 0
 					for _, dID := range dIDs {
-						if ad.ID == dID {
+						if !slices.ContainsFunc(a.Dispatchers, func(d types.AlertDispatcher) bool { return d.ID == dID }) {
+							a.Dispatchers = append(a.Dispatchers, types.AlertDispatcher{ID: dID, Type: types.ALERTDISPATCHERTYPE_SCHEDULEDSEARCH})
+							added += 1
+						} else {
+							duplicate += 1
+						}
+					}
+					results[i] = scaffold.Result{Success: true}
+					results[i].Output = fmt.Sprintf("added %s to alert %s (ID: %s)", english.Plural(added, "dispatcher", ""), a.Name, a.ID)
+					if duplicate > 0 {
+						results[i].Output += fmt.Sprintf("; skipped %d duplicates", duplicate)
+					}
+				} else if remove {
+					found := 0
+					clilog.Writer.Info("removing dispatchers from alert", log.KV("alert ID", ID), log.KV("dispatcher IDs", dIDs))
+					a.Dispatchers = slices.DeleteFunc(a.Dispatchers, func(ad types.AlertDispatcher) bool {
+						if slices.Contains(dIDs, ad.ID) {
 							found += 1
 							return true
 						}
+						return false
+					})
+					results[i] = scaffold.Result{
+						Success: true,
+						Output: fmt.Sprintf("removed %d (of %d given) %s from alert %s (ID: %s); %d remaining",
+							found, len(dIDs), english.PluralWord(found, "dispatcher", ""), a.Name, a.ID, len(a.Dispatchers)),
 					}
-					return false
-				})
-				success = fmt.Sprintf("removed %d (of %d given) %s from alert %s (ID: %s); %d remaining",
-					found, len(dIDs), english.PluralWord(found, "dispatcher", ""), a.Name, a.ID, len(a.Dispatchers))
-			} else {
-				clilog.Writer.Info("replacing dispatchers on alert", log.KV("alert ID", ID), log.KV("new dispatcher IDs", dIDs), log.KV("old dispatchers", a.Dispatchers))
-				a.Dispatchers = make([]types.AlertDispatcher, len(dIDs))
-				for i, dID := range dIDs {
-					a.Dispatchers[i] = types.AlertDispatcher{ID: dID, Type: types.ALERTDISPATCHERTYPE_SCHEDULEDSEARCH}
+				} else {
+					clilog.Writer.Info("replacing dispatchers on alert", log.KV("alert ID", ID), log.KV("new dispatcher IDs", dIDs), log.KV("old dispatchers", a.Dispatchers))
+					a.Dispatchers = make([]types.AlertDispatcher, len(dIDs))
+					for i, dID := range dIDs {
+						a.Dispatchers[i] = types.AlertDispatcher{ID: dID, Type: types.ALERTDISPATCHERTYPE_SCHEDULEDSEARCH}
+					}
+					results[i] = scaffold.Result{
+						Success: true,
+						Output:  fmt.Sprintf("replaced dispatchers on alert %s (ID: %s)", a.Name, a.ID),
+					}
 				}
-				success = fmt.Sprintf("replaced dispatchers on alert %s (ID: %s)", a.Name, a.ID)
-			}
 
-			if _, err := connection.Client.UpdateAlert(a); err != nil {
-				return "", err
+				if _, err := connection.Client.UpdateAlert(a); err != nil {
+					results[i] = scaffold.Result{
+						Success: false,
+						Output:  fmt.Sprintf("failed to update alert: %v\nOriginal operation: %v", err, results[i].Output),
+					}
+				}
+				// successful result is already built
 			}
-			return success, nil // success built in each branch
-
+			return results, nil
 		},
 		scaffoldselect.Options{
 			CommonOptions: scaffold.CommonOptions{
@@ -395,42 +421,48 @@ func save() action.Pair {
 			return alertsToGeneric(a), nil
 
 		},
-		func(ID string, fs *pflag.FlagSet) (success string, _ error) {
+		func(IDs []string, fs *pflag.FlagSet) (results []scaffold.Result, _ error) {
 			// checked by validate
 			enable, _ := fs.GetBool("enable")
 			duration, _ := fs.GetDuration("duration")
 			disable, _ := fs.GetBool("disable")
 
-			a, err := connection.Client.GetAlert(ID)
-			if err != nil {
-				return "", err
-			}
-			a.SaveSearchEnabled = !a.SaveSearchEnabled
-			if duration != 0 { // duration was provided
-				a.SaveSearchDuration = int32(duration.Seconds())
-			}
-			if enable {
-				a.SaveSearchEnabled = true
-			} else if disable {
-				a.SaveSearchEnabled = false
-			}
+			results = make([]scaffold.Result, len(IDs))
+			for i, ID := range IDs {
+				a, err := connection.Client.GetAlert(ID)
+				if err != nil {
+					results[i] = scaffold.Result{Output: fmt.Sprintf("failed to fetch alert by ID %s: %v", ID, err)}
+					continue
+				}
+				a.SaveSearchEnabled = !a.SaveSearchEnabled
+				if duration != 0 { // duration was provided
+					a.SaveSearchDuration = int32(duration.Seconds())
+				}
+				if enable {
+					a.SaveSearchEnabled = true
+				} else if disable {
+					a.SaveSearchEnabled = false
+				}
 
-			// if save would be enabled with a duration of 0, default it
-			if a.SaveSearchEnabled && a.SaveSearchDuration == 0 {
-				a.SaveSearchDuration = int32(defaultDuration.Seconds())
-			}
+				// if save would be enabled with a duration of 0, default it
+				if a.SaveSearchEnabled && a.SaveSearchDuration == 0 {
+					a.SaveSearchDuration = int32(defaultDuration.Seconds())
+				}
 
-			a, err = connection.Client.UpdateAlert(a)
-			if err != nil {
-				return "", err
-			}
-			if a.SaveSearchEnabled {
-				success = fmt.Sprintf("alert will save triggering searches for %d seconds", a.SaveSearchDuration)
-			} else {
-				success = "alert will not save triggering searches"
-			}
+				a, err = connection.Client.UpdateAlert(a)
+				if err != nil {
+					results[i] = scaffold.Result{Output: fmt.Sprintf("failed to update alert %s (ID: %s): %v", a.Name, ID, err)}
+					continue
+				}
 
-			return success, nil
+				results[i] = scaffold.Result{Success: true}
+				if a.SaveSearchEnabled {
+					results[i].Output = fmt.Sprintf("alert %s (ID: %s) will save triggering searches for %d seconds", a.Name, a.ID, a.SaveSearchDuration)
+				} else {
+					results[i].Output = fmt.Sprintf("alert %s (ID: %s) will not save triggering searches", a.Name, a.ID)
+				}
+			}
+			return results, nil
 		},
 		scaffoldselect.Options{
 			CommonOptions: scaffold.CommonOptions{

--- a/gwcli/tree/alerts/alerts.go
+++ b/gwcli/tree/alerts/alerts.go
@@ -92,33 +92,28 @@ func alertsList() action.Pair {
 	)
 
 	return scaffoldlist.NewListAction(short, long, types.Alert{},
-		func(fs *pflag.FlagSet) ([]types.Alert, error) {
+		func(fs *pflag.FlagSet, params scaffoldlist.DataParameters) ([]types.Alert, error) {
+
 			if listConsumerID != "" {
-				resp, err := connection.Client.ListAlerts(&types.QueryOptions{
-					Filters: []types.Filter{
-						{
-							Key:       "Consumers.ID",
-							Operation: "=",
-							Values:    []any{listConsumerID},
-						},
-					},
+				params.QueryOpts.Filters = append(params.QueryOpts.Filters, types.Filter{
+					Key:       "Consumers.ID",
+					Operation: "=",
+					Values:    []any{listConsumerID},
 				})
+				resp, err := connection.Client.ListAlerts(params.QueryOpts)
 				return resp.Results, err
 
 			} else if listDispatcherID != "" {
-				resp, err := connection.Client.ListAlerts(&types.QueryOptions{
-					Filters: []types.Filter{
-						{
-							Key:       "Dispatchers.ID",
-							Operation: "=",
-							Values:    []any{listDispatcherID},
-						},
-					},
+				params.QueryOpts.Filters = append(params.QueryOpts.Filters, types.Filter{
+					Key:       "Dispatchers.ID",
+					Operation: "=",
+					Values:    []any{listDispatcherID},
 				})
+				resp, err := connection.Client.ListAlerts(params.QueryOpts)
 				return resp.Results, err
 			}
 
-			resp, err := connection.Client.ListAlerts(nil)
+			resp, err := connection.Client.ListAlerts(params.QueryOpts)
 			return resp.Results, err
 		},
 		nil,
@@ -141,11 +136,14 @@ func alertsList() action.Pair {
 				"TargetTag",
 			},
 			ValidateArgs: func(fs *pflag.FlagSet) (invalid string, _ error) {
-				if listConsumerID, invalid = validateListID("consumer", fs); invalid != "" {
-					return invalid, nil
+				var err error
+				listConsumerID, err = fs.GetString("consumer")
+				if err != nil {
+					return "", clilog.GetFlag(err)
 				}
-				if listDispatcherID, invalid = validateListID("dispatcher", fs); invalid != "" {
-					return invalid, nil
+				listDispatcherID, err = fs.GetString("dispatcher")
+				if err != nil {
+					return "", clilog.GetFlag(err)
 				}
 
 				if listConsumerID != "" && listDispatcherID != "" {
@@ -154,15 +152,6 @@ func alertsList() action.Pair {
 				return "", nil
 			},
 		})
-}
-
-// helper function for list's ValidateArgs.
-func validateListID(flagName string, fs *pflag.FlagSet) (id string, invalid string) {
-	s, err := fs.GetString(flagName)
-	if err != nil {
-		clilog.GetFlag(err)
-	}
-	return s, ""
 }
 
 func delete() action.Pair {

--- a/gwcli/tree/cbac/cbac.go
+++ b/gwcli/tree/cbac/cbac.go
@@ -1,0 +1,638 @@
+/*************************************************************************
+ * Copyright 2026 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
+// Package cbac provides actions for inspecting and managing Capability-Based
+// Access Control rules.
+package cbac
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/gravwell/gravwell/v4/client/types"
+	"github.com/gravwell/gravwell/v4/gwcli/action"
+	"github.com/gravwell/gravwell/v4/gwcli/bubbles/multiselectlist"
+	"github.com/gravwell/gravwell/v4/gwcli/clilog"
+	"github.com/gravwell/gravwell/v4/gwcli/connection"
+	"github.com/gravwell/gravwell/v4/gwcli/internal/listitem"
+	"github.com/gravwell/gravwell/v4/gwcli/stylesheet"
+	ft "github.com/gravwell/gravwell/v4/gwcli/stylesheet/flagtext"
+	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold"
+	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldcreate"
+	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldlist"
+	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldselect"
+	"github.com/gravwell/gravwell/v4/gwcli/utilities/treeutils"
+	"github.com/gravwell/gravwell/v4/ingest/log"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func NewNav() *cobra.Command {
+	return treeutils.GenerateNav(
+		"cbac", "manage capability-based access control",
+		"Inspect and manage CBAC rules that govern which operations users and groups may perform.",
+		[]string{"capabilities"},
+		[]*cobra.Command{},
+		[]action.Pair{
+			listCapabilities(),
+			listTemplates(),
+			myCapabilities(),
+			get(),
+			edit(),
+			set(),
+		})
+}
+
+func listCapabilities() action.Pair {
+	return scaffoldlist.NewListAction(
+		"list capabilities",
+		"List every capability by its canonical name and description",
+		types.CapabilityDesc{},
+		func(_ *pflag.FlagSet, params scaffoldlist.DataParameters) ([]types.CapabilityDesc, error) {
+			caps, err := connection.Client.CapabilityList()
+			if err != nil {
+				return nil, err
+			}
+			// sort by cat
+			slices.SortStableFunc(caps, func(a, b types.CapabilityDesc) int {
+				return strings.Compare(string(a.Category), string(b.Category))
+			})
+			return caps, nil
+		},
+		map[string]string{
+			"Cap":  "ID",
+			"Desc": "Description",
+		},
+		scaffoldlist.Options{
+			CommonOptions: scaffold.CommonOptions{
+				Use:     "capabilities",
+				Aliases: []string{"caps", "list-caps", "list-capabilities"},
+			},
+			DefaultColumns: []string{"Category", "Name", "Desc"},
+		})
+}
+
+func listTemplates() action.Pair {
+	return scaffoldlist.NewListAction(
+		"list capability templates",
+		"List every capability grouping (template)",
+		types.CapabilityTemplate{},
+		func(_ *pflag.FlagSet, params scaffoldlist.DataParameters) ([]types.CapabilityTemplate, error) {
+			return connection.Client.CapabilityTemplateList()
+		},
+		map[string]string{
+			"Desc": "Description",
+		},
+		scaffoldlist.Options{
+			CommonOptions: scaffold.CommonOptions{
+				Use:     "templates",
+				Aliases: []string{"list-templates"},
+			},
+			DefaultColumns: []string{"Name", "Desc", "Caps"},
+		})
+}
+
+// wrapper type for types.CapabilityExplanation{}.
+// Used to kill the awkward prefix, hide redundant fields, and perform implicit renames.
+type capExp struct {
+	ID          types.Capability
+	Name        string
+	Description string
+	Category    types.CapabilityCategory
+	AdminOnly   bool
+	UserGrant   bool    // True if the capability was explicitly granted to the user
+	GroupGrants []int32 // An array of GIDs to which the user belongs that grant the capability.
+}
+
+func explanationToLocal(orig types.CapabilityExplanation) capExp {
+	wrapped := capExp{
+		ID:          orig.Cap,
+		Name:        orig.Name,
+		Description: orig.Desc,
+		Category:    orig.Category,
+		AdminOnly:   orig.AdminOnly,
+		UserGrant:   orig.UserGrant,
+		GroupGrants: make([]int32, len(orig.GroupGrants)),
+	}
+	for i, g := range orig.GroupGrants {
+		wrapped.GroupGrants[i] = g.ID
+	}
+	return wrapped
+}
+func myCapabilities() action.Pair {
+	return scaffoldlist.NewListAction("list your effective capabilities",
+		"Display capabilities currently granted to your user account and what grants them to you.",
+		capExp{},
+		func(addtlFlags *pflag.FlagSet, params scaffoldlist.DataParameters) ([]capExp, error) {
+			var caps []capExp
+			if ex, err := connection.Client.CurrentUserCapabilityExplanations(); err != nil {
+				return nil, err
+			} else { // trim out permissions the user doesn't have
+				for _, e := range ex {
+					if e.Granted {
+						caps = append(caps, explanationToLocal(e))
+					}
+				}
+			}
+
+			// sort by cat
+			slices.SortStableFunc(caps, func(a, b capExp) int {
+				return strings.Compare(string(a.Category), string(b.Category))
+			})
+
+			return caps, nil
+		},
+		nil, // implicit in the wrapper type
+		scaffoldlist.Options{
+			CommonOptions: scaffold.CommonOptions{
+				Use:     "my",
+				Aliases: []string{"self", "current", "my-capabilities", "my-caps"},
+			},
+			DefaultColumns: []string{"Category", "Name", "UserGrant", "GroupGrants"},
+		})
+}
+
+type getCaps struct { // TODO should we be using this for list as well?
+	ID     string // uid/gid
+	Grants []string
+}
+
+// TODO this is admin only
+func get() action.Pair {
+	var uids, gids []int32
+	return scaffoldlist.NewListAction("get user/group capabilities",
+		"List capabilities assigned to specific users and/or groups",
+		getCaps{},
+		func(addtlFlags *pflag.FlagSet, params scaffoldlist.DataParameters) ([]getCaps, error) {
+			// compose the fetched data with what caused it to be fetched
+			items := []getCaps{}
+			for _, uid := range uids {
+				uidString := "uid" + strconv.FormatInt(int64(uid), 10)
+				u, err := connection.Client.GetUserCapabilities(uid)
+				if err != nil {
+					return nil, fmt.Errorf("%s: %w", uidString, err)
+				}
+				items = append(items, getCaps{
+					ID:     uidString,
+					Grants: u.Grants,
+				})
+			}
+			for _, gid := range gids {
+				gidString := "gid" + strconv.FormatInt(int64(gid), 10)
+				g, err := connection.Client.GetGroupCapabilities(gid)
+				if err != nil {
+					return nil, fmt.Errorf("%s: %w", gidString, err)
+				}
+				items = append(items, getCaps{
+					ID:     gidString,
+					Grants: g.Grants,
+				})
+			}
+			return items, nil
+		},
+		nil, // TODO
+		scaffoldlist.Options{
+			CommonOptions: scaffold.CommonOptions{
+				Use:     "get",
+				Aliases: []string{"users", "groups"},
+				AddtlFlags: func() *pflag.FlagSet {
+					fs := &pflag.FlagSet{}
+					fs.Int32Slice("uids", nil, "IDs of the users to include")
+					fs.Int32Slice("gids", nil, "IDs of the groups to include")
+					return fs
+				},
+			},
+			ValidateArgs: func(fs *pflag.FlagSet) (_ string, err error) {
+				uids, err = fs.GetInt32Slice("uids")
+				clilog.GetFlag(err)
+				gids, err = fs.GetInt32Slice("gids")
+				clilog.GetFlag(err)
+				if len(uids) < 1 && len(gids) < 1 {
+					return "at least one ID must be specified for --uids or --gids", nil
+				}
+				return "", nil
+			},
+		},
+	)
+}
+
+// Fine-grain toggle over a single user's or group's capabilities.
+// TODO this would work better as a multistage (issues#2433)
+func edit() action.Pair {
+	var ( // everything here is destroyed and then re-set in validate
+		id            int32  // id if the entity to fetch
+		user          bool   // if not user, then group
+		grant, revoke bool   // only do this, do not toggle
+		noun          string // "user" or "group"
+	)
+	return scaffoldselect.NewSelectAction(
+		"edit capabilities",
+		"Tune the capabilities assigned to a single user or group.\n"+
+			"If neither --grant nor --revoke are specified, the given set will supplant the set of capabilities assigned to the user or group.\n"+
+			"Use "+stylesheet.Cur.Action.Render("cbac replace")+" if you wish to replace the capabilities of multiple groups/users at once.",
+		"capability name",
+		func(addtlFlags *pflag.FlagSet) ([]multiselectlist.SelectableItem[string], error) {
+			// NOTE(rlandau): grant/revoke do not affect cap collection for interactive mode; they only alter how the final set is constructed.
+
+			// fetch all caps
+			caps, err := connection.Client.CapabilityList()
+			if err != nil {
+				return nil, err
+			}
+			// sort by cat
+			slices.SortStableFunc(caps, func(a, b types.CapabilityDesc) int {
+				return strings.Compare(string(a.Category), string(b.Category))
+			})
+
+			// preselect using the caps the user/group has
+			var cs types.CapabilityState
+			if user {
+				cs, err = connection.Client.GetUserCapabilities(id)
+			} else {
+				cs, err = connection.Client.GetGroupCapabilities(id)
+			}
+			if err != nil {
+				return nil, err
+			}
+			// transform cs into a map for faster lookups
+			preselections := map[string]bool{}
+			for _, grant := range cs.Grants {
+				preselections[grant] = true
+			}
+
+			data := make([]multiselectlist.SelectableItem[string], len(caps))
+			for i, cap := range caps {
+				data[i] = &multiselectlist.DefaultSelectableItem[string]{
+					ID_:          cap.Name,
+					Title_:       cap.Name,
+					Description_: cap.Desc,
+					Selected_:    preselections[cap.Name],
+				}
+			}
+			return data, nil
+		},
+		func(CanonicalCapNames []string, addtlFlags *pflag.FlagSet) (results []scaffold.Result, err error) {
+			// IDs now contains the full set of selected capabilities the user should have.
+			// We need to compare it against their current set and toggle, only grant, or only revoke based on the given flags.
+			// As we validate bare arguments, we can guarantee that the list of cap names contains only valid caps.
+
+			switch {
+			case grant: // add selected caps not in the entity's current set
+				results = make([]scaffold.Result, 0, len(CanonicalCapNames))
+				var (
+					caps types.CapabilityState
+				)
+				if user {
+					caps, err = connection.Client.GetUserCapabilities(id)
+				} else {
+					caps, err = connection.Client.GetGroupCapabilities(id)
+				}
+				if err != nil {
+					return nil, fmt.Errorf("failed to refetch current %s capabilities: %w", noun, err)
+				}
+				// insert
+				slices.Sort(caps.Grants)
+				clilog.Writer.Debugf("%s ID %d current caps: %v", noun, id, caps)
+				for _, cap := range CanonicalCapNames {
+					idx, found := slices.BinarySearch(caps.Grants, cap)
+					if !found {
+						caps.Grants = slices.Insert(caps.Grants, idx, cap)
+						results = append(results, scaffold.Result{
+							Success: true,
+							Output:  fmt.Sprintf("added capability '%s' to %s %d", cap, noun, id),
+						})
+					} else {
+						clilog.Writer.Debug("redundant cap specified", log.KV("name", cap))
+					}
+				}
+
+				if user {
+					err = connection.Client.SetUserCapabilities(id, caps)
+				} else {
+					err = connection.Client.SetGroupCapabilities(id, caps)
+				}
+				if err != nil {
+					return nil, fmt.Errorf("failed to install updated set of caps into %s: %w", noun, err)
+				}
+
+				return slices.Clip(results), err
+			case revoke:
+				results = make([]scaffold.Result, 0, len(CanonicalCapNames))
+				var (
+					caps types.CapabilityState
+				)
+				if user {
+					caps, err = connection.Client.GetUserCapabilities(id)
+				} else {
+					caps, err = connection.Client.GetGroupCapabilities(id)
+				}
+				if err != nil {
+					return nil, fmt.Errorf("failed to refetch current %s capabilities: %w", noun, err)
+				}
+				// remove caps
+				slices.Sort(caps.Grants)
+				clilog.Writer.Debugf("%s ID %d current caps: %v", noun, id, caps)
+				for _, cap := range CanonicalCapNames {
+					idx, found := slices.BinarySearch(caps.Grants, cap)
+					if !found {
+						clilog.Writer.Debug("cap specified for deletion not found in target's cap set", log.KV("name", cap))
+						continue
+					}
+					caps.Grants = slices.Delete(caps.Grants, idx, idx+1)
+					results = append(results, scaffold.Result{
+						Success: true,
+						Output:  fmt.Sprintf("removed capability '%s' from %s %d", cap, noun, id),
+					})
+				}
+
+				if user {
+					err = connection.Client.SetUserCapabilities(id, caps)
+				} else {
+					err = connection.Client.SetGroupCapabilities(id, caps)
+				}
+				if err != nil {
+					return nil, fmt.Errorf("failed to install updated set of caps into %s: %w", noun, err)
+				}
+
+				return slices.Clip(results), err
+			default: // supplant cap set with the selections
+				cs := types.CapabilityState{Grants: CanonicalCapNames}
+				if user {
+					err = connection.Client.SetUserCapabilities(id, cs)
+				} else {
+					err = connection.Client.SetGroupCapabilities(id, cs)
+				}
+				if err != nil {
+					return nil, fmt.Errorf("failed to install updated set of caps into %s: %w", noun, err)
+				}
+				return []scaffold.Result{
+					{Success: true, Output: fmt.Sprintf("replaced %s ID %d's capability set with %v", noun, id, CanonicalCapNames)},
+				}, nil
+			}
+		},
+		scaffoldselect.Options{
+			CommonOptions: scaffold.CommonOptions{
+				Use: "edit",
+				Usage: "edit " +
+					ft.MutuallyExclusive([]string{"--uid", "--gid"}) +
+					ft.Optional(ft.MutuallyExclusive([]string{"--grant", "--revoke"})),
+				Example: "edit --uid=5",
+				AddtlFlags: func() *pflag.FlagSet {
+					fs := &pflag.FlagSet{}
+					fs.Int32("uid", 0, "ID of the user to edit.\n"+
+						"Mutually exclusive with --gid")
+					fs.Int32("gid", 0, "ID of the group to edit.\n"+
+						"Mutually exclusive with --uid")
+					fs.Bool("grant", false, "Only grant caps; no caps will be removed through this call")
+					fs.Bool("revoke", false, "Only revoke caps; no caps will be added through this call")
+					return fs
+				},
+			},
+			ValidateArgs: func(fs *pflag.FlagSet) (invalid string, err error) {
+				// ensure all prior data is destroyed
+				id = 0
+				user, grant, revoke = false, false, false
+				noun = ""
+
+				// fetch specifications for this run
+				uid, err := fs.GetInt32("uid")
+				clilog.GetFlag(err)
+				if uid != 0 {
+					noun = "user"
+					id = uid
+					user = true
+				}
+				gid, err := fs.GetInt32("gid")
+				clilog.GetFlag(err)
+				if gid != 0 {
+					if id != 0 {
+						return "--uid and --gid are mutually exclusive", nil
+					}
+					noun = "group"
+					id = gid
+				}
+				if id == 0 {
+					return "you must specify --uid or --gid", nil
+				}
+				grant, err = fs.GetBool("grant")
+				clilog.GetFlag(err)
+				revoke, err = fs.GetBool("revoke")
+				clilog.GetFlag(err)
+				if grant && revoke {
+					return "--grant and --revoke are mutually exclusive", nil
+				}
+
+				// ensure that pre-selected cap names are valid
+				bare := fs.Args()
+				if len(bare) > 0 {
+					caps, err := connection.Client.CapabilityList()
+					if err != nil {
+						return "", err
+					}
+					for _, arg := range bare {
+						if !slices.ContainsFunc(caps, func(c types.CapabilityDesc) bool {
+							return c.Name == arg
+						}) {
+							return arg + " is not a valid, canonical capability name", nil
+						}
+					}
+				}
+
+				return "", nil
+			},
+		})
+}
+
+// TODO this would work better as a multistage (issues#2433)
+func set() action.Pair {
+	return scaffoldcreate.NewCreateAction("capabilities",
+		map[string]scaffoldcreate.Field{
+			"users": {
+				Title:    "Users",
+				Required: false,
+				Flag: scaffoldcreate.FlagConfig{
+					Name:  "uids",
+					Usage: "IDs of the users who's capabilities will be replaced",
+				},
+				Order: 200,
+				Provider: scaffoldcreate.NewMSLProvider(nil, scaffoldcreate.MSLOptions{
+					ListOptions: multiselectlist.Options{},
+					SetArgsInsertItems: func(currentItems []multiselectlist.SelectableItem[string]) (_ []multiselectlist.SelectableItem[string]) {
+						lr, err := connection.Client.ListUsers(nil)
+						if err != nil {
+							clilog.Writer.Error("failed to get user list", log.KVErr(err))
+						} else if len(lr.Results) < 1 {
+							return nil
+						}
+						data := make([]multiselectlist.SelectableItem[string], len(lr.Results))
+						var sb strings.Builder
+						for i, u := range lr.Results {
+							sb.Reset()
+							if u.Admin {
+								sb.WriteString("(admin) ")
+							}
+							fmt.Fprintf(&sb, "%s (%s)", u.Name, u.Email)
+							data[i] = &listitem.Generic{
+								ID_:        strconv.FormatInt(int64(u.ID), 10),
+								Name:       fmt.Sprintf("(%d) %s", u.ID, u.Username),
+								SecondLine: sb.String(),
+							}
+						}
+						return data
+					},
+				}),
+			},
+			"groups": {
+				Title:    "Groups",
+				Required: false,
+				Flag: scaffoldcreate.FlagConfig{
+					Name:  "gids",
+					Usage: "IDs of the groups who's capabilities will be replaced",
+				},
+				Order: 180,
+				Provider: scaffoldcreate.NewMSLProvider(nil, scaffoldcreate.MSLOptions{
+					ListOptions: multiselectlist.Options{},
+					SetArgsInsertItems: func(currentItems []multiselectlist.SelectableItem[string]) (_ []multiselectlist.SelectableItem[string]) {
+						lr, err := connection.Client.ListGroups(nil)
+						if err != nil {
+							clilog.Writer.Error("failed to get group list", log.KVErr(err))
+						} else if len(lr.Results) < 1 {
+							return nil
+						}
+						data := make([]multiselectlist.SelectableItem[string], len(lr.Results))
+						for i, g := range lr.Results {
+							data[i] = &listitem.Generic{
+								ID_:        strconv.FormatInt(int64(g.ID), 10),
+								Name:       fmt.Sprintf("(%d) %s", g.ID, g.Name),
+								SecondLine: g.Description,
+							}
+						}
+						return data
+					},
+				}),
+			},
+			"caps": {
+				Title:    "Capabilities",
+				Required: false,
+				Flag: scaffoldcreate.FlagConfig{
+					Name: "caps",
+					Usage: "Canonical names of the capabilities to set." +
+						"Omitting this field will clear all capabilities from specified users and groups!",
+				},
+				Order: 160,
+				Provider: scaffoldcreate.NewMSLProvider(nil, scaffoldcreate.MSLOptions{
+					ListOptions: multiselectlist.Options{},
+					SetArgsInsertItems: func(currentItems []multiselectlist.SelectableItem[string]) (_ []multiselectlist.SelectableItem[string]) {
+						allCaps, err := connection.Client.CapabilityList()
+						if err != nil {
+							clilog.Writer.Error("failed to get user list", log.KVErr(err))
+						} else if len(allCaps) < 1 {
+							return nil
+						}
+						data := make([]multiselectlist.SelectableItem[string], len(allCaps))
+						for i, cap := range allCaps {
+							data[i] = &multiselectlist.DefaultSelectableItem[string]{
+								ID_:          cap.Name,
+								Title_:       cap.Name,
+								Description_: cap.Desc,
+							}
+						}
+						return data
+					},
+				}),
+			},
+		},
+		func(fields map[string]scaffoldcreate.Field, fs *pflag.FlagSet) (_ any, invalid string, _ error) {
+			// get set of entities to update
+			var uids []int32
+			users := strings.TrimSpace(fields["users"].Provider.Get())
+			if users != "" {
+				for sUID := range strings.SplitSeq(users, scaffoldcreate.MSLProviderSeparator) {
+					id, err := strconv.ParseInt(sUID, 10, 32)
+					if err != nil {
+						clilog.Writer.Error("failed to parse user ID from MSLProvider Get() into int32", log.KV("string", sUID), log.KVErr(err))
+						return 0, "", clilog.ErrInternal{}
+					}
+					uids = append(uids, int32(id))
+				}
+			}
+
+			var gids []int32
+			groups := strings.TrimSpace(fields["groups"].Provider.Get())
+			if groups != "" {
+				for sGID := range strings.SplitSeq(groups, scaffoldcreate.MSLProviderSeparator) {
+					id, err := strconv.ParseInt(sGID, 10, 32)
+					if err != nil {
+						clilog.Writer.Error("failed to parse group ID from MSLProvider Get() into int32", log.KV("string", sGID), log.KVErr(err))
+						return 0, "", clilog.ErrInternal{}
+					}
+					gids = append(gids, int32(id))
+				}
+			}
+
+			if len(uids)+len(gids) < 1 { // nonsense request
+				return 0, "you must select at least one user/group to update", nil
+			}
+
+			// construct set of new caps
+			var newCaps types.CapabilityState
+			if caps := strings.TrimSpace(fields["caps"].Provider.Get()); caps != "" {
+				for cap := range strings.SplitSeq(caps, scaffoldcreate.MSLProviderSeparator) {
+					newCaps.Grants = append(newCaps.Grants, cap)
+				}
+			}
+
+			// execute
+			for _, uid := range uids {
+				if err := connection.Client.SetUserCapabilities(uid, newCaps); err != nil {
+					return 0, "", fmt.Errorf("uid: %w", err)
+				}
+			}
+			for _, gid := range gids {
+				if err := connection.Client.SetGroupCapabilities(gid, newCaps); err != nil {
+					return 0, "", fmt.Errorf("gid: %w", err)
+				}
+			}
+
+			var sb strings.Builder
+			// craft success message
+			if len(newCaps.Grants) < 1 {
+				sb.WriteString("removed all capabilities from")
+			} else {
+				sb.WriteString("replaced the capabilities of")
+			}
+			if len(uids) > 0 {
+				fmt.Fprintf(&sb, " users %v", uids)
+			}
+			if len(gids) > 0 {
+				if len(uids) > 0 {
+					fmt.Fprintf(&sb, " and")
+				}
+				fmt.Fprintf(&sb, " groups %v", gids)
+			}
+			if len(newCaps.Grants) > 1 {
+				fmt.Fprintf(&sb, " with %v", newCaps.Grants)
+			}
+
+			return "Replaced the capabilities of ", "", nil // TODO custom success message
+		},
+		scaffoldcreate.Options{
+			CommonOptions: scaffold.CommonOptions{
+				Use: "set",
+				Usage: "set " +
+					ft.MutuallyExclusive([]string{"--uids", "--gids"}) +
+					ft.Mandatory("--caps"),
+				Aliases: []string{"replace"},
+			},
+			Short:              "set capabilities of users and groups",
+			Long:               "Supplant the current capabilities of each selected user and group by providing a new set of capabilities.",
+			IDIsSuccessMessage: true,
+		})
+}

--- a/gwcli/tree/cbac/cbac.go
+++ b/gwcli/tree/cbac/cbac.go
@@ -532,7 +532,7 @@ func set() action.Pair {
 					SetArgsInsertItems: func(currentItems []multiselectlist.SelectableItem[string]) (_ []multiselectlist.SelectableItem[string]) {
 						allCaps, err := connection.Client.CapabilityList()
 						if err != nil {
-							clilog.Writer.Error("failed to get user list", log.KVErr(err))
+							clilog.Writer.Error("failed to get capability list", log.KVErr(err))
 						} else if len(allCaps) < 1 {
 							return nil
 						}

--- a/gwcli/tree/cbac/cbac_noci_test.go
+++ b/gwcli/tree/cbac/cbac_noci_test.go
@@ -1,3 +1,5 @@
+//go:build noci
+
 /*************************************************************************
  * Copyright 2026 Gravwell, Inc. All rights reserved.
  * Contact: <legal@gravwell.io>

--- a/gwcli/tree/cbac/cbac_noci_test.go
+++ b/gwcli/tree/cbac/cbac_noci_test.go
@@ -1,0 +1,230 @@
+/*************************************************************************
+ * Copyright 2026 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
+package cbac_test
+
+import (
+	"encoding/csv"
+	"fmt"
+	"maps"
+	"os"
+	"path"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/Pallinder/go-randomdata"
+	"github.com/gravwell/gravwell/v4/client"
+	"github.com/gravwell/gravwell/v4/client/types"
+	"github.com/gravwell/gravwell/v4/gwcli/internal/testsupport"
+	"github.com/gravwell/gravwell/v4/gwcli/tree"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(m *testing.M) {
+	// we can only run these tests if cbac is enabled
+	cli, err := client.New(testsupport.Server(), false, false)
+	if err != nil {
+		panic(err)
+	}
+	if err := cli.Login("admin", "changeme"); err != nil {
+		panic(err)
+	}
+	li, err := cli.GetLicenseInfo()
+	if err != nil {
+		panic(err)
+	}
+	cbac := li.CBACEnabled()
+	// we don't actually have a way to check if cbac is enabled *in the system*, rather than just the license
+	cli.Close()
+
+	if cbac {
+		m.Run()
+	}
+}
+
+func TestCBACLifecycle(t *testing.T) {
+	// spool up a client to check directly against the results we get
+	cli, err := client.New(testsupport.Server(), false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.Nil(t, cli.Login("admin", "changeme"))
+
+	allCaps, err := cli.CapabilityList()
+	if err != nil {
+		t.Log("failed to get direct list of capabilities, skipping")
+		t.Skip()
+	}
+	// sort the caps into a map for faster lookup
+	allCapsMap := map[string]any{} // canonical name -> nothing
+	for _, cap := range allCaps {
+		allCapsMap[cap.Name] = 0
+	}
+
+	metaAdmin := testsupport.MetaArgs(t, false, testsupport.WithDefaults())
+
+	t.Run("capabilities matches full list of caps and vice versa", func(t *testing.T) {
+		var stdout, stderr strings.Builder
+		capsPath := path.Join(t.TempDir(), "caps_list.csv")
+		require.Zero(t, tree.Execute(append(metaAdmin, "cbac", "capabilities", "--csv", "-o", capsPath, "--columns=Name"), &stdout, &stderr), stderr.String())
+		assert.Empty(t, stderr.String())
+		f, err := os.Open(capsPath)
+		require.Nil(t, err)
+		defer f.Close()
+		rdr := csv.NewReader(f)
+		records, err := rdr.ReadAll()
+		require.Nil(t, err)
+		assert.Greater(t, len(records), 2)
+		seenCaps := map[string]any{} // should make allCapsMap by the time we are done
+		for i := 1; i < len(records); i++ {
+			record := records[i]
+			assert.Len(t, record, 1)
+			seenCaps[record[0]] = 0
+		}
+		assert.True(t, maps.Equal(allCapsMap, seenCaps))
+	})
+
+	// spool up a second user that isn't an admin to test against
+	secondUser, err := cli.CreateUser(
+		types.AddUser{Username: randomdata.Alphanumeric(10), Password: "pass", Name: "ziv", Email: "ziv@example.com", Admin: false},
+	)
+	if err != nil {
+		t.Logf("failed to create secondary user to test against: %v", err)
+		t.Skip()
+	}
+	t.Cleanup(func() { cli.DeleteUser(secondUser.ID) })
+	secondCli, err := client.New(testsupport.Server(), false, false)
+	if err != nil {
+		t.Logf("failed to create secondary user client: %v", err)
+		t.Skip()
+	}
+	require.Nil(t, secondCli.Login(secondUser.Username, "pass"))
+	metaSecond := testsupport.MetaArgs(t, false,
+		testsupport.WithUsernamePassword(secondUser.Username, "pass"),
+		testsupport.WithServer(false, ""),
+	)
+	t.Run("new user has no caps", func(t *testing.T) {
+		var stdout, stderr strings.Builder
+		require.Zero(t,
+			tree.Execute(append(metaSecond, "cbac", "my", "--columns=Name"), &stdout, &stderr),
+		)
+		rdr := csv.NewReader(strings.NewReader(stdout.String()))
+		header, err := rdr.Read()
+		assert.Nil(t, err)
+		assert.Len(t, header, 1)
+		records, err := rdr.ReadAll()
+		assert.Nil(t, err)
+		require.Len(t, records, 0)
+
+		stdout.Reset()
+		stderr.Reset()
+
+		// check that getting as admin agrees
+		require.Zero(t,
+			tree.Execute(append(metaAdmin, "cbac", "get", "--csv", "--columns=ID,Grants",
+				"--uids="+strconv.FormatInt(int64(secondUser.ID), 10)),
+				&stdout, &stderr),
+			stderr.String())
+		assert.Empty(t, stderr.String())
+		rdr = csv.NewReader(strings.NewReader(stdout.String()))
+		header, err = rdr.Read()
+		assert.Nil(t, err)
+		assert.Len(t, header, 2)
+		records, err = rdr.ReadAll()
+		assert.Nil(t, err)
+		require.Len(t, records, 1)
+		var uid int32
+		fmt.Sscanf(records[0][0], "uid%d", &uid)
+		assert.Equal(t, secondUser.ID, uid)
+	})
+	t.Run("edit with --revoke will add no caps", func(t *testing.T) {
+		var stdout, stderr strings.Builder
+
+		args := append(metaAdmin, "cbac", "edit", "--revoke", "--uid="+strconv.FormatInt(int64(secondUser.ID), 10))
+		bareArgs := slices.Collect(maps.Keys(allCapsMap))
+		require.Zero(t,
+			tree.Execute(append(args, bareArgs...),
+				&stdout, &stderr),
+			stderr.String())
+		userHasCaps(t, cli, secondUser.ID, []string{})
+	})
+	t.Run("replace to fill caps", func(t *testing.T) {
+		var stdout, stderr strings.Builder
+
+		expectedCaps := []string{"PivotRead", "KitWrite"}
+
+		args := append(metaAdmin, "cbac", "set", "--uids="+strconv.FormatInt(int64(secondUser.ID), 10), "--caps="+strings.Join(expectedCaps, ","))
+		bareArgs := slices.Collect(maps.Keys(allCapsMap))
+		require.Zero(t,
+			tree.Execute(append(args, bareArgs...),
+				&stdout, &stderr),
+			stderr.String())
+		userHasCaps(t, cli, secondUser.ID, expectedCaps)
+	})
+	t.Run("replace supplants caps", func(t *testing.T) {
+		var stdout, stderr strings.Builder
+
+		expectedCaps := []string{"NotificationRead"}
+
+		args := append(metaAdmin, "cbac", "set", "--uids="+strconv.FormatInt(int64(secondUser.ID), 10), "--caps="+strings.Join(expectedCaps, ","))
+		require.Zero(t,
+			tree.Execute(args, &stdout, &stderr),
+			stderr.String())
+		userHasCaps(t, cli, secondUser.ID, expectedCaps)
+	})
+	t.Run("edit without --grant or --revoke works like replace", func(t *testing.T) {
+		var stdout, stderr strings.Builder
+
+		expectedCaps := []string{"SaveSearch", "LicenseRead", "ListUsers"}
+
+		args := append(metaAdmin, "cbac", "edit", "--uid="+strconv.FormatInt(int64(secondUser.ID), 10))
+		require.Zero(t,
+			tree.Execute(append(args, expectedCaps...),
+				&stdout, &stderr),
+			stderr.String())
+		userHasCaps(t, cli, secondUser.ID, expectedCaps)
+	})
+	t.Run("edit with --grant adds only new caps", func(t *testing.T) {
+		var stdout, stderr strings.Builder
+
+		expectedCaps := []string{"SaveSearch", "LicenseRead", "ListUsers",
+			"BackgroundSearch", // new
+		}
+
+		givenCaps := []string{"LicenseRead", // dup
+			"ListUsers",        // dup
+			"BackgroundSearch", // new
+		}
+
+		args := append(metaAdmin, "cbac", "edit", "--grant", "--uid="+strconv.FormatInt(int64(secondUser.ID), 10))
+		require.Zero(t,
+			tree.Execute(append(args, givenCaps...),
+				&stdout, &stderr),
+			stderr.String())
+		userHasCaps(t, cli, secondUser.ID, expectedCaps)
+	})
+	t.Run("replace with no caps clears all", func(t *testing.T) {
+		var stdout, stderr strings.Builder
+
+		args := append(metaAdmin, "cbac", "set", "--uids="+strconv.FormatInt(int64(secondUser.ID), 10))
+		require.Zero(t,
+			tree.Execute(args, &stdout, &stderr),
+			stderr.String())
+		userHasCaps(t, cli, secondUser.ID, []string{})
+	})
+}
+
+func userHasCaps(t *testing.T, adminCli *client.Client, uid int32, expectedCapNames []string) {
+	t.Helper()
+	cs, err := adminCli.GetUserCapabilities(uid)
+	require.Nil(t, err)
+	assert.ElementsMatch(t, cs.Grants, expectedCapNames)
+}

--- a/gwcli/tree/dashboards/dashboards.go
+++ b/gwcli/tree/dashboards/dashboards.go
@@ -10,13 +10,13 @@
 package dashboards
 
 import (
+	"fmt"
+
 	"github.com/gravwell/gravwell/v4/client/types"
 	"github.com/gravwell/gravwell/v4/gwcli/action"
 	"github.com/gravwell/gravwell/v4/gwcli/bubbles/multiselectlist"
-	"github.com/gravwell/gravwell/v4/gwcli/clilog"
 	"github.com/gravwell/gravwell/v4/gwcli/connection"
 	"github.com/gravwell/gravwell/v4/gwcli/internal/listitem"
-	ft "github.com/gravwell/gravwell/v4/gwcli/stylesheet/flagtext"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffolddelete"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldlist"
@@ -49,31 +49,16 @@ func NewNav() *cobra.Command {
 
 func listAction() action.Pair {
 	return scaffoldlist.NewListAction("list dashboards", "list dashboards available to you and the system",
-		types.Dashboard{}, list,
+		types.Dashboard{}, func(_ *pflag.FlagSet, params scaffoldlist.DataParameters) ([]types.Dashboard, error) {
+			r, err := connection.Client.ListDashboards(params.QueryOpts)
+			return r.Results, err
+		},
 		nil,
-		scaffoldlist.Options{CommonOptions: scaffold.CommonOptions{AddtlFlags: flags}, DefaultColumns: []string{
-			"ID",
-			"Name",
-			"Description",
+		scaffoldlist.Options{DefaultColumns: []string{
+			"CommonFields.ID",
+			"CommonFields.Name",
+			"CommonFields.Description",
 		}})
-}
-
-func flags() *pflag.FlagSet {
-	addtlFlags := pflag.FlagSet{}
-	ft.GetAll.Register(&addtlFlags, true, "dashboards")
-
-	return &addtlFlags
-}
-
-func list(fs *pflag.FlagSet) ([]types.Dashboard, error) {
-	if all, err := fs.GetBool(ft.GetAll.Name()); err != nil {
-		clilog.GetFlag(err)
-	} else if all {
-		r, err := connection.Client.ListAllDashboards(nil)
-		return r.Results, err
-	}
-	r, err := connection.Client.ListDashboards(nil)
-	return r.Results, err
 }
 
 //#region delete
@@ -128,16 +113,31 @@ func cloneAction() action.Pair {
 			}
 			return items, nil
 		},
-		func(ID string, _ *pflag.FlagSet) (success string, _ error) {
-			cur, err := connection.Client.GetDashboard(ID)
-			if err != nil {
-				return "", err
+		func(IDs []string, addtlFlags *pflag.FlagSet) (results []scaffold.Result, _ error) {
+			results = make([]scaffold.Result, len(IDs))
+			for i, id := range IDs {
+				cur, err := connection.Client.GetDashboard(id)
+				if err != nil {
+					results[i] = scaffold.Result{
+						Output:  fmt.Sprintf("failed to clone dashboard %s: %v", id, err),
+						Success: false,
+					}
+					continue
+				}
+				new, err := connection.Client.CreateDashboard(cur)
+				if err != nil {
+					results[i] = scaffold.Result{
+						Output:  fmt.Sprintf("failed to clone dashboard %s: %v", id, err),
+						Success: false,
+					}
+					continue
+				}
+				results[i] = scaffold.Result{
+					Output:  "cloned dashboard " + cur.Name + " into dashboard " + new.Name,
+					Success: true,
+				}
 			}
-			new, err := connection.Client.CreateDashboard(cur)
-			if err != nil {
-				return "", err
-			}
-			return "cloned dashboard " + cur.Name + " into dashboard " + new.Name, nil
+			return results, nil
 		},
 		scaffoldselect.Options{
 			CommonOptions: scaffold.CommonOptions{Use: "clone"},

--- a/gwcli/tree/email/email.go
+++ b/gwcli/tree/email/email.go
@@ -48,17 +48,14 @@ func NewNav() *cobra.Command {
 func show() action.Pair {
 	return scaffoldlist.NewListAction("display email configuration", "Display the current email/SMTP configuration.",
 		types.UserMailConfig{},
-		func(fs *pflag.FlagSet) ([]types.UserMailConfig, error) {
+		func(_ *pflag.FlagSet, _ scaffoldlist.DataParameters) ([]types.UserMailConfig, error) {
 			mc, err := connection.Client.MailConfig()
-			if err != nil {
-				return nil, err
-			}
-			return []types.UserMailConfig{mc}, nil
+			return []types.UserMailConfig{mc}, err
 		},
 		nil,
 		scaffoldlist.Options{
 			CommonOptions: scaffold.CommonOptions{Use: "show"},
-			Pretty: func(DQColumns []string, DQToAlias map[string]string) (string, error) {
+			Pretty: func(_ *pflag.FlagSet, DQColumns []string, DQToAlias map[string]string, _ scaffoldlist.DataParameters) (string, error) {
 				mc, err := connection.Client.MailConfig()
 				if err != nil {
 					return "", err
@@ -68,6 +65,9 @@ func show() action.Pair {
 				}
 				return fmt.Sprintf("Server: %s\nPort: %d\nUsername: %s\nUseTLS: %v\nInsecureSkipVerify: %v",
 					mc.Server, mc.Port, mc.Username, mc.UseTLS, mc.InsecureSkipVerify), nil
+			},
+			Omit: scaffold.OmitFlags{
+				Everything: true,
 			},
 		})
 }

--- a/gwcli/tree/extractors/extractors.go
+++ b/gwcli/tree/extractors/extractors.go
@@ -518,8 +518,11 @@ func find() action.Pair {
 			results = make([]scaffold.Result, len(tags))
 			for i, tag := range tags {
 				ax, err := connection.Client.FindExtraction(tag)
-				if err != nil {
-					results[i].Output = "failed to get extraction for " + tag
+				if phrases.IsNotFoundErr(err) {
+					results[i].Output = "tag '" + tag + "' does not have an extractor"
+					results[i].Success = true
+				} else if err != nil {
+					results[i].Output = "failed to get extractor for " + tag
 				} else {
 					results[i].Output = fmt.Sprintf("tag '%v' uses extractor '%v'\n"+
 						"ID: %v\n"+

--- a/gwcli/tree/extractors/extractors.go
+++ b/gwcli/tree/extractors/extractors.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -32,6 +33,7 @@ import (
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffolddelete"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldedit"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldlist"
+	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldselect"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/treeutils"
 	"github.com/gravwell/gravwell/v4/ingest/log"
 
@@ -58,6 +60,7 @@ func NewNav() *cobra.Command {
 			modules(),
 			edit(),
 			importUpload(),
+			find(),
 		})
 }
 
@@ -483,6 +486,55 @@ func importUpload() action.Pair {
 					return phrases.Exactly1ArgRequired("file path"), nil
 				}
 				return "", nil
+			},
+		})
+}
+
+func find() action.Pair {
+	return scaffoldselect.NewSelectAction("find a tag's extractor", "Display information about the extractor associated to a selected tag",
+		"tag",
+		func(addtlFlags *pflag.FlagSet) ([]multiselectlist.SelectableItem[string], error) {
+			tags, err := connection.Client.GetTags()
+			if err != nil {
+				return nil, err
+			}
+			data := make([]multiselectlist.SelectableItem[string], 0, len(tags))
+			for _, tag := range tags {
+				ax, err := connection.Client.FindExtraction(tag)
+				if phrases.IsNotFoundErr(err) { // no associated ax
+					continue
+				} else if err != nil {
+					return nil, err
+				}
+				data = append(data, &listitem.Generic{
+					ID_:        tag,
+					Name:       tag,
+					SecondLine: fmt.Sprintf("%s(%s): %s", ax.Name, ax.Module, ax.Description),
+				})
+			}
+			return slices.Clip(data), nil
+		},
+		func(tags []string, addtlFlags *pflag.FlagSet) (results []scaffold.Result, _ error) {
+			results = make([]scaffold.Result, len(tags))
+			for i, tag := range tags {
+				ax, err := connection.Client.FindExtraction(tag)
+				if err != nil {
+					results[i].Output = "failed to get extraction for " + tag
+				} else {
+					results[i].Output = fmt.Sprintf("tag '%v' uses extractor '%v'\n"+
+						"ID: %v\n"+
+						"Module: %v\n"+
+						"Args: %v\n"+
+						"Other tags: %v",
+						tag, ax.Name, ax.ID, ax.Module, ax.Args, slices.DeleteFunc(ax.Tags, func(s string) bool { return s == tag }))
+					results[i].Success = true
+				}
+			}
+			return results, nil
+		},
+		scaffoldselect.Options{
+			CommonOptions: scaffold.CommonOptions{
+				Use: "find",
 			},
 		})
 }

--- a/gwcli/tree/extractors/extractors.go
+++ b/gwcli/tree/extractors/extractors.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldedit"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldlist"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/treeutils"
+	"github.com/gravwell/gravwell/v4/ingest/log"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -92,16 +93,16 @@ func list() action.Pair {
 		short,
 		long,
 		types.AX{},
-		func(fs *pflag.FlagSet) ([]types.AX, error) {
-			if id, err := fs.GetString("id"); err != nil {
-				clilog.GetFlag(err)
-			} else if id != "" {
-				clilog.Writer.Infof("Fetching ax with id \"%v\"", id)
-				d, err := connection.Client.GetExtraction(id)
+		func(fs *pflag.FlagSet, param scaffoldlist.DataParameters) ([]types.AX, error) {
+			id, err := fs.GetString("id")
+			clilog.GetFlag(err)
+			if id != "" {
+				clilog.Writer.Info("Fetching ax by ID", log.KV("ID", id))
+				d, err := connection.Client.GetExtraction(id) // TODO this needs an EX equivalent, no?
 				return []types.AX{d}, err
 			}
 
-			lr, err := connection.Client.ListExtractions(nil)
+			lr, err := connection.Client.ListExtractions(param.QueryOpts)
 			return lr.Results, err
 
 		},

--- a/gwcli/tree/files/files.go
+++ b/gwcli/tree/files/files.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldlist"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldselect"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/treeutils"
+	"github.com/gravwell/gravwell/v4/ingest/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -129,35 +130,32 @@ func create() action.Pair {
 		map[string]scaffoldcreate.Field{
 			"name":   scaffoldcreate.FieldName("file"),
 			"desc":   scaffoldcreate.FieldDescription("file"),
-			"path":   scaffoldcreate.FieldPath("file"),
+			"path":   scaffoldcreate.FieldPath("file", false),
 			"labels": scaffoldcreate.FieldLabels(),
 		},
 		func(cfg map[string]scaffoldcreate.Field, fs *pflag.FlagSet) (id any, invalid string, err error) {
 			var (
 				name, desc, filePath string
-				labels               []string
 			)
 			name = cfg["name"].Provider.Get()
 			desc = cfg["desc"].Provider.Get()
 			filePath = cfg["path"].Provider.Get()
-			if lbls := cfg["labels"].Provider.Get(); lbls != "" {
-				labels = strings.Split(lbls, ",")
-			}
 
-			// TODO make file content/path non-mandatory
-
-			// get a reader on the file
-			f, err := os.Open(filePath)
-			if err != nil {
-				return 0, "", err
+			var f *os.File
+			if filePath != "" {
+				// get a reader on the file
+				f, err = os.Open(filePath)
+				if err != nil {
+					return 0, "", err
+				}
+				defer f.Close()
 			}
-			defer f.Close()
 
 			var inMeta = types.File{
 				CommonFields: types.CommonFields{
 					Name:        name,
 					Description: desc,
-					Labels:      labels,
+					Labels:      scaffoldcreate.GetLabelsFromField(cfg["labels"]),
 				},
 			}
 
@@ -165,9 +163,10 @@ func create() action.Pair {
 			if err != nil {
 				return 0, "", fmt.Errorf("failed to create empty file: %w", err)
 			}
-			// populate the file
-			if _, err := connection.Client.PopulateFileFromReader(outMeta.ID, f); err != nil {
-				return 0, "", fmt.Errorf("failed to populate file: %w", err)
+			if f != nil {
+				if _, err := connection.Client.PopulateFileFromReader(outMeta.ID, f); err != nil {
+					return 0, "", fmt.Errorf("failed to populate file: %w", err)
+				}
 			}
 
 			return outMeta.ID, "", nil
@@ -265,7 +264,7 @@ func delete() action.Pair {
 
 func replace() action.Pair {
 	return scaffoldselect.NewSelectAction("replace file contents",
-		"Populate a file with the contents of a local file, clobbering any existing data",
+		"Populate one or many files with the contents of a single local file, clobbering any existing data",
 		"file ID",
 		func(addtlFlags *pflag.FlagSet) ([]multiselectlist.SelectableItem[string], error) {
 			lr, err := connection.Client.ListFiles(&types.QueryOptions{AdminMode: connection.AdminMode()})
@@ -278,18 +277,32 @@ func replace() action.Pair {
 			}
 			return items, nil
 		},
-		func(ID string, addtlFlags *pflag.FlagSet) (success string, _ error) {
+		func(IDs []string, addtlFlags *pflag.FlagSet) (results []scaffold.Result, _ error) {
+			results = make([]scaffold.Result, len(IDs))
 			// slurp file
 			pth, _ := addtlFlags.GetString(ft.Path.Name())
 			contentF, err := os.Open(pth)
 			if err != nil {
-				return "", err
+				return nil, err
 			}
-			updatedFile, err := connection.Client.PopulateFileFromReader(ID, contentF)
-			if err != nil {
-				return "", err
+			for i, ID := range IDs {
+				if _, err := contentF.Seek(0, 0); err != nil {
+					clilog.Writer.Warn("failed to rewind file", log.KV("file path", pth), log.KVErr(err))
+				}
+				updatedFile, err := connection.Client.PopulateFileFromReader(ID, contentF)
+				if err != nil {
+					results[i] = scaffold.Result{
+						Output:  fmt.Sprintf("failed to repopulate file %s (ID: %s): %v", contentF.Name(), ID, err),
+						Success: false,
+					}
+					continue
+				}
+				results[i] = scaffold.Result{
+					Output:  fmt.Sprintf("replaced file contents of %s (ID: %s). New size: %d", updatedFile.Name, updatedFile.ID, updatedFile.Size),
+					Success: true,
+				}
 			}
-			return fmt.Sprintf("replaced file contents of %s (ID: %s). New size: %d", updatedFile.Name, updatedFile.ID, updatedFile.Size), nil
+			return results, nil
 		},
 		scaffoldselect.Options{
 			CommonOptions: scaffold.CommonOptions{

--- a/gwcli/tree/files/files.go
+++ b/gwcli/tree/files/files.go
@@ -65,36 +65,12 @@ func list() action.Pair {
 		long  string = "Lists information about the files you have access to."
 	)
 	return scaffoldlist.NewListAction(short, long,
-		types.File{}, func(fs *pflag.FlagSet) ([]types.File, error) {
-			// check for all
-			all, err := fs.GetBool(ft.GetAll.Name())
-			if err != nil {
-				clilog.GetFlag(err)
-			}
-
-			var flr types.FileListResponse
-			if all {
-				flr, err = connection.Client.ListAllFiles(nil)
-				if err != nil {
-					return nil, err
-				}
-			} else {
-				flr, err = connection.Client.ListFiles(nil)
-				if err != nil {
-					return nil, err
-				}
-			}
-			return flr.Results, nil
+		types.File{}, func(fs *pflag.FlagSet, param scaffoldlist.DataParameters) ([]types.File, error) {
+			flr, err := connection.Client.ListFiles(param.QueryOpts)
+			return flr.Results, err
 		},
 		map[string]string{"Size": "SizeBytes"},
 		scaffoldlist.Options{
-			CommonOptions: scaffold.CommonOptions{
-				AddtlFlags: func() *pflag.FlagSet {
-					var fs = &pflag.FlagSet{}
-					ft.GetAll.Register(fs, true, "files")
-					return fs
-				},
-			},
 			DefaultColumns: []string{
 				"CommonFields.ID",
 				"CommonFields.Name",

--- a/gwcli/tree/files/files.go
+++ b/gwcli/tree/files/files.go
@@ -277,15 +277,15 @@ func replace() action.Pair {
 		},
 		func(IDs []string, addtlFlags *pflag.FlagSet) (results []scaffold.Result, _ error) {
 			results = make([]scaffold.Result, len(IDs))
-			for _, ID := range IDs {
+			for i, ID := range IDs {
 				pth, _ := addtlFlags.GetString(ft.Path.Name())
-				_, err := connection.Client.PopulateFileFromPath(ID, pth)
+				f, err := connection.Client.PopulateFileFromPath(ID, pth)
 				if err != nil {
-					results = append(results, scaffold.Result{Output: err.Error()})
+					results[i] = scaffold.Result{Output: err.Error()}
 				} else {
-					results = append(results, scaffold.Result{
+					results[i] = scaffold.Result{
 						Success: true,
-						Output:  fmt.Sprintf("populated file ID %s with the contents of %s", ID, pth)})
+						Output:  fmt.Sprintf("populated file %s (ID: %s) with the contents of %s", f.Name, ID, pth)}
 				}
 			}
 

--- a/gwcli/tree/flows/flows.go
+++ b/gwcli/tree/flows/flows.go
@@ -49,11 +49,10 @@ func NewNav() *cobra.Command {
 			backfillToggle(),
 			clear(),
 			parse(),
+			create(),
 		},
 	)
 }
-
-//#region list
 
 func listActions() action.Pair {
 	return scaffoldlist.NewListAction("list flows", "Lists information about flows you can access.",
@@ -484,4 +483,57 @@ func parse() action.Pair {
 				return "", nil
 			},
 		})
+}
+
+func create() action.Pair {
+	return scaffoldcreate.NewCreateAction("flow",
+		map[string]scaffoldcreate.Field{
+			"name":     scaffoldcreate.FieldName("flow"),
+			"desc":     scaffoldcreate.FieldDescription("flow"),
+			"path":     scaffoldcreate.FieldPath("flow specification", true),
+			"labels":   scaffoldcreate.FieldLabels(),
+			"schedule": scaffoldcreate.FieldFrequency(),
+			"enabled": {
+				Title: "Enabled?", Required: false,
+				Flag:     scaffoldcreate.FlagConfig{},
+				Order:    30,
+				Provider: &scaffoldcreate.BoolProvider{},
+			},
+			"backfill": {
+				Title: "Backfill?", Required: false,
+				Flag:     scaffoldcreate.FlagConfig{},
+				Order:    20,
+				Provider: &scaffoldcreate.BoolProvider{},
+			},
+		},
+		func(fields map[string]scaffoldcreate.Field, fs *pflag.FlagSet) (id any, invalid string, err error) {
+			pth := fields["path"].Provider.Get()
+			flowContent, err := os.ReadFile(pth)
+			if err != nil {
+				return 0, "", err
+			}
+
+			enabled, _ := strconv.ParseBool(fields["enabled"].Provider.Get())
+			backfill, _ := strconv.ParseBool(fields["backfill"].Provider.Get())
+
+			newFlow, err := connection.Client.CreateFlow(types.Flow{
+				CommonFields: types.CommonFields{
+					Name:        fields["name"].Provider.Get(),
+					Description: fields["desc"].Provider.Get(),
+					Labels:      scaffoldcreate.GetLabelsFromField(fields["labels"]),
+				},
+				AutomationCommonFields: types.AutomationCommonFields{
+					Schedule:        fields["schedule"].Provider.Get(),
+					Disabled:        !enabled,
+					BackfillEnabled: backfill,
+				},
+				Flow: string(flowContent),
+			})
+			if err != nil {
+				return 0, "", err
+			}
+			return newFlow.ID, "", nil
+		},
+		scaffoldcreate.Options{})
+
 }

--- a/gwcli/tree/flows/flows.go
+++ b/gwcli/tree/flows/flows.go
@@ -41,13 +41,13 @@ func NewNav() *cobra.Command {
 		[]string{"flow"},
 		nil,
 		[]action.Pair{
-			listFlows(),
+			listActions(),
 			importCreate(),
 			download(),
 			delete(),
 			cancel(),
 			backfillToggle(),
-			clearResults(),
+			clear(),
 			parse(),
 		},
 	)
@@ -55,15 +55,12 @@ func NewNav() *cobra.Command {
 
 //#region list
 
-func listFlows() action.Pair {
+func listActions() action.Pair {
 	return scaffoldlist.NewListAction("list flows", "Lists information about flows you can access.",
 		types.Flow{},
-		func(fs *pflag.FlagSet) ([]types.Flow, error) {
-			baseList, err := connection.Client.ListFlows(nil)
-			if err != nil {
-				return nil, err
-			}
-			return baseList.Results, nil
+		func(fs *pflag.FlagSet, params scaffoldlist.DataParameters) ([]types.Flow, error) {
+			baseList, err := connection.Client.ListFlows(params.QueryOpts)
+			return baseList.Results, err
 		},
 		nil,
 		scaffoldlist.Options{
@@ -77,18 +74,15 @@ func listFlows() action.Pair {
 	)
 }
 
-//#endregion list
-
-var validGIDs map[int32]string // cached each SetArg so we don't hit the backend on every key
-
 // importCreate is the create function for flows, but the flow itself is created from JSON slurped from a file
 func importCreate() action.Pair {
+	var validGIDs map[int32]string // cached each SetArg so we don't hit the backend on every key
 	return scaffoldcreate.NewCreateAction("flow",
 		map[string]scaffoldcreate.Field{
 			"name":      scaffoldcreate.FieldName("flow"),
 			"desc":      scaffoldcreate.FieldDescription("flow"),
 			"frequency": scaffoldcreate.FieldFrequency(),
-			"path":      scaffoldcreate.FieldPath("file containing a flow in JSON form"),
+			"path":      scaffoldcreate.FieldPath("file containing a flow in JSON form", true),
 			"groups": {
 				Required: false,
 				Title:    "Groups",
@@ -290,11 +284,16 @@ func cancel() action.Pair {
 			// we don't appear to currently have that capability via the client library
 			return listFlowItems()
 		},
-		func(id string, _ *pflag.FlagSet) (success string, err error) {
-			if err := connection.Client.CancelFlow(id); err != nil {
-				return "", err
+		func(IDs []string, _ *pflag.FlagSet) (results []scaffold.Result, _ error) {
+			results = make([]scaffold.Result, len(IDs))
+			for i, ID := range IDs {
+				if err := connection.Client.CancelFlow(ID); err != nil {
+					results[i] = scaffold.Result{Success: false, Output: fmt.Sprintf("failed to cancel flow %s: %v", ID, err)}
+				} else {
+					results[i] = scaffold.Result{Success: true, Output: fmt.Sprintf("successfully cancelled flow %s", ID)}
+				}
 			}
-			return fmt.Sprintf("successfully cancelled flow %s", id), nil
+			return results, nil
 		},
 		scaffoldselect.Options{
 			CommonOptions: scaffold.CommonOptions{Use: "cancel"},
@@ -334,35 +333,41 @@ func backfillToggle() action.Pair {
 			}
 			return itms, nil
 		},
-		func(id string, fs *pflag.FlagSet) (success string, err error) {
+		func(IDs []string, fs *pflag.FlagSet) (results []scaffold.Result, _ error) {
 			enable, disable, err := getBackfillFlags(fs)
 			if err != nil {
-				return "", err
+				return nil, err
 			}
 
-			flow, err := connection.Client.GetFlow(id)
-			if err != nil {
-				return "", err
-			}
-			flow.BackfillEnabled = !flow.BackfillEnabled
-			if enable {
-				flow.BackfillEnabled = true
-			} else if disable {
-				flow.BackfillEnabled = false
-			}
+			results = make([]scaffold.Result, len(IDs))
+			for i, ID := range IDs {
+				flow, err := connection.Client.GetFlow(ID)
+				if err != nil {
+					results[i] = scaffold.Result{Success: false, Output: fmt.Sprintf("failed to get flow %s: %v", ID, err)}
+					continue
+				}
+				flow.BackfillEnabled = !flow.BackfillEnabled
+				if enable {
+					flow.BackfillEnabled = true
+				} else if disable {
+					flow.BackfillEnabled = false
+				}
 
-			if err := connection.Client.UpdateFlow(flow); err != nil {
-				return "", err
+				if err := connection.Client.UpdateFlow(flow); err != nil {
+					results[i] = scaffold.Result{Success: false, Output: fmt.Sprintf("failed to update backfill for flow %s: %v", ID, err)}
+					continue
+				}
+				state := "enabled"
+				if !flow.BackfillEnabled {
+					state = "disabled"
+				}
+				results[i] = scaffold.Result{Success: true, Output: fmt.Sprintf("flow '%s' backfill %s", ID, state)}
 			}
-			state := "enabled"
-			if !flow.BackfillEnabled {
-				state = "disabled"
-			}
-			return fmt.Sprintf("flow '%s' backfill %s", id, state), nil
+			return results, nil
 		},
 		scaffoldselect.Options{
 			CommonOptions: scaffold.CommonOptions{
-				Use: "toggle-backfill",
+				Use: "backfill",
 				AddtlFlags: func() *pflag.FlagSet {
 					fs := &pflag.FlagSet{}
 					fs.Bool("enable", false, "enable backfill")
@@ -377,18 +382,23 @@ func backfillToggle() action.Pair {
 		})
 }
 
-func clearResults() action.Pair {
+func clear() action.Pair {
 	return scaffoldselect.NewSelectAction("clear results for flows",
 		"Clear the execution results (including errors and state) for one or several flows.",
 		"flow",
 		func(_ *pflag.FlagSet) ([]multiselectlist.SelectableItem[string], error) {
 			return listFlowItems()
 		},
-		func(id string, _ *pflag.FlagSet) (success string, err error) {
-			if err := connection.Client.ClearFlowResults(id); err != nil {
-				return "", err
+		func(IDs []string, _ *pflag.FlagSet) (results []scaffold.Result, _ error) {
+			results = make([]scaffold.Result, len(IDs))
+			for i, ID := range IDs {
+				if err := connection.Client.ClearFlowResults(ID); err != nil {
+					results[i] = scaffold.Result{Success: false, Output: fmt.Sprintf("failed to clear results for flow %s: %v", ID, err)}
+				} else {
+					results[i] = scaffold.Result{Success: true, Output: fmt.Sprintf("successfully cleared results for flow %s", ID)}
+				}
 			}
-			return fmt.Sprintf("successfully cleared results for flow %s", id), nil
+			return results, nil
 		},
 		scaffoldselect.Options{
 			CommonOptions: scaffold.CommonOptions{Use: "clear"},

--- a/gwcli/tree/kits/kits.go
+++ b/gwcli/tree/kits/kits.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gravwell/gravwell/v4/gwcli/action"
 	"github.com/gravwell/gravwell/v4/gwcli/clilog"
 	"github.com/gravwell/gravwell/v4/gwcli/connection"
-	ft "github.com/gravwell/gravwell/v4/gwcli/stylesheet/flagtext"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldlist"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/treeutils"
@@ -41,13 +40,13 @@ func NewNav() *cobra.Command {
 func newKitsListAction() action.Pair {
 	const short string = "list installed and staged kits"
 	var long = "lists kits available to your user" +
-		"(or all kits on the system, via the --" + ft.GetAll.Name() + " flag if you are an admin)"
+		"(or all kits on the system, via the --all flag if you are an admin)"
 
 	return scaffoldlist.NewListAction(
 		short, long,
-		types.IdKitState{}, func(fs *pflag.FlagSet) ([]types.IdKitState, error) {
+		types.IdKitState{}, func(fs *pflag.FlagSet, _ scaffoldlist.DataParameters) ([]types.IdKitState, error) {
 			// if --all, use the admin version
-			if all, err := fs.GetBool(ft.GetAll.Name()); err != nil {
+			if all, err := fs.GetBool("all"); err != nil {
 				clilog.GetFlag(err)
 			} else if all {
 				return connection.Client.AdminListKits()
@@ -67,8 +66,7 @@ func newKitsListAction() action.Pair {
 
 func flags() *pflag.FlagSet {
 	addtlFlags := pflag.FlagSet{}
-	ft.GetAll.Register(&addtlFlags, true, "kits")
-
+	addtlFlags.Bool("all", false, "Get all kits available on the system.")
 	return &addtlFlags
 }
 

--- a/gwcli/tree/macros/macros.go
+++ b/gwcli/tree/macros/macros.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gravwell/gravwell/v4/gwcli/connection"
 	"github.com/spf13/cobra"
 
-	ft "github.com/gravwell/gravwell/v4/gwcli/stylesheet/flagtext"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldcreate"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffolddelete"
@@ -59,20 +58,12 @@ func NewNav() *cobra.Command {
 
 func list() action.Pair {
 	return scaffoldlist.NewListAction("list your macros", "lists all macros associated to your user, a group, or the system itself",
-		types.Macro{}, func(fs *pflag.FlagSet) ([]types.Macro, error) {
-			if all, err := fs.GetBool("all"); err != nil {
-				return nil, clilog.GetFlag(err)
-			} else if all { // fetch all macros instead of just user macros
-				r, err := connection.Client.ListAllMacros(nil)
-				if err != nil {
-					return nil, err
-				}
-				return r.Results, nil
-			}
-			if gid, err := fs.GetInt32("group"); err != nil {
-				return nil, clilog.GetFlag(err)
-			} else if gid != 0 { // fetch all macros our group ID can read
-				macros, err := connection.Client.ListAllMacros(nil)
+		types.Macro{}, func(fs *pflag.FlagSet, params scaffoldlist.DataParameters) ([]types.Macro, error) {
+			gid, err := fs.GetInt32("group")
+			clilog.GetFlag(err)
+			if gid != 0 { // fetch all macros our group ID can read
+				// TODO inject the group ID filter here rather than manually filtering after the fact
+				macros, err := connection.Client.ListAllMacros(params.QueryOpts)
 				if err != nil {
 					return nil, err
 				}
@@ -84,11 +75,8 @@ func list() action.Pair {
 				}
 				return macroResults, nil
 			}
-			r, err := connection.Client.ListMacros(nil)
-			if err != nil {
-				return nil, err
-			}
-			return r.Results, nil
+			r, err := connection.Client.ListMacros(params.QueryOpts)
+			return r.Results, err
 		},
 		nil,
 		scaffoldlist.Options{
@@ -103,7 +91,6 @@ func list() action.Pair {
 
 func flags() *pflag.FlagSet {
 	addtlFlags := pflag.FlagSet{}
-	ft.GetAll.Register(&addtlFlags, true, "macros", "Supersedes --group")
 	addtlFlags.Int32("group", 0, "fetches all macros shared with the given group id")
 	return &addtlFlags
 }

--- a/gwcli/tree/notifications.go
+++ b/gwcli/tree/notifications.go
@@ -15,7 +15,7 @@ import (
 
 func notifications() action.Pair {
 	return scaffoldlist.NewListAction("view your notifications", "review your notifications, new or previously seen", types.Notification{},
-		func(fs *pflag.FlagSet) ([]types.Notification, error) {
+		func(fs *pflag.FlagSet, _ scaffoldlist.DataParameters) ([]types.Notification, error) {
 			seen, err := fs.GetBool("seen")
 			if err != nil {
 				clilog.GetFlag(err)
@@ -41,9 +41,11 @@ func notifications() action.Pair {
 					return fs
 				},
 			},
-
 			DefaultColumns: []string{
 				"Sender", "Msg", "Broadcast", "Level",
+			},
+			Omit: scaffold.OmitFlags{
+				Everything: true,
 			},
 		},
 	)

--- a/gwcli/tree/playbooks/playbooks.go
+++ b/gwcli/tree/playbooks/playbooks.go
@@ -10,6 +10,7 @@
 package playbooks
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -29,6 +30,7 @@ import (
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldlist"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldselect"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/treeutils"
+	"github.com/gravwell/gravwell/v4/ingest/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )

--- a/gwcli/tree/playbooks/playbooks.go
+++ b/gwcli/tree/playbooks/playbooks.go
@@ -82,7 +82,7 @@ func download() action.Pair {
 			}
 			return data, nil
 		},
-		func(ID string, addtlFlags *pflag.FlagSet) (success string, _ error) {
+		func(IDs []string, addtlFlags *pflag.FlagSet) (results []scaffold.Result, _ error) {
 			// check for output
 			out, err := addtlFlags.GetString(ft.Output.Name())
 			clilog.GetFlag(err)
@@ -90,24 +90,35 @@ func download() action.Pair {
 			if out != "" {
 				f, err = os.Create(out)
 				if err != nil {
-					return "", err
+					return nil, err
 				}
 				defer f.Close()
 			}
-
-			pb, err := connection.Client.GetPlaybook(ID)
+			// This is an exactly1 function
+			if len(IDs) != 1 {
+				clilog.Writer.Warn("exactly1 function with incorrect number of IDs made it to operate()",
+					log.KV("count", len(IDs)),
+					scaffold.IdentifyCaller())
+				if len(IDs) == 0 {
+					return nil, errors.New(phrases.Exactly1ArgRequired("playbook ID"))
+				}
+			}
+			pb, err := connection.Client.GetPlaybook(IDs[0])
 			if err != nil {
-				return "", err
+				if phrases.IsNotFoundErr(err) {
+					return nil, phrases.ErrUnknownIdentifier(IDs[0], "playbook ID")
+				} else {
+					return nil, err
+				}
 			}
 			if f != nil {
 				n, err := f.WriteString(pb.Body)
 				if err != nil {
-					return "", err
+					return nil, err
 				}
-				return phrases.SuccessfullyWroteToFile(n, f.Name()), nil
+				return []scaffold.Result{{Output: phrases.SuccessfullyWroteToFile(n, f.Name()), Success: true}}, nil
 			}
-			return pb.Body + "\n", nil
-
+			return []scaffold.Result{{Output: pb.Body + "\n", Success: true}}, nil
 		},
 		scaffoldselect.Options{
 			CommonOptions: scaffold.CommonOptions{
@@ -124,7 +135,7 @@ func download() action.Pair {
 
 // create allows creation of a playbook, optionally with content.
 func create() action.Pair {
-	path := scaffoldcreate.FieldPath("")
+	path := scaffoldcreate.FieldPath("", true)
 	path.Flag.Usage = "path to the markdown file to use as the playbook's contents"
 	return scaffoldcreate.NewCreateAction("playbook",
 		map[string]scaffoldcreate.Field{
@@ -157,7 +168,7 @@ func create() action.Pair {
 				CommonFields: types.CommonFields{
 					Name:        cfg["name"].Provider.Get(),
 					Description: cfg["desc"].Provider.Get(),
-					Labels:      strings.Split(strings.TrimSpace(cfg["labels"].Provider.Get()), ","),
+					Labels:      scaffoldcreate.GetLabelsFromField(cfg["labels"]),
 				},
 				Body: body,
 			}

--- a/gwcli/tree/playbooks/playbooks.go
+++ b/gwcli/tree/playbooks/playbooks.go
@@ -49,8 +49,8 @@ func NewNav() *cobra.Command {
 func listAction() action.Pair {
 	return scaffoldlist.NewListAction("list playbooks", "List playbooks available to your user.",
 		types.Playbook{},
-		func(fs *pflag.FlagSet) ([]types.Playbook, error) {
-			resp, err := connection.Client.ListPlaybooks(&types.QueryOptions{AdminMode: connection.AdminMode()})
+		func(fs *pflag.FlagSet, params scaffoldlist.DataParameters) ([]types.Playbook, error) {
+			resp, err := connection.Client.ListPlaybooks(params.QueryOpts)
 			return resp.Results, err
 		},
 		nil,

--- a/gwcli/tree/queries/queries.go
+++ b/gwcli/tree/queries/queries.go
@@ -153,7 +153,7 @@ func info() action.Pair {
 			},
 			DefaultColumns: []string{"ID", "UID"},
 			ValidateArgs: func(fs *pflag.FlagSet) (invalid string, err error) {
-				if fs.NArg() > 1 {
+				if fs.NArg() < 1 {
 					return phrases.AtLeast1ArgRequired("query IDs"), nil
 				}
 				SIDs = []types.SearchInfo{}
@@ -232,6 +232,7 @@ func importAction() action.Pair {
 			if err != nil {
 				return 0, "", err
 			}
+			defer clilog.CloseFile(f)
 			return 0, "", connection.Client.ImportSearch(f, 0)
 
 		},

--- a/gwcli/tree/queries/queries.go
+++ b/gwcli/tree/queries/queries.go
@@ -51,24 +51,11 @@ func NewNav() *cobra.Command {
 // #region past queries
 
 func past() action.Pair {
-	const (
-		pastUse string = "past"
-		short   string = "display search history"
-		long    string = "display past searches made by your user"
-	)
-
 	return scaffoldlist.NewListAction(
-		short, long,
+		"display search history", "display past searches made by your user",
 		types.SearchHistoryEntry{},
-		func(fs *pflag.FlagSet) ([]types.SearchHistoryEntry, error) {
-			opts := &types.QueryOptions{}
-			if count, err := fs.GetInt("count"); err != nil {
-				clilog.GetFlag(err)
-			} else if count > 0 {
-				opts.Limit = count
-			}
-
-			resp, err := connection.Client.ListSearchHistory(opts)
+		func(fs *pflag.FlagSet, params scaffoldlist.DataParameters) ([]types.SearchHistoryEntry, error) {
+			resp, err := connection.Client.ListSearchHistory(params.QueryOpts)
 			if err != nil {
 				// check for explicit no records error
 				if strings.Contains(err.Error(), "No record") {
@@ -81,7 +68,7 @@ func past() action.Pair {
 		},
 		nil,
 		scaffoldlist.Options{
-			CommonOptions: scaffold.CommonOptions{Use: pastUse, AddtlFlags: flags},
+			CommonOptions: scaffold.CommonOptions{Use: "past"},
 			DefaultColumns: []string{
 				"CommonFields.ID",
 				"EffectiveQuery",

--- a/gwcli/tree/queries/queries.go
+++ b/gwcli/tree/queries/queries.go
@@ -13,38 +13,52 @@ All query creation is done at the top-level query action.
 package queries
 
 import (
+	"fmt"
+	"os"
 	"strings"
+	"time"
 
 	"github.com/gravwell/gravwell/v4/client/types"
 	"github.com/gravwell/gravwell/v4/gwcli/action"
+	"github.com/gravwell/gravwell/v4/gwcli/bubbles/multiselectlist"
 	"github.com/gravwell/gravwell/v4/gwcli/clilog"
 	"github.com/gravwell/gravwell/v4/gwcli/connection"
+	"github.com/gravwell/gravwell/v4/gwcli/internal/listitem"
+	"github.com/gravwell/gravwell/v4/gwcli/stylesheet"
+	ft "github.com/gravwell/gravwell/v4/gwcli/stylesheet/flagtext"
+	"github.com/gravwell/gravwell/v4/gwcli/stylesheet/phrases"
 	"github.com/gravwell/gravwell/v4/gwcli/tree/queries/attach"
 	"github.com/gravwell/gravwell/v4/gwcli/tree/queries/saved"
 	"github.com/gravwell/gravwell/v4/gwcli/tree/queries/scheduled"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold"
+	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldcreate"
+	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffolddelete"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldlist"
+	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldselect"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/treeutils"
+	"github.com/gravwell/gravwell/v4/gwcli/utilities/uniques"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
-const (
-	use   string = "queries"
-	short string = "manage existing and past queries"
-	long  string = "Queries contains utilities for managing auxiliary query actions." +
-		"Query creation is handled by the top-level `query` action."
-)
-
-var aliases []string = []string{"searches"}
-
 func NewNav() *cobra.Command {
-	return treeutils.GenerateNav(use, short, long, aliases,
+	return treeutils.GenerateNav("searches", "manage existing and past searches",
+		"Manage active, past, saved, and scheduled queries.\n"+
+			"You can issue new searches using the top-level "+stylesheet.Cur.Action.Render("query")+" action.",
+		[]string{"queries"},
 		[]*cobra.Command{scheduled.NewScheduledNav(), saved.NewSavedNav()},
 		[]action.Pair{
 			past(),
 			attach.NewAttachAction(),
+			info(),
+			listAction(),
+			stop(),
+			importAction(),
+			save(),
+			background(),
+			delete(),
+			setGroup(),
 		})
 }
 
@@ -77,9 +91,283 @@ func past() action.Pair {
 		})
 }
 
-func flags() *pflag.FlagSet {
-	addtlFlags := pflag.FlagSet{}
-	addtlFlags.Int("count", 0, "the number of past searches to display.\n"+
-		"If negative or 0, fetches entire history")
-	return &addtlFlags
+// if details, uses ListSearchDetails to return ALL data relevant to a search.
+//
+// TODO install omit
+func fetchActiveSearchesForMSL(details bool) ([]multiselectlist.SelectableItem[string], error) {
+	if details {
+		lsd, err := connection.Client.ListSearchDetails()
+		if err != nil {
+			return nil, err
+		}
+		items := make([]multiselectlist.SelectableItem[string], len(lsd))
+		for i, s := range lsd {
+			var secondLine strings.Builder
+			if s.Error != "" {
+				secondLine.WriteString("error: ")
+				secondLine.WriteString(stylesheet.Cur.ErrorText.Render(s.Error))
+			} else {
+				fmt.Fprintf(&secondLine, "duration: %s | item count: %v", s.Duration, s.ItemCount)
+			}
+			items[i] = &listitem.Generic{
+				ID_:        s.ID,
+				Name:       s.UserQuery,
+				SecondLine: secondLine.String(),
+			}
+		}
+		return items, nil
+	}
+	searches, err := connection.Client.ListSearchStatuses()
+	if err != nil {
+		return nil, err
+	}
+	data := make([]multiselectlist.SelectableItem[string], len(searches))
+	for i, s := range searches {
+		var secondLine strings.Builder
+		secondLine.WriteString(s.State.String())
+		secondLine.WriteString(" ")
+		if s.Error != "" {
+			secondLine.WriteString(stylesheet.Cur.ErrorText.Render(s.Error))
+		} else {
+			fmt.Fprintf(&secondLine, "(started: %v) progress: %v", s.LaunchInfo.Started, s.State.Progress)
+		}
+		data[i] = &listitem.Generic{
+			ID_:        s.ID,
+			Name:       s.UserQuery,
+			SecondLine: secondLine.String(),
+		}
+	}
+	return data, nil
+}
+
+func info() action.Pair {
+	var SIDs []types.SearchInfo // clobbered and set in validate
+	return scaffoldlist.NewListAction("request info for a given query", "Request information about an active query",
+		types.SearchInfo{}, func(addtlFlags *pflag.FlagSet, params scaffoldlist.DataParameters) ([]types.SearchInfo, error) {
+			return SIDs, nil
+		},
+		nil,
+		scaffoldlist.Options{
+			CommonOptions: scaffold.CommonOptions{
+				Use: "info",
+			},
+			DefaultColumns: []string{"ID", "UID"},
+			ValidateArgs: func(fs *pflag.FlagSet) (invalid string, err error) {
+				if fs.NArg() > 1 {
+					return phrases.AtLeast1ArgRequired("query IDs"), nil
+				}
+				SIDs = []types.SearchInfo{}
+				for _, ID := range fs.Args() {
+					si, err := connection.Client.SearchInfo(ID)
+					if phrases.IsNotFoundErr(err) {
+						return phrases.ErrUnknownSID(ID).Error(), nil
+					} else if err != nil {
+						return "", err
+					}
+					SIDs = append(SIDs, si)
+				}
+				return "", nil
+			},
+		})
+}
+
+func listAction() action.Pair {
+	return scaffoldlist.NewListAction("list active queries", "List all current queries.",
+		types.SearchCtrlStatus{},
+		func(addtlFlags *pflag.FlagSet, params scaffoldlist.DataParameters) ([]types.SearchCtrlStatus, error) {
+			if params.QueryOpts.AdminMode {
+				return connection.Client.ListAllSearchStatuses()
+			}
+			return connection.Client.ListSearchStatuses()
+		},
+		nil,
+		scaffoldlist.Options{
+			Omit: scaffold.OmitFlags{
+				AllData:        false,
+				IncludeDeleted: true,
+				Limit:          true,
+			},
+		})
+}
+
+func stop() action.Pair {
+	return scaffoldselect.NewSelectAction("stop an active query", "Stop a running query without deleting it entirely.", "search ID",
+		func(addtlFlags *pflag.FlagSet) ([]multiselectlist.SelectableItem[string], error) {
+			return fetchActiveSearchesForMSL(false)
+		},
+		func(IDs []string, _ *pflag.FlagSet) (results []scaffold.Result, _ error) {
+			results = make([]scaffold.Result, len(IDs))
+			for i, ID := range IDs {
+				if err := connection.Client.StopSearch(ID); err != nil {
+					var msg string
+					if phrases.IsNotFoundErr(err) {
+						msg = "there are no running searches with the ID: " + ID
+					} else {
+						msg = fmt.Sprintf("failed to stop search %s: %v", ID, err)
+					}
+					results[i] = scaffold.Result{Success: false, Output: msg}
+				} else {
+					results[i] = scaffold.Result{Success: true, Output: "stopped search " + ID}
+				}
+			}
+			return results, nil
+		},
+		scaffoldselect.Options{
+			CommonOptions: scaffold.CommonOptions{
+				Use: "stop",
+			},
+			NoItemsError: func(fs *pflag.FlagSet) string { return "There are no running queries (that you can access)" }},
+	)
+
+}
+
+func importAction() action.Pair {
+	return scaffoldcreate.NewCreateAction("archived search",
+		map[string]scaffoldcreate.Field{
+			"path": scaffoldcreate.FieldPath("archived search", true),
+		},
+		func(fields map[string]scaffoldcreate.Field, fs *pflag.FlagSet) (id any, invalid string, err error) {
+			pth := fields["path"].Provider.Get()
+			f, err := os.Open(pth)
+			if err != nil {
+				return 0, "", err
+			}
+			return 0, "", connection.Client.ImportSearch(f, 0)
+
+		},
+		scaffoldcreate.Options{CommonOptions: scaffold.CommonOptions{Use: "import"}})
+}
+
+func save() action.Pair {
+	return scaffoldselect.NewSelectAction("save a search",
+		"Request that a search be saved and optionally modify the expiration or add a name and notes.\n"+
+			"Saving a search will keep the results around until you explicitly delete them.",
+		"search ID",
+		func(_ *pflag.FlagSet) ([]multiselectlist.SelectableItem[string], error) {
+			return fetchActiveSearchesForMSL(false)
+		},
+		func(IDs []string, addtlFlags *pflag.FlagSet) (results []scaffold.Result, _ error) {
+
+			name, err := addtlFlags.GetString(ft.Name.Name())
+			clilog.GetFlag(err)
+			notes, err := addtlFlags.GetString("notes")
+			clilog.GetFlag(err)
+
+			ssp := types.SaveSearchPatch{
+				Name:  name,
+				Notes: notes,
+			}
+			if expire, err := addtlFlags.GetTime("expire"); err != nil {
+				clilog.GetFlag(err)
+			} else if !expire.IsZero() {
+				ssp.Expires = expire
+			}
+			results = make([]scaffold.Result, len(IDs))
+			for i, ID := range IDs {
+				if err := connection.Client.SaveSearch(ID, ssp); err != nil {
+					results[i] = scaffold.Result{Success: false, Output: fmt.Sprintf("failed to save search %s: %v", ID, err)}
+				} else {
+					results[i] = scaffold.Result{Success: true, Output: "saved search " + ID}
+				}
+			}
+			return results, nil
+		},
+		scaffoldselect.Options{
+			CommonOptions: scaffold.CommonOptions{
+				Use: "save",
+				AddtlFlags: func() *pflag.FlagSet {
+					fs := &pflag.FlagSet{}
+					fs.String(ft.Name.Name(), "", "name the newly saved search")
+					fs.String("notes", "", "attach extra information to the saved search")
+					fs.Time("expire", time.Time{}, []string{uniques.SearchTimeFormat}, "override the expiration time of the this search")
+					return fs
+				},
+			},
+		},
+	)
+}
+
+func background() action.Pair {
+	return scaffoldselect.NewSelectAction("background a search",
+		"Background the specified search such that it can continue running without any connected clients.\n"+
+			"Note that backgrounded searches do not persist across webserver restarts;"+
+			"to keep results around permanently, use the “Save results” option.\n"+
+			"Unsaved background queries are automatically deleted after 7 days. Save your search to preserve results permanently.\n"+
+			"\n"+
+			"Use `queries attach` to foreground a search.",
+		"search ID",
+		func(addtlFlags *pflag.FlagSet) ([]multiselectlist.SelectableItem[string], error) {
+			return fetchActiveSearchesForMSL(false)
+		},
+		func(IDs []string, addtlFlags *pflag.FlagSet) (results []scaffold.Result, _ error) {
+			results = make([]scaffold.Result, len(IDs))
+			for i, ID := range IDs {
+				if err := connection.Client.BackgroundSearch(ID); err != nil {
+					results[i] = scaffold.Result{Success: false, Output: fmt.Sprintf("failed to background search %s: %v", ID, err)}
+				} else {
+					results[i] = scaffold.Result{Success: true, Output: "backgrounded search " + ID}
+				}
+			}
+			return results, nil
+		},
+		scaffoldselect.Options{})
+}
+
+func delete() action.Pair {
+	return scaffolddelete.NewDeleteAction("search ID", "search IDs",
+		func(dryrun bool, ID string) error {
+			if dryrun {
+				_, err := connection.Client.SearchStatus(ID)
+				return err
+			}
+			return connection.Client.DeleteSearch(ID)
+		},
+		func() ([]multiselectlist.SelectableItem[string], error) {
+			return fetchActiveSearchesForMSL(false)
+		},
+		scaffolddelete.Options{})
+}
+
+// TODO this should be converted to a scaffoldcreate with two MSL fields after the scaffoldcreate/edit merge.
+func setGroup() action.Pair {
+	var GIDs []int32 // managed in validate args
+	return scaffoldselect.NewSelectAction("set or wipe the group read permissions of a search",
+		"Modify with groups can read a set of searches. Omitting --groups removes all groups from the selected searches.",
+		"group ID",
+		func(addtlFlags *pflag.FlagSet) ([]multiselectlist.SelectableItem[string], error) {
+			return fetchActiveSearchesForMSL(false)
+		},
+		func(IDs []string, _ *pflag.FlagSet) (results []scaffold.Result, _ error) {
+			results = make([]scaffold.Result, len(IDs))
+			for i, ID := range IDs {
+				if err := connection.Client.SetGroups(ID, GIDs); err != nil {
+					results[i] = scaffold.Result{Success: false, Output: fmt.Sprintf("failed to set groups for search %s: %v", ID, err)}
+				} else if len(GIDs) < 1 {
+					results[i] = scaffold.Result{Success: true, Output: "cleared read groups from search " + ID}
+				} else {
+					results[i] = scaffold.Result{Success: true, Output: fmt.Sprintf("assigned read access for GIDs %v to search %s", GIDs, ID)}
+				}
+			}
+			return results, nil
+		},
+		scaffoldselect.Options{
+			CommonOptions: scaffold.CommonOptions{
+				Use:     "set-groups",
+				Aliases: []string{"set-group"},
+				AddtlFlags: func() *pflag.FlagSet {
+					fs := &pflag.FlagSet{}
+					fs.Int32Slice("groups", nil, "Groups to grant read access to the search. You must have access to the group."+
+						"If you omit this flag, all groups will be removed from the selected searches.")
+					return fs
+				},
+			},
+			ValidateArgs: func(fs *pflag.FlagSet) (invalid string, err error) {
+				// check they we have at least one search and at least one group
+				GIDs, err = fs.GetInt32Slice("groups")
+				clilog.GetFlag(err)
+
+				return "", nil
+			},
+		},
+	)
 }

--- a/gwcli/tree/queries/saved/saved.go
+++ b/gwcli/tree/queries/saved/saved.go
@@ -16,10 +16,8 @@ import (
 	"github.com/gravwell/gravwell/v4/client/types"
 	"github.com/gravwell/gravwell/v4/gwcli/action"
 	"github.com/gravwell/gravwell/v4/gwcli/bubbles/multiselectlist"
-	"github.com/gravwell/gravwell/v4/gwcli/clilog"
 	"github.com/gravwell/gravwell/v4/gwcli/connection"
 	"github.com/gravwell/gravwell/v4/gwcli/internal/listitem"
-	ft "github.com/gravwell/gravwell/v4/gwcli/stylesheet/flagtext"
 	"github.com/gravwell/gravwell/v4/gwcli/stylesheet/phrases"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldcreate"
@@ -49,33 +47,15 @@ func NewSavedNav() *cobra.Command {
 
 func list() action.Pair {
 	return scaffoldlist.NewListAction("list your saved queries", "lists all saved queries associated to your user",
-		types.SavedQuery{}, func(fs *pflag.FlagSet) ([]types.SavedQuery, error) {
-			if all, err := fs.GetBool("all"); err != nil {
-				return nil, clilog.GetFlag(err)
-			} else if all {
-				r, err := connection.Client.ListAllSavedQueries(nil)
-				if err != nil {
-					return nil, err
-				}
-				return r.Results, nil
-			}
-			r, err := connection.Client.ListSavedQueries(nil)
-			if err != nil {
-				return nil, err
-			}
-			return r.Results, nil
+		types.SavedQuery{}, func(fs *pflag.FlagSet, param scaffoldlist.DataParameters) ([]types.SavedQuery, error) {
+			r, err := connection.Client.ListSavedQueries(param.QueryOpts)
+			return r.Results, err
 		},
 		nil,
 		scaffoldlist.Options{
-			CommonOptions:  scaffold.CommonOptions{AddtlFlags: flags},
+			CommonOptions:  scaffold.CommonOptions{},
 			DefaultColumns: []string{"CommonFields.ID", "CommonFields.Name", "CommonFields.Description", "Query"},
 		})
-}
-
-func flags() *pflag.FlagSet {
-	addtlFlags := &pflag.FlagSet{}
-	ft.GetAll.Register(addtlFlags, true, "saved queries", "")
-	return addtlFlags
 }
 
 //#endregion list

--- a/gwcli/tree/queries/scheduled/scheduled.go
+++ b/gwcli/tree/queries/scheduled/scheduled.go
@@ -10,7 +10,10 @@
 package scheduled
 
 import (
+	"errors"
 	"fmt"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -28,6 +31,7 @@ import (
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffolddelete"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldedit"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldlist"
+	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldselect"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/treeutils"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/validate"
 
@@ -43,6 +47,10 @@ func NewScheduledNav() *cobra.Command {
 			listAction(),
 			delete(),
 			edit(),
+			cancel(),
+			backfillToggle(),
+			clear(),
+			createScript(),
 		})
 }
 
@@ -263,21 +271,259 @@ func edit() action.Pair {
 
 			return "", nil
 
-		},
-		GetTitleSub: func(item types.ScheduledSearch) string {
-			return fmt.Sprintf("%s (executes '%s')", item.Name, item.SearchString)
-		},
-		GetDescriptionSub: func(item types.ScheduledSearch) string {
-			return fmt.Sprintf("(%s) %s", item.Schedule, item.Description)
-		},
-		UpdateSub: func(data *types.ScheduledSearch) (identifier string, err error) {
-			return data.Name, connection.Client.UpdateScheduledSearch(*data)
-		},
+func wrapSS(ss types.ScheduledSearch) *listitem.Generic {
+	line := fmt.Sprintf("[%s] %s", ss.Schedule, ss.SearchString)
+	if ss.Description != "" {
+		line += " - " + ss.Description
 	}
-
-	return scaffoldedit.NewEditAction(singular, "scheduled searches", cfg, funcs)
+	return &listitem.Generic{
+		ID_:          ss.ID,
+		Name:         ss.Name,
+		SecondLine:   line,
+		ShowDisabled: true,
+		Enabled:      !ss.Disabled,
+	}
 }
 
-//#endregion edit
+func getBackfillFlags(fs *pflag.FlagSet) (enable, disable bool, err error) {
+	enable, err = fs.GetBool("enable")
+	if err != nil {
+		clilog.GetFlag(err)
+		return
+	}
+	disable, err = fs.GetBool("disable")
+	if err != nil {
+		clilog.GetFlag(err)
+		return
+	}
+	if enable && disable {
+		return false, false, ft.ErrMutuallyExclusive("enable", "disable")
+	}
+	return
+}
 
-// cancelAction, backfillToggle, setOffset, and clearResults are defined in interactive.go
+func cancel() action.Pair {
+	return scaffoldselect.NewSelectAction("cancel running scheduled searches",
+		"Cancel one or several currently-executing scheduled searches by ID.",
+		"scheduled search",
+		func(_ *pflag.FlagSet) ([]multiselectlist.SelectableItem[string], error) {
+			l, err := connection.Client.ListScheduledSearches(nil)
+			if err != nil {
+				return nil, err
+			}
+			itms := make([]multiselectlist.SelectableItem[string], len(l.Results))
+			for i, ss := range l.Results {
+				itms[i] = wrapSS(ss)
+			}
+			return itms, nil
+		},
+		func(IDs []string, _ *pflag.FlagSet) (results []scaffold.Result, _ error) {
+			results = make([]scaffold.Result, len(IDs))
+			for i, ID := range IDs {
+				if err := connection.Client.CancelScheduledSearch(ID); err != nil {
+					results[i] = scaffold.Result{Success: false, Output: err.Error()}
+				} else {
+					results[i] = scaffold.Result{Success: true, Output: "successfully cancelled scheduled search " + ID}
+				}
+			}
+			return results, nil
+		},
+		scaffoldselect.Options{
+			CommonOptions: scaffold.CommonOptions{Use: "cancel"},
+		})
+}
+
+func backfillToggle() action.Pair {
+	return scaffoldselect.NewSelectAction("toggle scheduled search backfill",
+		"Toggle backfill for one or several scheduled searches.\n"+
+			"Backfill causes the automation to run for missed time periods.\n"+
+			"Use --enable or --disable to set explicitly.",
+		"scheduled search",
+		func(fs *pflag.FlagSet) ([]multiselectlist.SelectableItem[string], error) {
+			enable, disable, err := getBackfillFlags(fs)
+			if err != nil {
+				return nil, err
+			}
+			l, err := connection.Client.ListScheduledSearches(nil)
+			if err != nil {
+				return nil, err
+			}
+			itms := make([]multiselectlist.SelectableItem[string], len(l.Results))
+			for i, ss := range l.Results {
+				if enable && ss.BackfillEnabled {
+					continue
+				} else if disable && !ss.BackfillEnabled {
+					continue
+				}
+
+				itms[i] = wrapSS(ss)
+			}
+
+			return itms, nil
+		},
+		func(IDs []string, fs *pflag.FlagSet) (results []scaffold.Result, _ error) {
+			enable, disable, err := getBackfillFlags(fs)
+			if err != nil {
+				return nil, err
+			}
+
+			results = make([]scaffold.Result, len(IDs))
+			for i, ID := range IDs {
+				ss, err := connection.Client.GetScheduledSearch(ID)
+				if err != nil {
+					results[i] = scaffold.Result{Success: false, Output: err.Error()}
+					continue
+				}
+				ss.BackfillEnabled = !ss.BackfillEnabled
+				if enable {
+					ss.BackfillEnabled = true
+				} else if disable {
+					ss.BackfillEnabled = false
+				}
+
+				if err := connection.Client.UpdateScheduledSearch(ss); err != nil {
+					results[i] = scaffold.Result{Success: false, Output: err.Error()}
+				} else {
+					state := "enabled"
+					if !ss.BackfillEnabled {
+						state = "disabled"
+					}
+					results[i] = scaffold.Result{Success: true, Output: fmt.Sprintf("scheduled search '%s' backfill %s", ID, state)}
+				}
+			}
+			return results, nil
+		},
+		scaffoldselect.Options{
+			CommonOptions: scaffold.CommonOptions{
+				Use: "backfill",
+				AddtlFlags: func() *pflag.FlagSet {
+					fs := &pflag.FlagSet{}
+					fs.Bool("enable", false, "enable backfill")
+					fs.Bool("disable", false, "disable backfill")
+					return fs
+				},
+			},
+			ValidateArgs: func(fs *pflag.FlagSet) (invalid string, err error) {
+				_, _, err = getBackfillFlags(fs)
+				return "", err
+			},
+		})
+}
+
+func clear() action.Pair {
+	return scaffoldselect.NewSelectAction("clear results for scheduled searches",
+		"Clear the execution results (including errors and state) for one or several scheduled searches.",
+		"scheduled search",
+		func(_ *pflag.FlagSet) ([]multiselectlist.SelectableItem[string], error) {
+			l, err := connection.Client.ListScheduledSearches(nil)
+			if err != nil {
+				return nil, err
+			}
+			itms := make([]multiselectlist.SelectableItem[string], len(l.Results))
+			for i, ss := range l.Results {
+				itms[i] = wrapSS(ss)
+			}
+			return itms, nil
+		},
+		func(IDs []string, _ *pflag.FlagSet) (results []scaffold.Result, _ error) {
+			results = make([]scaffold.Result, len(IDs))
+			for i, ID := range IDs {
+				if err := connection.Client.ClearScheduledSearchResults(ID); err != nil {
+					results[i] = scaffold.Result{Success: false, Output: err.Error()}
+				} else {
+					results[i] = scaffold.Result{Success: true, Output: fmt.Sprintf("successfully cleared results for scheduled search %s", ID)}
+				}
+			}
+			return results, nil
+		},
+		scaffoldselect.Options{
+			CommonOptions: scaffold.CommonOptions{Use: "clear"},
+		})
+}
+
+func createScript() action.Pair {
+	return scaffoldcreate.NewCreateAction("scheduled script",
+		map[string]scaffoldcreate.Field{
+			"lang": scaffoldcreate.Field{
+				Title:    "Language",
+				Required: true,
+				Flag: scaffoldcreate.FlagConfig{
+					Name: "language",
+					Usage: "Set the language the script is written in." +
+						"Possible values: 'go', 'anko'.",
+				},
+				DefaultValue: "anko",
+				Order:        200,
+				Provider: &scaffoldcreate.TextProvider{
+					CustomInit: func() textinput.Model {
+						ti := stylesheet.NewTI("anko", false)
+						ti.Validate = func(s string) error {
+							_, err := types.ParseScriptLang(s)
+							return err
+						}
+						return ti
+					},
+				},
+			},
+			"name":        scaffoldcreate.FieldName("scheduled script"),
+			"description": scaffoldcreate.FieldDescription("scheduled script"),
+			"path":        scaffoldcreate.FieldPath("script", true),
+			"schedule":    scaffoldcreate.FieldFrequency(),
+			"enabled": {
+				Title: "Enabled?", Required: false,
+				Flag:     scaffoldcreate.FlagConfig{},
+				Order:    30,
+				Provider: &scaffoldcreate.BoolProvider{},
+			},
+			"backfill": {
+				Title: "Backfill?", Required: false,
+				Flag:     scaffoldcreate.FlagConfig{},
+				Order:    20,
+				Provider: &scaffoldcreate.BoolProvider{},
+			},
+		},
+		func(fields map[string]scaffoldcreate.Field, fs *pflag.FlagSet) (id any, invalid string, err error) {
+			pth := fields["path"].Provider.Get()
+			flowContent, err := os.ReadFile(pth)
+			if err != nil {
+				return 0, "", err
+			}
+
+			enabled, err := strconv.ParseBool(fields["enabled"].Provider.Get())
+			if err != nil {
+				return 0, err.Error(), nil
+			}
+			backfill, err := strconv.ParseBool(fields["backfill"].Provider.Get())
+			if err != nil {
+				return 0, err.Error(), nil
+			}
+
+			lang, err := types.ParseScriptLang(fields["lang"].Provider.Get())
+			if err != nil {
+				return 0, err.Error(), nil
+			}
+
+			new, err := connection.Client.CreateScheduledScript(types.ScheduledScript{
+				CommonFields: types.CommonFields{
+					Name:        fields["name"].Provider.Get(),
+					Description: fields["desc"].Provider.Get(),
+					Labels:      scaffoldcreate.GetLabelsFromField(fields["labels"]),
+				},
+				AutomationCommonFields: types.AutomationCommonFields{
+					Schedule:        fields["schedule"].Provider.Get(),
+					Disabled:        !enabled,
+					BackfillEnabled: backfill,
+				},
+				Script:         string(flowContent),
+				ScriptLanguage: lang,
+			})
+			return new.ID, "", err
+		},
+		scaffoldcreate.Options{
+			CommonOptions: scaffold.CommonOptions{
+				Use:     "script",
+				Aliases: []string{"from-script", "create-script"},
+			},
+		},
+	)
+}

--- a/gwcli/tree/queries/scheduled/scheduled.go
+++ b/gwcli/tree/queries/scheduled/scheduled.go
@@ -88,6 +88,14 @@ func listAction() action.Pair {
 		})
 }
 
+const ( // field keys
+	createNameKey     = "name"
+	createDescKey     = "desc"
+	createFreqKey     = "freq"
+	createQryKey      = "qry"
+	createDurationKey = "dur"
+)
+
 func create() action.Pair {
 	fields := map[string]scaffoldcreate.Field{
 		createQryKey: scaffoldcreate.Field{
@@ -181,95 +189,148 @@ func delete() action.Pair {
 		}, scaffolddelete.Options{})
 }
 
-//#endregion delete
-
-//#region edit
-
-const ( // field keys
-	editNameKey     = "name"
-	editDescKey     = "description"
-	editSearchKey   = "search"
-	editScheduleKey = "schedule"
-)
-
-const singular string = "scheduled search"
-
 func edit() action.Pair {
-	cfg := scaffoldedit.Config{
-		editNameKey: &scaffoldedit.Field{
-			Required: true,
-			Title:    "name",
-			Usage:    ft.Name.Usage(singular),
-			FlagName: ft.Name.Name(),
-			Order:    100,
-		},
-		editDescKey: &scaffoldedit.Field{
-			Required: true,
-			Title:    "description",
-			Usage:    ft.Description.Usage(singular),
-			FlagName: ft.Description.Name(),
-			Order:    80,
-		},
-		editSearchKey: &scaffoldedit.Field{
-			Required: true,
-			Title:    "query",
-			Usage:    "the query executed by this scheduled search",
-			FlagName: "query",
-			Order:    60,
-		},
-		editScheduleKey: &scaffoldedit.Field{
-			Required: true,
-			Title:    "frequency",
-			Usage:    ft.Frequency.Usage(),
-			FlagName: ft.Frequency.Name(),
-			Order:    40,
-			CustomTIFuncInit: func() textinput.Model {
-				ti := stylesheet.NewTI("", false)
-				ti.Placeholder = "* * * * *"
-				ti.Validate = validate.CronRuneValidator
-				return ti
+	return scaffoldedit.NewEditAction("scheduled search", "scheduled searches",
+		scaffoldedit.Config{
+			"name": &scaffoldedit.Field{
+				Required: true,
+				Title:    "Name",
+				Usage:    ft.Name.Usage("scheduled search"),
+				FlagName: ft.Name.Name(),
+				Order:    200,
 			},
+			"description": &scaffoldedit.Field{
+				Required: true,
+				Title:    "Description",
+				Usage:    ft.Description.Usage("scheduled search"),
+				FlagName: ft.Description.Name(),
+				Order:    180,
+			},
+			"search": &scaffoldedit.Field{
+				Required: true,
+				Title:    "Search",
+				Usage:    "the search executed by this scheduled search",
+				FlagName: "search",
+				Order:    160,
+			},
+			"frequency": &scaffoldedit.Field{
+				Required: true,
+				Title:    "Frequency",
+				Usage:    ft.Frequency.Usage(),
+				FlagName: ft.Frequency.Name(),
+				Order:    140,
+				CustomTIFuncInit: func() textinput.Model {
+					ti := stylesheet.NewTI("", false)
+					ti.Placeholder = "* * * * *"
+					ti.Validate = validate.CronRuneValidator
+					return ti
+				},
+			},
+			"duration": &scaffoldedit.Field{
+				Required: true,
+				Title:    "Duration",
+				Usage:    "how many seconds back to pass. Must be negative.",
+				FlagName: "duration",
+				Order:    120,
+				CustomTIFuncInit: func() textinput.Model {
+					ti := stylesheet.NewTI("", false)
+					ti.Validate = func(s string) error {
+						if s == "" {
+							return errors.New("duration is required")
+						}
+						return validate.NegativeNumber(s)
+					}
+					return ti
+				},
+			},
+			"offset": &scaffoldedit.Field{
+				Required: true,
+				Title:    "Offset",
+				Usage:    "how many seconds to offset the search timeframe. Must be negative.",
+				FlagName: "offset",
+				Order:    100,
+				CustomTIFuncInit: func() textinput.Model {
+					ti := stylesheet.NewTI("", false)
+					ti.Validate = func(s string) error {
+						if s == "" {
+							return errors.New("offset is required")
+						}
+						return validate.NegativeNumber(s)
+					}
+					return ti
+				},
+			},
+			// TODO introduce SearchSinceLastRun bool after the scaffoldcreate/edit merge
+			// TODO introduce enabled after the scaffoldcreate/edit merge
+			// TODO introduce backfill after the scaffoldcreate/edit merge
 		},
-	}
+		scaffoldedit.SubroutineSet[string, types.ScheduledSearch]{
+			// GetScheduledSearch can take an int32 or uuid
+			SelectSub: func(id string) (item types.ScheduledSearch, err error) {
+				return connection.Client.GetScheduledSearch(id)
+			},
+			FetchSub: func() (items []types.ScheduledSearch, err error) {
+				list, err := connection.Client.ListScheduledSearches(nil)
+				return list.Results, err
+			},
+			GetFieldSub: func(item types.ScheduledSearch, fieldKey string) (value string, err error) {
+				switch fieldKey {
+				case "name":
+					return item.Name, nil
+				case "description":
+					return item.Description, nil
+				case "search":
+					return item.SearchString, nil
+				case "frequency":
+					return item.Schedule, nil
+				case "duration":
+					return strconv.FormatInt(item.Duration, 10), nil
+				case "offset":
+					return strconv.FormatInt(item.TimeframeOffset, 10), nil
+				}
 
-	funcs := scaffoldedit.SubroutineSet[string, types.ScheduledSearch]{
-		// GetScheduledSearch can take an int32 or uuid
-		SelectSub: func(id string) (item types.ScheduledSearch, err error) {
-			return connection.Client.GetScheduledSearch(id)
-		},
-		FetchSub: func() (items []types.ScheduledSearch, err error) {
-			list, err := connection.Client.ListScheduledSearches(nil)
-			return list.Results, err
-		},
-		GetFieldSub: func(item types.ScheduledSearch, fieldKey string) (value string, err error) {
-			switch fieldKey {
-			case editNameKey:
-				return item.Name, nil
-			case editDescKey:
-				return item.Description, nil
-			case editSearchKey:
-				return item.SearchString, nil
-			case editScheduleKey:
-				return item.Schedule, nil
-			}
+				return "", fmt.Errorf("unknown get field key: %v", fieldKey)
+			},
+			SetFieldSub: func(item *types.ScheduledSearch, fieldKey, val string) (invalid string, err error) {
+				switch fieldKey {
+				case "name":
+					item.Name = val
+				case "description":
+					item.Description = val
+				case "search":
+					item.SearchString = val
+				case "frequency":
+					item.Schedule = val
+				case "duration":
+					dur, err := strconv.ParseInt(val, 10, 64)
+					if err != nil {
+						return err.Error(), nil
+					}
+					item.Duration = dur
+				case "offset":
+					offset, err := strconv.ParseInt(val, 10, 64)
+					if err != nil {
+						return err.Error(), nil
+					}
+					item.TimeframeOffset = offset
+				default:
+					return "", fmt.Errorf("unknown set field key: %v", fieldKey)
+				}
 
-			return "", fmt.Errorf("unknown get field key: %v", fieldKey)
-		},
-		SetFieldSub: func(item *types.ScheduledSearch, fieldKey, val string) (invalid string, err error) {
-			switch fieldKey {
-			case editNameKey:
-				item.Name = val
-			case editDescKey:
-				item.Description = val
-			case editSearchKey:
-				item.SearchString = val
-			case editScheduleKey:
-				item.Schedule = val
-			default:
-				return "", fmt.Errorf("unknown set field key: %v", fieldKey)
-			}
+				return "", nil
 
-			return "", nil
+			},
+			GetTitleSub: func(item types.ScheduledSearch) string {
+				return fmt.Sprintf("%s (executes '%s')", item.Name, item.SearchString)
+			},
+			GetDescriptionSub: func(item types.ScheduledSearch) string {
+				return fmt.Sprintf("(%s) %s", item.Schedule, item.Description)
+			},
+			UpdateSub: func(data *types.ScheduledSearch) (identifier string, err error) {
+				return data.Name, connection.Client.UpdateScheduledSearch(*data)
+			},
+		})
+}
 
 func wrapSS(ss types.ScheduledSearch) *listitem.Generic {
 	line := fmt.Sprintf("[%s] %s", ss.Schedule, ss.SearchString)

--- a/gwcli/tree/queries/scheduled/scheduled.go
+++ b/gwcli/tree/queries/scheduled/scheduled.go
@@ -40,24 +40,35 @@ func NewScheduledNav() *cobra.Command {
 		[]*cobra.Command{},
 		[]action.Pair{
 			create(),
-			list(),
+			listAction(),
 			delete(),
 			edit(),
 		})
 }
 
-//#region list
-
-func list() action.Pair {
-	var (
-		short = "list scheduled queries"
-		long  = "prints out all scheduled queries."
-	)
-	return scaffoldlist.NewListAction(short, long,
-		types.ScheduledSearch{}, listScheduledSearch,
+// also serves as GET
+func listAction() action.Pair {
+	return scaffoldlist.NewListAction(
+		"list scheduled queries",
+		"Lists information about scheduled searches you can access.",
+		types.ScheduledSearch{},
+		func(fs *pflag.FlagSet, params scaffoldlist.DataParameters) ([]types.ScheduledSearch, error) {
+			if id, err := fs.GetString("id"); err != nil {
+				clilog.GetFlag(err)
+			} else if id != "" {
+				ss, err := connection.Client.GetScheduledSearchEx(id, params.QueryOpts)
+				return []types.ScheduledSearch{ss}, err
+			}
+			list, err := connection.Client.ListScheduledSearches(params.QueryOpts)
+			return list.Results, err
+		},
 		nil,
 		scaffoldlist.Options{
-			CommonOptions: scaffold.CommonOptions{AddtlFlags: flags},
+			CommonOptions: scaffold.CommonOptions{AddtlFlags: func() *pflag.FlagSet {
+				fs := pflag.FlagSet{}
+				fs.String("id", "", "fetches the scheduled search associated to the given id.")
+				return &fs
+			}},
 			DefaultColumns: []string{
 				"CommonFields.ID",
 				"CommonFields.Name",
@@ -69,46 +80,6 @@ func list() action.Pair {
 		})
 }
 
-func flags() *pflag.FlagSet {
-	addtlFlags := pflag.FlagSet{}
-	addtlFlags.Bool("all", false, "ADMIN ONLY. Lists all schedule searches on the system.\n"+
-		"Supersedes --id.")
-	addtlFlags.String("id", "", "fetches the scheduled search associated to the given id."+
-		"This id can be a standard, numeric ID or a uuid.")
-
-	return &addtlFlags
-}
-
-func listScheduledSearch(fs *pflag.FlagSet) ([]types.ScheduledSearch, error) {
-	if all, err := fs.GetBool("all"); err != nil {
-		clilog.GetFlag(err)
-	} else if all {
-		list, err := connection.Client.ListAllScheduledSearches(nil)
-		return list.Results, err
-	}
-	if id, err := fs.GetString("id"); err != nil {
-		clilog.GetFlag(err)
-	} else if id != "" {
-		ss, err := connection.Client.GetScheduledSearch(id)
-		return []types.ScheduledSearch{ss}, err
-	}
-	list, err := connection.Client.ListScheduledSearches(nil)
-	return list.Results, err
-}
-
-//#endregion list
-
-//#region create
-
-const ( // field keys
-	createNameKey     = "name"
-	createDescKey     = "desc"
-	createFreqKey     = "freq"
-	createQryKey      = "qry"
-	createDurationKey = "dur"
-)
-
-// create creates the action for creating new scheduled queries.
 func create() action.Pair {
 	fields := map[string]scaffoldcreate.Field{
 		createQryKey: scaffoldcreate.Field{

--- a/gwcli/tree/queries/scheduled/scheduled.go
+++ b/gwcli/tree/queries/scheduled/scheduled.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"time"
 
@@ -409,18 +410,18 @@ func backfillToggle() action.Pair {
 			if err != nil {
 				return nil, err
 			}
-			itms := make([]multiselectlist.SelectableItem[string], len(l.Results))
-			for i, ss := range l.Results {
+			itms := make([]multiselectlist.SelectableItem[string], 0, len(l.Results))
+			for _, ss := range l.Results {
 				if enable && ss.BackfillEnabled {
 					continue
 				} else if disable && !ss.BackfillEnabled {
 					continue
 				}
 
-				itms[i] = wrapSS(ss)
+				itms = append(itms, wrapSS(ss))
 			}
 
-			return itms, nil
+			return slices.Clip(itms), nil
 		},
 		func(IDs []string, fs *pflag.FlagSet) (results []scaffold.Result, _ error) {
 			enable, disable, err := getBackfillFlags(fs)

--- a/gwcli/tree/resources/resources.go
+++ b/gwcli/tree/resources/resources.go
@@ -66,18 +66,8 @@ func list() action.Pair {
 		long  string = "view resources available to your user."
 	)
 	return scaffoldlist.NewListAction(short, long,
-		types.Resource{}, func(fs *pflag.FlagSet) ([]types.Resource, error) {
-			if all, err := fs.GetBool("all"); err != nil {
-				clilog.GetFlag(err)
-			} else if all {
-				resp, err := connection.Client.ListAllResources(nil)
-				if err != nil {
-					return nil, err
-				}
-				return resp.Results, nil
-			}
-
-			resp, err := connection.Client.ListResources(nil)
+		types.Resource{}, func(fs *pflag.FlagSet, param scaffoldlist.DataParameters) ([]types.Resource, error) {
+			resp, err := connection.Client.ListResources(param.QueryOpts)
 			if err != nil {
 				return nil, err
 			}
@@ -92,14 +82,8 @@ func list() action.Pair {
 				"Size",
 				"ContentType",
 			},
-			CommonOptions: scaffold.CommonOptions{AddtlFlags: flags},
+			CommonOptions: scaffold.CommonOptions{},
 		})
-}
-
-func flags() *pflag.FlagSet {
-	addtlFlags := pflag.FlagSet{}
-	ft.GetAll.Register(&addtlFlags, true, "resources")
-	return &addtlFlags
 }
 
 func download() action.Pair {
@@ -162,7 +146,7 @@ func create() action.Pair {
 	fields := map[string]scaffoldcreate.Field{
 		"name":   scaffoldcreate.FieldName("resource"),
 		"desc":   scaffoldcreate.FieldDescription("resource"),
-		"path":   scaffoldcreate.FieldPath("resource"),
+		"path":   scaffoldcreate.FieldPath("resource", true),
 		"labels": scaffoldcreate.FieldLabels(),
 	}
 

--- a/gwcli/tree/resources/resources.go
+++ b/gwcli/tree/resources/resources.go
@@ -298,6 +298,7 @@ func replace() action.Pair {
 			if err != nil {
 				return nil, err
 			}
+			defer clilog.CloseFile(contentF)
 			ext := filepath.Ext(pth)
 			for i, ID := range IDs {
 				if _, err := contentF.Seek(0, 0); err != nil {

--- a/gwcli/tree/resources/resources.go
+++ b/gwcli/tree/resources/resources.go
@@ -164,16 +164,11 @@ func create() action.Pair {
 				return "", "path must point to a file", nil
 			}
 			// transmute to resource struct
-			var labels []string
-			if lbls := cfg["labels"].Provider.Get(); strings.TrimSpace(lbls) != "" {
-				labels = strings.Split(strings.TrimSpace(lbls), ",")
-			}
-
 			data := types.Resource{
 				CommonFields: types.CommonFields{
 					Name:        cfg["name"].Provider.Get(),
 					Description: cfg["desc"].Provider.Get(),
-					Labels:      labels,
+					Labels:      scaffoldcreate.GetLabelsFromField(cfg["labels"]),
 				},
 			}
 

--- a/gwcli/tree/resources/resources.go
+++ b/gwcli/tree/resources/resources.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	filesystem "io/fs"
 	"os"
+	"path/filepath"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -297,11 +298,12 @@ func replace() action.Pair {
 			if err != nil {
 				return nil, err
 			}
+			ext := filepath.Ext(pth)
 			for i, ID := range IDs {
 				if _, err := contentF.Seek(0, 0); err != nil {
 					clilog.Writer.Warn("failed to rewind file", log.KV("file path", pth), log.KVErr(err))
 				}
-				err := connection.Client.PopulateResourceFromReader(ID, contentF)
+				updated, err := connection.Client.PopulateResourceFromReader(ID, ext, contentF)
 				if err != nil {
 					results[i] = scaffold.Result{
 						Output:  fmt.Sprintf("failed to repopulate resource %s (ID: %s): %v", contentF.Name(), ID, err),
@@ -309,18 +311,11 @@ func replace() action.Pair {
 					}
 					continue
 				}
-				updatedResource, err := connection.Client.GetResourceMetadata(ID)
-				if err != nil {
-					results[i] = scaffold.Result{
-						Output:  fmt.Sprintf("failed to confirm resource update: %v", err),
-						Success: false,
-					}
-				} else {
-					results[i] = scaffold.Result{
-						Output: fmt.Sprintf("replaced file contents of %s (ID: %s). New size: %d",
-							updatedResource.Name, updatedResource.ID, updatedResource.Size),
-						Success: true,
-					}
+
+				results[i] = scaffold.Result{
+					Output: fmt.Sprintf("replaced file contents of %s (ID: %s). New size: %d",
+						updated.Name, updated.ID, updated.Size),
+					Success: true,
 				}
 
 			}

--- a/gwcli/tree/resources/resources.go
+++ b/gwcli/tree/resources/resources.go
@@ -34,7 +34,9 @@ import (
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffolddelete"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldedit"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldlist"
+	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldselect"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/treeutils"
+	"github.com/gravwell/gravwell/v4/ingest/log"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -57,6 +59,7 @@ func NewNav() *cobra.Command {
 			delete(),
 			download(),
 			edit(),
+			replace(),
 		})
 }
 
@@ -282,4 +285,88 @@ func edit() action.Pair {
 			return data.Name, connection.Client.UpdateResourceMetadata(data.ID, *data)
 		},
 	})
+}
+
+func replace() action.Pair {
+	return scaffoldselect.NewSelectAction("replace resource contents",
+		"Populate one or many resources with the contents of a single local file, clobbering any existing data",
+		"resource ID",
+		func(addtlFlags *pflag.FlagSet) ([]multiselectlist.SelectableItem[string], error) {
+			lr, err := connection.Client.ListResources(&types.QueryOptions{AdminMode: connection.AdminMode()})
+			if err != nil {
+				return nil, err
+			}
+			items := make([]multiselectlist.SelectableItem[string], len(lr.Results))
+			for i, f := range lr.Results {
+				items[i] = resourceToGeneric(f, false)
+			}
+			return items, nil
+		},
+		func(IDs []string, addtlFlags *pflag.FlagSet) (results []scaffold.Result, _ error) {
+			results = make([]scaffold.Result, len(IDs))
+			// slurp file
+			pth, _ := addtlFlags.GetString(ft.Path.Name())
+			contentF, err := os.Open(pth)
+			if err != nil {
+				return nil, err
+			}
+			for i, ID := range IDs {
+				if _, err := contentF.Seek(0, 0); err != nil {
+					clilog.Writer.Warn("failed to rewind file", log.KV("file path", pth), log.KVErr(err))
+				}
+				err := connection.Client.PopulateResourceFromReader(ID, contentF)
+				if err != nil {
+					results[i] = scaffold.Result{
+						Output:  fmt.Sprintf("failed to repopulate resource %s (ID: %s): %v", contentF.Name(), ID, err),
+						Success: false,
+					}
+					continue
+				}
+				updatedResource, err := connection.Client.GetResourceMetadata(ID)
+				if err != nil {
+					results[i] = scaffold.Result{
+						Output:  fmt.Sprintf("failed to confirm resource update: %v", err),
+						Success: false,
+					}
+				} else {
+					results[i] = scaffold.Result{
+						Output: fmt.Sprintf("replaced file contents of %s (ID: %s). New size: %d",
+							updatedResource.Name, updatedResource.ID, updatedResource.Size),
+						Success: true,
+					}
+				}
+
+			}
+			return results, nil
+		},
+		scaffoldselect.Options{
+			CommonOptions: scaffold.CommonOptions{
+				Use: "replace",
+				AddtlFlags: func() *pflag.FlagSet {
+					fs := &pflag.FlagSet{}
+					ft.Path.Register(fs, "", "local file to replace the resource contents")
+					return fs
+				},
+			},
+			ValidateArgs: func(fs *pflag.FlagSet) (invalid string, err error) {
+				pth, err := fs.GetString(ft.Path.Name())
+				clilog.GetFlag(err)
+				if pth == "" {
+					return "--path is required", nil
+				}
+				return "", nil
+			},
+			Exactly1: true,
+		})
+}
+
+//#region helpers
+
+func resourceToGeneric(f types.Resource, selected bool) *listitem.Generic {
+	return &listitem.Generic{
+		Selected_:  selected,
+		ID_:        f.ID,
+		Name:       f.Name,
+		SecondLine: fmt.Sprintf("(Size: %v) %s", f.Size, f.Description),
+	}
 }

--- a/gwcli/tree/root.go
+++ b/gwcli/tree/root.go
@@ -17,19 +17,14 @@ package tree
 import (
 	"errors"
 	"fmt"
-	"gravwell/pkg/scripting"
 	"io"
-	"math"
 	"os"
 	"runtime/pprof"
 	"strings"
-	"time"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/crewjam/rfc5424"
 	"github.com/gravwell/gravwell/v4/client"
-	"github.com/gravwell/gravwell/v4/client/types"
 	"github.com/gravwell/gravwell/v4/gwcli/action"
 	"github.com/gravwell/gravwell/v4/gwcli/clilog"
 	"github.com/gravwell/gravwell/v4/gwcli/connection"
@@ -37,7 +32,6 @@ import (
 	"github.com/gravwell/gravwell/v4/gwcli/internal/state"
 	"github.com/gravwell/gravwell/v4/gwcli/stylesheet"
 	ft "github.com/gravwell/gravwell/v4/gwcli/stylesheet/flagtext"
-	"github.com/gravwell/gravwell/v4/gwcli/stylesheet/phrases"
 	"github.com/gravwell/gravwell/v4/gwcli/tree/actionables"
 	"github.com/gravwell/gravwell/v4/gwcli/tree/admin"
 	"github.com/gravwell/gravwell/v4/gwcli/tree/alerts"
@@ -61,7 +55,6 @@ import (
 	"github.com/gravwell/gravwell/v4/gwcli/tree/templates"
 	"github.com/gravwell/gravwell/v4/gwcli/tree/tokens"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/cfgdir"
-	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/treeutils"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/uniques"
 
@@ -307,7 +300,7 @@ func Execute(args []string, stdout, stderr io.Writer) int {
 			query.NewQueryAction(),
 			showTags(),
 			notifications(),
-			executeScript(),
+			//executeScript(),
 		})
 	rootCmd.SilenceUsage = true
 	rootCmd.PersistentPreRunE = ppre
@@ -410,7 +403,9 @@ func Execute(args []string, stdout, stderr io.Writer) int {
 	return 0
 }
 
-func executeScript() action.Pair {
+// TODO This relies on backend libraries that the TUI doesn't have access to as it is in Mono.
+// We will need a decision on how to proceed.
+/*func executeScript() action.Pair {
 	return scaffold.NewBasicAction("script", "execute an anko script", "Run an anko script in a VM on the connected Gravwell system",
 		func(fs *pflag.FlagSet) (output string, addtlCmds tea.Cmd) {
 			network, err := fs.GetBool("network")
@@ -478,4 +473,4 @@ func executeScript() action.Pair {
 				return "", nil
 			},
 		})
-}
+}*/

--- a/gwcli/tree/root.go
+++ b/gwcli/tree/root.go
@@ -17,14 +17,19 @@ package tree
 import (
 	"errors"
 	"fmt"
+	"gravwell/pkg/scripting"
 	"io"
+	"math"
 	"os"
 	"runtime/pprof"
 	"strings"
+	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/crewjam/rfc5424"
 	"github.com/gravwell/gravwell/v4/client"
+	"github.com/gravwell/gravwell/v4/client/types"
 	"github.com/gravwell/gravwell/v4/gwcli/action"
 	"github.com/gravwell/gravwell/v4/gwcli/clilog"
 	"github.com/gravwell/gravwell/v4/gwcli/connection"
@@ -32,9 +37,11 @@ import (
 	"github.com/gravwell/gravwell/v4/gwcli/internal/state"
 	"github.com/gravwell/gravwell/v4/gwcli/stylesheet"
 	ft "github.com/gravwell/gravwell/v4/gwcli/stylesheet/flagtext"
+	"github.com/gravwell/gravwell/v4/gwcli/stylesheet/phrases"
 	"github.com/gravwell/gravwell/v4/gwcli/tree/actionables"
 	"github.com/gravwell/gravwell/v4/gwcli/tree/admin"
 	"github.com/gravwell/gravwell/v4/gwcli/tree/alerts"
+	"github.com/gravwell/gravwell/v4/gwcli/tree/cbac"
 	"github.com/gravwell/gravwell/v4/gwcli/tree/dashboards"
 	"github.com/gravwell/gravwell/v4/gwcli/tree/email"
 	"github.com/gravwell/gravwell/v4/gwcli/tree/extractors"
@@ -54,6 +61,7 @@ import (
 	"github.com/gravwell/gravwell/v4/gwcli/tree/templates"
 	"github.com/gravwell/gravwell/v4/gwcli/tree/tokens"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/cfgdir"
+	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/treeutils"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/uniques"
 
@@ -299,6 +307,7 @@ func Execute(args []string, stdout, stderr io.Writer) int {
 			query.NewQueryAction(),
 			showTags(),
 			notifications(),
+			executeScript(),
 		})
 	rootCmd.SilenceUsage = true
 	rootCmd.PersistentPreRunE = ppre
@@ -352,6 +361,7 @@ func Execute(args []string, stdout, stderr io.Writer) int {
 		actionables.NewNav,
 		admin.NewNav,
 		alerts.NewNav,
+		cbac.NewNav,
 		dashboards.NewNav,
 		email.NewNav,
 		extractors.NewNav,
@@ -398,4 +408,74 @@ func Execute(args []string, stdout, stderr io.Writer) int {
 	}
 
 	return 0
+}
+
+func executeScript() action.Pair {
+	return scaffold.NewBasicAction("script", "execute an anko script", "Run an anko script in a VM on the connected Gravwell system",
+		func(fs *pflag.FlagSet) (output string, addtlCmds tea.Cmd) {
+			network, err := fs.GetBool("network")
+			clilog.GetFlag(err)
+			duration, err := fs.GetDuration("duration")
+			clilog.GetFlag(err)
+			duration = time.Duration(math.Abs(float64(duration)))
+			maxRuntime, err := fs.GetDuration("max-runtime")
+			clilog.GetFlag(err)
+			maxRuntime = time.Duration(math.Abs(float64(maxRuntime)))
+
+			var sb strings.Builder
+			for _, pth := range fs.Args() {
+				body, err := os.ReadFile(pth)
+				if err != nil {
+					fmt.Fprintf(&sb, "failed to read script %v: %v\n", pth, err)
+					continue
+				}
+
+				if line, column, err := connection.Client.ParseScheduledScript(string(body), types.ScriptAnko); err != nil {
+					fmt.Fprintf(&sb, "%v is invalid: L%d:%d %v\n", pth, line, column, err)
+					continue
+				}
+				cfg := scripting.ScriptConfig{
+					SR:             scripting.NewLocalScriptRunner(connection.Client),
+					Language:       types.ScriptAnko,
+					Content:        string(body),
+					DisableNetwork: !network,
+					Debug:          true,
+					Start:          time.Now(),
+					Duration:       duration,
+					MaxRunTime:     maxRuntime,
+				}
+				svm, err := scripting.NewScriptVM(cfg)
+				if err != nil {
+					fmt.Fprintf(&sb, "failed to containerize script %v: %v\n", pth, err)
+					continue
+				}
+				out, err := svm.Run()
+				if err != nil {
+					fmt.Fprintf(&sb, "failed to run script %v: %v\n", pth, err)
+					continue
+				}
+				fmt.Fprintf(&sb, "Script %v executed successfully\n", pth)
+				if len(out) > 0 {
+					fmt.Fprintf(&sb, "_____DEBUG OUTPUT_____\n%s\n______________________\n", string(out))
+				}
+			}
+			return sb.String(), nil
+		},
+		scaffold.BasicOptions{
+			CommonOptions: scaffold.CommonOptions{
+				AddtlFlags: func() *pflag.FlagSet {
+					fs := &pflag.FlagSet{}
+					fs.Bool("network", false, "Enable networking when running the scripts")
+					fs.Duration("duration", time.Minute, "Duration the scripts should execute over from the moment it begins")
+					fs.Duration("max-runtime", 10*time.Minute, "Maximum duration the scripts may execute for")
+					return fs
+				},
+			},
+			ValidateArgs: func(fs *pflag.FlagSet) (invalid string, err error) {
+				if fs.NArg() < 1 {
+					return phrases.AtLeast1ArgRequired("paths/to/anko scripts"), nil
+				}
+				return "", nil
+			},
+		})
 }

--- a/gwcli/tree/secrets/secrets.go
+++ b/gwcli/tree/secrets/secrets.go
@@ -17,10 +17,8 @@ import (
 	"github.com/gravwell/gravwell/v4/client/types"
 	"github.com/gravwell/gravwell/v4/gwcli/action"
 	"github.com/gravwell/gravwell/v4/gwcli/bubbles/multiselectlist"
-	"github.com/gravwell/gravwell/v4/gwcli/clilog"
 	"github.com/gravwell/gravwell/v4/gwcli/connection"
 	"github.com/gravwell/gravwell/v4/gwcli/internal/listitem"
-	ft "github.com/gravwell/gravwell/v4/gwcli/stylesheet/flagtext"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldcreate"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffolddelete"
@@ -57,18 +55,8 @@ func listAction() action.Pair {
 		long  string = "View secrets available to your user."
 	)
 	return scaffoldlist.NewListAction(short, long,
-		types.Secret{}, func(fs *pflag.FlagSet) ([]types.Secret, error) {
-			if all, err := fs.GetBool("all"); err != nil {
-				clilog.GetFlag(err)
-			} else if all {
-				resp, err := connection.Client.ListAllSecrets(nil)
-				if err != nil {
-					return nil, err
-				}
-				return resp.Results, nil
-			}
-
-			resp, err := connection.Client.ListSecrets(nil)
+		types.Secret{}, func(fs *pflag.FlagSet, params scaffoldlist.DataParameters) ([]types.Secret, error) {
+			resp, err := connection.Client.ListSecrets(params.QueryOpts)
 			if err != nil {
 				return nil, err
 			}
@@ -81,14 +69,8 @@ func listAction() action.Pair {
 				"CommonFields.Name",
 				"CommonFields.Description",
 			},
-			CommonOptions: scaffold.CommonOptions{AddtlFlags: flags},
+			CommonOptions: scaffold.CommonOptions{},
 		})
-}
-
-func flags() *pflag.FlagSet {
-	addtlFlags := pflag.FlagSet{}
-	ft.GetAll.Register(&addtlFlags, true, "secrets")
-	return &addtlFlags
 }
 
 func create() action.Pair {
@@ -107,17 +89,11 @@ func create() action.Pair {
 
 	return scaffoldcreate.NewCreateAction("secret", fields,
 		func(cfg map[string]scaffoldcreate.Field, fs *pflag.FlagSet) (id any, invalid string, err error) {
-			// transmute to resource struct
-			var labels []string
-			if lbls := cfg["labels"].Provider.Get(); strings.TrimSpace(lbls) != "" {
-				labels = strings.Split(strings.TrimSpace(lbls), ",")
-			}
-
 			data := types.SecretCreate{
 				CommonFields: types.CommonFields{
 					Name:        cfg["name"].Provider.Get(),
 					Description: cfg["desc"].Provider.Get(),
-					Labels:      labels,
+					Labels:      scaffoldcreate.GetLabelsFromField(cfg["labels"]),
 				},
 				Value: cfg["value"].Provider.Get(),
 			}

--- a/gwcli/tree/secrets/secrets_noci_test.go
+++ b/gwcli/tree/secrets/secrets_noci_test.go
@@ -92,7 +92,7 @@ func TestCreateEditDownload(t *testing.T) {
 	{
 		t.Logf("deleting secret %v", secretID)
 		// execute spins up singletons for us
-		if ec := tree.Execute(append(meta, []string{"secrets", "delete", "--id", secretID}...), nil, &sbErr); ec != 0 {
+		if ec := tree.Execute(append(meta, []string{"secrets", "delete", secretID}...), nil, &sbErr); ec != 0 {
 			t.Fatal("bad error code. STDERR: ", sbErr.String())
 		}
 	}

--- a/gwcli/tree/self/self.go
+++ b/gwcli/tree/self/self.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gravwell/gravwell/v4/gwcli/action"
 	"github.com/gravwell/gravwell/v4/gwcli/clilog"
 	"github.com/gravwell/gravwell/v4/gwcli/connection"
+	"github.com/gravwell/gravwell/v4/gwcli/tree/admin"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldlist"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/treeutils"
@@ -31,81 +32,16 @@ var aliases []string = []string{"me"}
 func NewNav() *cobra.Command {
 	return treeutils.GenerateNav(use, short, long, aliases, nil,
 		[]action.Pair{
-			admin(),
 			MyInfo(),
 			sessions(),
 			groups(),
 			changePassword(),
 			searchGroup(),
 			update(),
+			logoutAll(),
+			admin.Status("admin"),
 		})
 }
-
-//#region admin mode
-
-func admin() action.Pair {
-	const (
-		use   string = "admin"
-		short string = "display or modify your admin status"
-		long  string = "If called bare, admin displays whether or not you are an admin (and thus can enter admin mode).\n" +
-			"Use -t to toggle your admin status, which will attach admin=true to future queries.\n" +
-			"Exercise caution in admin mode, as it gives access to objects belonging to other users and makes it easy to break things.\n" +
-			"Admin mode does not persist between sessions."
-	)
-	return scaffold.NewBasicAction(use, short, long,
-		func(fs *pflag.FlagSet) (string, tea.Cmd) {
-			isAdministrator, err := connection.Client.IsAdmin()
-			if err != nil {
-				return "failed to fetch administrator status: " + err.Error(), nil
-			}
-
-			// branch on toggle flag
-			if t, err := fs.GetBool("toggle"); err != nil {
-				clilog.GetFlag(err)
-			} else if t {
-				return toggle(isAdministrator)
-			}
-
-			// display state
-			inAdminMode := connection.Client.AdminMode()
-			if isAdministrator {
-				var not string
-				if !inAdminMode {
-					not = " not"
-				}
-				return "You are an administrator.\n" + "You are in" + not + " admin mode.", nil
-			}
-			var s = "You are not an administrator."
-			if inAdminMode {
-				s += "\nYet, you are somehow in admin mode.\nYour admin mode flag will be ignored. Please file a bug report."
-			}
-			return s, nil
-		},
-		scaffold.BasicOptions{
-			CommonOptions: scaffold.CommonOptions{
-				AddtlFlags: func() *pflag.FlagSet {
-					fs := &pflag.FlagSet{}
-					fs.BoolP("toggle", "t", false, "toggle your admin status")
-					return fs
-				},
-			},
-		})
-}
-
-func toggle(isAdministrator bool) (string, tea.Cmd) {
-	if !isAdministrator {
-		return "Only administrators can toggle admin mode", nil
-	}
-	if !connection.Client.AdminMode() {
-		connection.Client.SetAdminMode()
-		return "You are now in admin mode", nil
-	}
-	connection.Client.ClearAdminMode()
-	return "You are no longer in admin mode", nil
-
-}
-
-//#endregion admin mode
 
 // wrapper for types.Session to limit the information sessions returns.
 type session struct {
@@ -224,6 +160,23 @@ func groups() action.Pair {
 					fmt.Fprintf(&sb, "%s (ID: %d)\n", grp.Name, grp.ID)
 				}
 				return sb.String()[:sb.Len()-1], nil
+			},
+			Omit: scaffold.OmitFlags{Everything: true},
+		})
+}
+
+func logoutAll() action.Pair {
+	return scaffold.NewBasicAction("logout-all", "logout all sessions", "Terminate all active sessions for your user.",
+		func(fs *pflag.FlagSet) (string, tea.Cmd) {
+			if err := connection.Client.LogoutAll(); err != nil {
+				return err.Error(), nil
+			}
+			connection.End()
+			return "Successfully logged out all sessions", tea.Quit
+		}, scaffold.BasicOptions{
+			CommonOptions: scaffold.CommonOptions{
+				Usage:   "logout-all",
+				Aliases: []string{"boot"},
 			},
 		})
 }

--- a/gwcli/tree/self/self.go
+++ b/gwcli/tree/self/self.go
@@ -126,7 +126,7 @@ func sessions() action.Pair {
 	return scaffoldlist.NewListAction("display your active sessions",
 		"Displays information about how and where you are currently logged in.\n"+
 			"If --since is not set, it will default to fetching all records for the past 48 hours.", session{},
-		func(fs *pflag.FlagSet) ([]session, error) {
+		func(fs *pflag.FlagSet, _ scaffoldlist.DataParameters) ([]session, error) {
 			rawSessions, err := connection.Client.MySessions()
 			if err != nil {
 				return nil, err
@@ -200,18 +200,19 @@ func sessions() action.Pair {
 				}
 				return "", nil
 			},
+			Omit: scaffold.OmitFlags{Everything: true},
 		})
 }
 
 func groups() action.Pair {
 	return scaffoldlist.NewListAction("display your group memberships", "Display groups you are a part of.", types.Group{},
-		func(fs *pflag.FlagSet) ([]types.Group, error) {
+		func(fs *pflag.FlagSet, _ scaffoldlist.DataParameters) ([]types.Group, error) {
 			return connection.Client.Groups()
 		},
 		nil,
 		scaffoldlist.Options{
 			CommonOptions: scaffold.CommonOptions{Use: "groups"},
-			Pretty: func(_ []string, _ map[string]string) (string, error) {
+			Pretty: func(_ *pflag.FlagSet, _ []string, _ map[string]string, _ scaffoldlist.DataParameters) (string, error) {
 				groups, err := connection.Client.Groups()
 				if err != nil {
 					return "", err

--- a/gwcli/tree/systems/indexers/calendar.go
+++ b/gwcli/tree/systems/indexers/calendar.go
@@ -43,7 +43,69 @@ func newCalendarAction() action.Pair {
 	)
 	var aliases = []string{"entries"}
 
-	return scaffoldlist.NewListAction(shortCalendar, longCalendar, types.CalendarEntry{}, data,
+	return scaffoldlist.NewListAction(shortCalendar, longCalendar, types.CalendarEntry{}, func(fs *pflag.FlagSet, _ scaffoldlist.DataParameters) ([]types.CalendarEntry, error) {
+		// all parameters, the globals, are managed by ValidateArgs()
+
+		wells, err := fs.GetStringSlice("wells")
+		if err != nil {
+			return nil, clilog.GetFlag(err)
+		}
+
+		// if an indexer was specified, get stats for that specific indexer
+		if idxrUUID.Valid {
+			clilog.Writer.Debugf("indexer=%v|start=%v|end=%v|given wells=%v", idxrUUID.UUID.String(), start, end, wells)
+
+			// if no wells were given, get all wells associated to this indexer
+			if len(wells) == 0 {
+				wellData, err := connection.Client.WellData()
+				if err != nil {
+					return nil, err
+				}
+				if wellData[idxrName].UUID != idxrUUID.UUID { // sanity check
+					err := fmt.Errorf("derived UUID (%v) does not match UUID of indexer associated to well data by name (%v)", idxrUUID.UUID, wellData[idxrName].UUID)
+					clilog.Writer.Errorf("%v", err)
+					return nil, err
+				}
+				wells = make([]string, len(wellData[idxrName].Wells))
+				for i, w := range wellData[idxrName].Wells {
+					wells[i] = w.ID
+				}
+			}
+
+			return connection.Client.GetIndexerCalendarStats(idxrUUID.UUID, start, end, wells)
+		}
+
+		clilog.Writer.Debugf("start=%v|end=%v|given wells=%v", start, end, wells)
+
+		// if no wells were given, get all wells
+		if len(wells) == 0 {
+			// if no wells were specified, fetch all wells from all indexers
+			wellData, err := connection.Client.WellData()
+			if err != nil {
+				return nil, err
+			}
+			var (
+				set sync.Map // well id -> 1
+				wg  sync.WaitGroup
+			)
+			for _, wd := range wellData {
+				wg.Add(1)
+				go func(data types.IndexerWellData) {
+					defer wg.Done()
+					for _, well := range data.Wells {
+						set.Store(well.ID, 1)
+					}
+				}(wd)
+			}
+			wg.Wait()
+			set.Range(func(key, value any) bool {
+				wells = append(wells, key.(string))
+				return true
+			})
+		}
+
+		return connection.Client.GetCalendarStats(start, end, wells)
+	},
 		nil,
 		scaffoldlist.Options{
 			CommonOptions: scaffold.CommonOptions{
@@ -87,6 +149,7 @@ func newCalendarAction() action.Pair {
 
 				return "", nil
 			},
+			Omit: scaffold.OmitFlags{Everything: true},
 		})
 }
 
@@ -156,69 +219,4 @@ func validateTime(fs *pflag.FlagSet, flagName string) (v time.Time, invalid stri
 		return v, "--" + flagName + " must be a valid date formatted as YYYY-MM-DD", nil
 	}
 	return t, "", nil
-}
-
-// actual fetch function
-func data(fs *pflag.FlagSet) ([]types.CalendarEntry, error) {
-	// all parameters, the globals, are managed by ValidateArgs()
-
-	wells, err := fs.GetStringSlice("wells")
-	if err != nil {
-		return nil, clilog.GetFlag(err)
-	}
-
-	// if an indexer was specified, get stats for that specific indexer
-	if idxrUUID.Valid {
-		clilog.Writer.Debugf("indexer=%v|start=%v|end=%v|given wells=%v", idxrUUID.UUID.String(), start, end, wells)
-
-		// if no wells were given, get all wells associated to this indexer
-		if len(wells) == 0 {
-			wellData, err := connection.Client.WellData()
-			if err != nil {
-				return nil, err
-			}
-			if wellData[idxrName].UUID != idxrUUID.UUID { // sanity check
-				err := fmt.Errorf("derived UUID (%v) does not match UUID of indexer associated to well data by name (%v)", idxrUUID.UUID, wellData[idxrName].UUID)
-				clilog.Writer.Errorf("%v", err)
-				return nil, err
-			}
-			wells = make([]string, len(wellData[idxrName].Wells))
-			for i, w := range wellData[idxrName].Wells {
-				wells[i] = w.ID
-			}
-		}
-
-		return connection.Client.GetIndexerCalendarStats(idxrUUID.UUID, start, end, wells)
-	}
-
-	clilog.Writer.Debugf("start=%v|end=%v|given wells=%v", start, end, wells)
-
-	// if no wells were given, get all wells
-	if len(wells) == 0 {
-		// if no wells were specified, fetch all wells from all indexers
-		wellData, err := connection.Client.WellData()
-		if err != nil {
-			return nil, err
-		}
-		var (
-			set sync.Map // well id -> 1
-			wg  sync.WaitGroup
-		)
-		for _, wd := range wellData {
-			wg.Add(1)
-			go func(data types.IndexerWellData) {
-				defer wg.Done()
-				for _, well := range data.Wells {
-					set.Store(well.ID, 1)
-				}
-			}(wd)
-		}
-		wg.Wait()
-		set.Range(func(key, value any) bool {
-			wells = append(wells, key.(string))
-			return true
-		})
-	}
-
-	return connection.Client.GetCalendarStats(start, end, wells)
 }

--- a/gwcli/tree/systems/indexers/get.go
+++ b/gwcli/tree/systems/indexers/get.go
@@ -29,7 +29,7 @@ func get() action.Pair {
 	)
 
 	return scaffoldlist.NewListAction("get details about a specific indexer", long, deepIndexerInfo{},
-		func(fs *pflag.FlagSet) ([]deepIndexerInfo, error) {
+		func(fs *pflag.FlagSet, _ scaffoldlist.DataParameters) ([]deepIndexerInfo, error) {
 			dii := deepIndexerInfo{Name: strings.TrimSpace(fs.Arg(0))}
 
 			if !dii.fetchByName() {
@@ -68,6 +68,7 @@ func get() action.Pair {
 				}
 				return "", nil
 			},
+			Omit: scaffold.OmitFlags{Everything: true},
 		})
 }
 

--- a/gwcli/tree/systems/indexers/list.go
+++ b/gwcli/tree/systems/indexers/list.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gravwell/gravwell/v4/gwcli/action"
 	"github.com/gravwell/gravwell/v4/gwcli/clilog"
 	"github.com/gravwell/gravwell/v4/gwcli/connection"
+	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldlist"
 	"github.com/spf13/pflag"
 )
@@ -42,7 +43,7 @@ func list() action.Pair {
 	)
 
 	return scaffoldlist.NewListAction(short, long, list_t{},
-		func(fs *pflag.FlagSet) ([]list_t, error) {
+		func(fs *pflag.FlagSet, _ scaffoldlist.DataParameters) ([]list_t, error) {
 			// keep the info in a map by indexer for better looking
 			m := map[string]*list_t{} // name (IP/"webserver") -> info
 
@@ -149,7 +150,9 @@ func list() action.Pair {
 			"Storage.EntryCountHot":    "Hot.Count",
 			"Storage.EntryCountCold":   "Cold.Count",
 		},
-		scaffoldlist.Options{})
+		scaffoldlist.Options{
+			Omit: scaffold.OmitFlags{Everything: true},
+		})
 }
 
 // Inserts the indexer into the map if it does not already exist.

--- a/gwcli/tree/systems/indexers/nav.go
+++ b/gwcli/tree/systems/indexers/nav.go
@@ -60,37 +60,39 @@ func wells() action.Pair {
 		ColdPath    string `json:",omitempty"` //cold storage location
 	}
 
-	return scaffoldlist.NewListAction("get a list of all wells", "returns the indexer each well is associated to and the well's full id", wd{}, func(fs *pflag.FlagSet) ([]wd, error) {
-		wells, err := connection.Client.WellData()
-		if err != nil {
-			return nil, err
-		}
-		toRet := make([]wd, 0)
-		for idxrName, iwd := range wells {
-			for _, well := range iwd.Wells {
-				toRet = append(toRet, wd{
-					Indexer: struct {
-						UUID uuid.UUID
-						Name string
-					}{
-						iwd.UUID,
-						idxrName,
-					},
-					ID:          well.ID,
-					Name:        well.Name,
-					Tags:        well.Tags,
-					Shards:      well.Shards,
-					Accelerator: well.Accelerator,
-					Engine:      well.Engine,
-					Path:        well.Path,
-					ColdPath:    well.ColdPath,
-				})
+	return scaffoldlist.NewListAction("get a list of all wells", "returns the indexer each well is associated to and the well's full id",
+		wd{}, func(fs *pflag.FlagSet, _ scaffoldlist.DataParameters) ([]wd, error) {
+			wells, err := connection.Client.WellData()
+			if err != nil {
+				return nil, err
 			}
+			toRet := make([]wd, 0)
+			for idxrName, iwd := range wells {
+				for _, well := range iwd.Wells {
+					toRet = append(toRet, wd{
+						Indexer: struct {
+							UUID uuid.UUID
+							Name string
+						}{
+							iwd.UUID,
+							idxrName,
+						},
+						ID:          well.ID,
+						Name:        well.Name,
+						Tags:        well.Tags,
+						Shards:      well.Shards,
+						Accelerator: well.Accelerator,
+						Engine:      well.Engine,
+						Path:        well.Path,
+						ColdPath:    well.ColdPath,
+					})
+				}
 
-		}
-		return toRet, nil
-	}, nil, scaffoldlist.Options{
-		CommonOptions:  scaffold.CommonOptions{Use: "wells", Aliases: []string{"well"}},
-		DefaultColumns: []string{"Indexer.UUID", "Indexer.Name", "ID", "Name", "Tags", "Accelerator", "Engine", "Path", "ColdPath"},
-	})
+			}
+			return toRet, nil
+		}, nil, scaffoldlist.Options{
+			CommonOptions:  scaffold.CommonOptions{Use: "wells", Aliases: []string{"well"}},
+			DefaultColumns: []string{"Indexer.UUID", "Indexer.Name", "ID", "Name", "Tags", "Accelerator", "Engine", "Path", "ColdPath"},
+			Omit:           scaffold.OmitFlags{Everything: true},
+		})
 }

--- a/gwcli/tree/systems/ingesters/get.go
+++ b/gwcli/tree/systems/ingesters/get.go
@@ -33,7 +33,7 @@ func get() action.Pair {
 	)
 
 	return scaffoldlist.NewListAction(short, long, wrappedIngesterStats{},
-		func(fs *pflag.FlagSet) ([]wrappedIngesterStats, error) {
+		func(fs *pflag.FlagSet, _ scaffoldlist.DataParameters) ([]wrappedIngesterStats, error) {
 			// check that we were given ingesters to fetch
 			hostPrefix, err := fs.GetString(flagHostname)
 			if err != nil {
@@ -105,6 +105,7 @@ func get() action.Pair {
 				}
 				return "", nil
 			},
+			Omit: scaffold.OmitFlags{Everything: true},
 		})
 }
 

--- a/gwcli/tree/systems/ingesters/list.go
+++ b/gwcli/tree/systems/ingesters/list.go
@@ -3,6 +3,7 @@ package ingesters
 import (
 	"github.com/gravwell/gravwell/v4/gwcli/action"
 	"github.com/gravwell/gravwell/v4/gwcli/connection"
+	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldlist"
 	"github.com/spf13/pflag"
 )
@@ -28,7 +29,7 @@ func list() action.Pair {
 	}
 
 	return scaffoldlist.NewListAction(short, long, wrappedIngesterStats{},
-		func(fs *pflag.FlagSet) ([]wrappedIngesterStats, error) {
+		func(fs *pflag.FlagSet, _ scaffoldlist.DataParameters) ([]wrappedIngesterStats, error) {
 			// GetIngesterStats returns data according to each indexer.
 			// We extract just the ingester stats sub items.
 			// The rest of the stats are inside of the indexer-specific actions.
@@ -55,5 +56,7 @@ func list() action.Pair {
 				}
 			}
 			return wrap, nil
-		}, nil, scaffoldlist.Options{})
+		}, nil, scaffoldlist.Options{
+			Omit: scaffold.OmitFlags{Everything: true},
+		})
 }

--- a/gwcli/tree/systems/ingesters/nav.go
+++ b/gwcli/tree/systems/ingesters/nav.go
@@ -11,8 +11,12 @@ package ingesters
 
 import (
 	"github.com/gravwell/gravwell/v4/gwcli/action"
+	"github.com/gravwell/gravwell/v4/gwcli/connection"
+	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold"
+	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldlist"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/treeutils"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func NewIngestersNav() *cobra.Command {
@@ -25,7 +29,58 @@ func NewIngestersNav() *cobra.Command {
 	return treeutils.GenerateNav(use, short, long, []string{},
 		[]*cobra.Command{},
 		[]action.Pair{
-			list(),
+			listAction(),
 			get(),
 		})
+}
+
+// listAction generates an action for retrieving information about the ingesters.
+func listAction() action.Pair {
+	const (
+		short string = "review info about all ingesters"
+		long  string = "Review general statistics about all ingesters."
+	)
+
+	type wrappedIngesterStats struct {
+		Indexer       string
+		Hostname      string
+		RemoteAddress string
+		Count         uint64
+		Size          uint64
+		Uptime        string
+		Tags          []string
+		Name          string
+		Version       string
+		UUID          string
+	}
+
+	return scaffoldlist.NewListAction(short, long, wrappedIngesterStats{},
+		func(fs *pflag.FlagSet, _ scaffoldlist.DataParameters) ([]wrappedIngesterStats, error) {
+			// GetIngesterStats returns data according to each indexer.
+			// We extract just the ingester stats sub items.
+			// The rest of the stats are inside of the indexer-specific actions.
+			ss, err := connection.Client.GetIngesterStats()
+			if err != nil {
+				return nil, err
+			}
+			// transform the data
+			var wrap = make([]wrappedIngesterStats, 0)
+			for idxr, stats := range ss { // walk each indexer
+				for _, ingstr := range stats.Ingesters { // walk each ingester
+					wrap = append(wrap, wrappedIngesterStats{
+						Indexer:       idxr,
+						Hostname:      ingstr.State.Hostname,
+						RemoteAddress: ingstr.RemoteAddress,
+						Count:         ingstr.Count,
+						Size:          ingstr.Size,
+						Uptime:        ingstr.Uptime.String(),
+						Tags:          ingstr.Tags,
+						Name:          ingstr.Name,
+						Version:       ingstr.Version,
+						UUID:          ingstr.UUID,
+					})
+				}
+			}
+			return wrap, nil
+		}, nil, scaffoldlist.Options{Omit: scaffold.OmitFlags{Everything: true}})
 }

--- a/gwcli/tree/systems/systems.go
+++ b/gwcli/tree/systems/systems.go
@@ -64,7 +64,7 @@ func newStorageAction() action.Pair {
 	)
 
 	return scaffoldlist.NewListAction(short, long, namedStorage{},
-		func(fs *pflag.FlagSet) ([]namedStorage, error) {
+		func(fs *pflag.FlagSet, params scaffoldlist.DataParameters) ([]namedStorage, error) {
 			ss, err := connection.Client.GetStorageStats()
 			if err != nil {
 				return []namedStorage{}, err
@@ -103,7 +103,7 @@ type idxrState struct {
 func state() action.Pair {
 	return scaffoldlist.NewListAction("display indexer state", "Displays the current error state of each indexer.",
 		idxrState{},
-		func(fs *pflag.FlagSet) ([]idxrState, error) {
+		func(fs *pflag.FlagSet, params scaffoldlist.DataParameters) ([]idxrState, error) {
 			idxrs, err := connection.Client.GetSystemDescriptions()
 			if err != nil {
 				return nil, err
@@ -126,7 +126,7 @@ func state() action.Pair {
 		nil,
 		scaffoldlist.Options{
 			CommonOptions: scaffold.CommonOptions{Use: "state"},
-			Pretty: func(_ []string, _ map[string]string) (string, error) {
+			Pretty: func(_ *pflag.FlagSet, _ []string, _ map[string]string, _ scaffoldlist.DataParameters) (string, error) {
 				idxrs, err := connection.Client.GetSystemDescriptions()
 				if err != nil {
 					return "", err
@@ -160,5 +160,6 @@ func state() action.Pair {
 				}
 				return sb.String()[:sb.Len()-1], nil
 			},
+			Omit: scaffold.OmitFlags{Everything: true},
 		})
 }

--- a/gwcli/tree/templates/templates.go
+++ b/gwcli/tree/templates/templates.go
@@ -99,18 +99,8 @@ func list() action.Pair {
 		long  string = "view templates available to your user."
 	)
 	return scaffoldlist.NewListAction(short, long,
-		wrappedTemplate{}, func(fs *pflag.FlagSet) ([]wrappedTemplate, error) {
-			if all, err := fs.GetBool("all"); err != nil {
-				clilog.GetFlag(err)
-			} else if all {
-				resp, err := connection.Client.ListAllTemplates(nil)
-				if err != nil {
-					return nil, err
-				}
-				return wrap(resp.Results), nil
-			}
-
-			resp, err := connection.Client.ListTemplates(nil)
+		wrappedTemplate{}, func(fs *pflag.FlagSet, params scaffoldlist.DataParameters) ([]wrappedTemplate, error) {
+			resp, err := connection.Client.ListTemplates(params.QueryOpts)
 			if err != nil {
 				return nil, err
 			}
@@ -120,7 +110,6 @@ func list() action.Pair {
 		scaffoldlist.Options{
 			CommonOptions: scaffold.CommonOptions{AddtlFlags: func() *pflag.FlagSet {
 				addtlFlags := &pflag.FlagSet{}
-				ft.GetAll.Register(addtlFlags, true, "templates")
 				return addtlFlags
 			}},
 
@@ -133,76 +122,6 @@ func list() action.Pair {
 			},
 		})
 }
-
-// TODO we will need a submodule to handle variables. Create currently cannot handle this.
-/*func create() action.Pair {
-	fields := map[string]scaffoldcreate.Field{
-		"name":  scaffoldcreate.FieldName("template"),
-		"desc":  scaffoldcreate.FieldDescription("template"),
-		"query": scaffoldcreate.FieldPath("template"),
-		"variables": scaffoldcreate.Field{
-			Required: false,
-			CustomTIFuncInit: func() textinput.Model {
-				ti := stylesheet.NewTI("", false)
-				// TODO
-				return ti
-			},
-		},
-		"labels": scaffoldcreate.FieldLabels(),
-	}
-
-	return scaffoldcreate.NewCreateAction("resource", fields,
-		func(cfg map[string]scaffoldcreate.Field, fieldValues map[string]string, fs *pflag.FlagSet) (id any, invalid string, err error) {
-			// check that path is valid and the file exists
-			if fi, err := os.Stat(fieldValues["path"]); err != nil {
-				switch {
-				case errors.Is(err, filesystem.ErrNotExist):
-					return "", fmt.Sprintf("file '%v' not found", fieldValues["path"]), nil
-				}
-				return "", fmt.Sprintf("failed to access path: %v", err), nil
-			} else if fi.IsDir() {
-				return "", "path must point to a file", nil
-			}
-			// transmute to resource struct
-			var labels []string
-			if lbls, found := fieldValues["labels"]; !found {
-				return "", "", errors.New("failed to find \"labels\" field")
-			} else if lbls = strings.TrimSpace(lbls); lbls != "" {
-				labels = strings.Split(lbls, ",")
-			}
-
-			data := types.Resource{
-				CommonFields: types.CommonFields{
-					Name:        fieldValues["name"],
-					Description: fieldValues["desc"],
-					Labels:      labels,
-				},
-			}
-
-			resp, err := connection.Client.CreateResource(data)
-			// upload the file
-			f, err := os.Open(fieldValues["path"])
-			if err != nil {
-				errStr := fmt.Sprintf("created resource, but failed to populate it: %v", err)
-				clilog.Writer.Warn(errStr, rfc5424.SDParam{Name: "stage", Value: "open file"})
-				return resp.ID, "", errors.New(errStr)
-			}
-			defer f.Close()
-			b, err := io.ReadAll(f)
-			if err != nil {
-				errStr := fmt.Sprintf("created resource, but failed to populate it: %v", err)
-				clilog.Writer.Warn(errStr, rfc5424.SDParam{Name: "stage", Value: "slurp file"})
-				return resp.ID, "", errors.New(errStr)
-			}
-			if err := connection.Client.PopulateResource(resp.ID, b); err != nil {
-				errStr := fmt.Sprintf("created resource, but failed to populate it: %v", err)
-				clilog.Writer.Warn(errStr, rfc5424.SDParam{Name: "stage", Value: "populate"})
-				return resp.ID, "", errors.New(errStr)
-			}
-
-			return resp.ID, "", err
-		}, nil)
-}*/
 
 func delete() action.Pair {
 	return scaffolddelete.NewDeleteAction("template", "templates",

--- a/gwcli/tree/templates/templates.go
+++ b/gwcli/tree/templates/templates.go
@@ -12,21 +12,29 @@ Package templates defines the templates nav, which holds data related to... er, 
 package templates
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gravwell/gravwell/v4/client/types"
 	"github.com/gravwell/gravwell/v4/gwcli/action"
 	"github.com/gravwell/gravwell/v4/gwcli/bubbles/multiselectlist"
 	"github.com/gravwell/gravwell/v4/gwcli/clilog"
 	"github.com/gravwell/gravwell/v4/gwcli/connection"
 	"github.com/gravwell/gravwell/v4/gwcli/internal/listitem"
+	"github.com/gravwell/gravwell/v4/gwcli/stylesheet"
 	ft "github.com/gravwell/gravwell/v4/gwcli/stylesheet/flagtext"
+	"github.com/gravwell/gravwell/v4/gwcli/stylesheet/phrases"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold"
+	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldcreate"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffolddelete"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldedit"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldlist"
+	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldselect"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/treeutils"
+	"github.com/gravwell/gravwell/v4/ingest/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -43,10 +51,11 @@ For instance, templates which expect an IP address as their variable can be used
 		[]*cobra.Command{},
 		[]action.Pair{
 			list(),
-			//create(),
 			delete(),
 			edit(),
-			//download(),
+			show(),
+			create(),
+			jsonAction(),
 		})
 }
 
@@ -203,4 +212,174 @@ func edit() action.Pair {
 		},
 	}
 	return scaffoldedit.NewEditAction("template", "templates", cfg, funcs)
+}
+
+// for to/from JSON
+type content struct {
+	Query     string
+	Variables []types.TemplateVariable
+}
+
+func show() action.Pair {
+	return scaffoldselect.NewSelectAction("display template contents", "Display the contents of a template", "template",
+		func(addtlFlags *pflag.FlagSet) ([]multiselectlist.SelectableItem[string], error) {
+			templates, err := connection.Client.ListTemplates(nil) // TODO need to pass in params
+			if err != nil {
+				return nil, err
+			}
+			data := make([]multiselectlist.SelectableItem[string], len(templates.Results))
+			for i, template := range templates.Results {
+				data[i] = &listitem.Generic{
+					ID_:        template.ID,
+					Name:       template.Name,
+					SecondLine: template.Description,
+				}
+			}
+			return data, nil
+		},
+		func(IDs []string, addtlFlags *pflag.FlagSet) (results []scaffold.Result, _ error) {
+			asJSON, err := addtlFlags.GetBool(ft.JSON.Name())
+			clilog.GetFlag(err)
+
+			results = make([]scaffold.Result, len(IDs))
+			for i, ID := range IDs {
+				template, err := connection.Client.GetTemplate(ID)
+				if phrases.IsNotFoundErr(err) {
+					results[i] = scaffold.Result{
+						Output: phrases.ErrUnknownIdentifier(ID, "flow ID").Error(),
+					}
+					continue
+				} else if err != nil {
+					clilog.Writer.Warn("failed to get template", log.KV("ID", ID), log.KVErr(err))
+					results[i] = scaffold.Result{
+						Output: err.Error(),
+					}
+					continue
+				}
+				// compose output
+				if asJSON {
+					content := content{Query: template.Query, Variables: template.Variables}
+					b, err := json.Marshal(content)
+					if err != nil {
+						clilog.Writer.Error("failed to marshal content", log.KV("content", content), log.KVErr(err))
+						results[i] = scaffold.Result{Output: "failed to marshal content: " + err.Error()}
+						continue
+					}
+					results[i] = scaffold.Result{Success: true, Output: string(b)}
+					continue
+				}
+				var sb strings.Builder
+				sb.WriteString("ID ")
+				sb.WriteString(ID)
+				sb.WriteString(": ")
+				sb.WriteString(template.Query)
+				sb.WriteString("\n")
+				for _, variable := range template.Variables {
+					requiredString := ""
+					if variable.Required {
+						requiredString = " (required)"
+					}
+					fmt.Fprintf(&sb,
+						"\t%s=%s%s\n"+
+							"\t\t%s\n",
+						variable.Name, variable.DefaultValue, requiredString,
+						variable.Description)
+				}
+
+				results[i] = scaffold.Result{
+					Success: true,
+					Output:  sb.String()[:sb.Len()-1],
+				}
+
+			}
+			return results, nil
+		},
+		scaffoldselect.Options{
+			CommonOptions: scaffold.CommonOptions{
+				Use: "show",
+				AddtlFlags: func() *pflag.FlagSet {
+					fs := &pflag.FlagSet{}
+					ft.JSON.Register(fs)
+					return fs
+				},
+			},
+		})
+}
+
+func create() action.Pair {
+	return scaffoldcreate.NewCreateAction("template",
+		map[string]scaffoldcreate.Field{
+			"name":   scaffoldcreate.FieldName("template"),
+			"desc":   scaffoldcreate.FieldDescription("template"),
+			"path":   scaffoldcreate.FieldPath("template specification", true),
+			"labels": scaffoldcreate.FieldLabels(),
+		},
+		func(fields map[string]scaffoldcreate.Field, fs *pflag.FlagSet) (id any, invalid string, err error) {
+			var (
+				content  content
+				emptyStr string
+			)
+			if pth := strings.TrimSpace(fields["path"].Provider.Get()); pth != "" {
+				b, err := os.ReadFile(pth)
+				if err != nil {
+					return 0, "", err
+				}
+				if err := json.Unmarshal(b, &content); err != nil {
+					return 0, "", err
+				}
+			} else {
+				emptyStr = " empty " // inserting into the success line to confirm that no actual data were given
+			}
+
+			newTemplate, err := connection.Client.CreateTemplate(types.Template{
+				CommonFields: types.CommonFields{
+					Name:        fields["name"].Provider.Get(),
+					Description: fields["desc"].Provider.Get(),
+					Labels:      scaffoldcreate.GetLabelsFromField(fields["labels"]),
+				},
+				Query:     content.Query,
+				Variables: content.Variables,
+			})
+			if err != nil {
+				return 0, "", err
+			}
+			return phrases.SuccessfullyCreatedItem(emptyStr+"template", newTemplate.ID), "", nil
+
+		},
+		scaffoldcreate.Options{
+			Long: "Create a new template. It will be empty unless you specify a --path to a JSON file.\n" +
+				"Call " + stylesheet.Cur.Action.Render("templates json") + " to see the format of the JSON file.",
+			IDIsSuccessMessage: true,
+		})
+}
+
+func jsonAction() action.Pair {
+	return scaffold.NewBasicAction("json", "display template JSON schema",
+		"Print the JSON schema expected for creating templates via the cli.",
+		func(fs *pflag.FlagSet) (output string, addtlCmds tea.Cmd) {
+			return `{
+  "Query": "my example query",
+  "Variables": [
+    {
+      "Name": "NAME1",
+      "Label": "lbl",
+      "Description": "my variable description",
+      "Required": true,
+      "DefaultValue": "default",
+      "PreviewValue": "preview"
+    },
+    {
+      "Name": "NAME2",
+      "Label": "lbl",
+      "Description": "my variable description",
+      "Required": true,
+      "DefaultValue": "default",
+      "PreviewValue": "preview"
+    }
+  ]
+}`, nil
+		},
+		scaffold.BasicOptions{},
+	)
+
 }

--- a/gwcli/tree/templates/templates.go
+++ b/gwcli/tree/templates/templates.go
@@ -246,7 +246,7 @@ func show() action.Pair {
 				template, err := connection.Client.GetTemplate(ID)
 				if phrases.IsNotFoundErr(err) {
 					results[i] = scaffold.Result{
-						Output: phrases.ErrUnknownIdentifier(ID, "flow ID").Error(),
+						Output: phrases.ErrUnknownIdentifier(ID, "template ID").Error(),
 					}
 					continue
 				} else if err != nil {
@@ -311,7 +311,7 @@ func create() action.Pair {
 		map[string]scaffoldcreate.Field{
 			"name":   scaffoldcreate.FieldName("template"),
 			"desc":   scaffoldcreate.FieldDescription("template"),
-			"path":   scaffoldcreate.FieldPath("template specification", true),
+			"path":   scaffoldcreate.FieldPath("template specification", false),
 			"labels": scaffoldcreate.FieldLabels(),
 		},
 		func(fields map[string]scaffoldcreate.Field, fs *pflag.FlagSet) (id any, invalid string, err error) {

--- a/gwcli/tree/tokens/tokens.go
+++ b/gwcli/tree/tokens/tokens.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/gravwell/gravwell/v4/client"
 	"github.com/gravwell/gravwell/v4/client/types"
 	"github.com/gravwell/gravwell/v4/gwcli/action"
 	"github.com/gravwell/gravwell/v4/gwcli/bubbles/multiselectlist"
@@ -26,6 +25,7 @@ import (
 	"github.com/gravwell/gravwell/v4/gwcli/connection"
 	"github.com/gravwell/gravwell/v4/gwcli/internal/listitem"
 	"github.com/gravwell/gravwell/v4/gwcli/stylesheet"
+	"github.com/gravwell/gravwell/v4/gwcli/stylesheet/phrases"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/pathtextinput"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold/scaffoldcreate"
@@ -62,8 +62,8 @@ func list() action.Pair {
 		long  string = "Lists information about the API tokens you have access to."
 	)
 	return scaffoldlist.NewListAction(short, long,
-		types.Token{}, func(fs *pflag.FlagSet) ([]types.Token, error) {
-			resp, err := connection.Client.ListTokens(nil)
+		types.Token{}, func(fs *pflag.FlagSet, params scaffoldlist.DataParameters) ([]types.Token, error) {
+			resp, err := connection.Client.ListTokens(params.QueryOpts)
 			if err != nil {
 				return nil, err
 			}
@@ -81,14 +81,12 @@ func list() action.Pair {
 }
 
 func get() action.Pair {
-	var tokens []types.Token // tokens for the current run; reset by ValidateArgs
 	return scaffoldlist.NewListAction(
 		"get token details",
 		"Retrieves details about specified tokens, based on list of IDs provided as arguments.",
 		types.Token{},
-		func(fs *pflag.FlagSet) ([]types.Token, error) {
-
-			return tokens, nil
+		func(fs *pflag.FlagSet, params scaffoldlist.DataParameters) ([]types.Token, error) {
+			return getTokens(fs.Args(), params)
 		},
 		nil,
 		scaffoldlist.Options{
@@ -96,7 +94,11 @@ func get() action.Pair {
 				Use:     "get",
 				Example: "get ID1 ID2",
 			},
-			Pretty: func(_ []string, _ map[string]string) (string, error) {
+			Pretty: func(addtlFlags *pflag.FlagSet, _ []string, _ map[string]string, params scaffoldlist.DataParameters) (string, error) {
+				tokens, err := getTokens(addtlFlags.Args(), params)
+				if err != nil {
+					return "", err
+				}
 				// find the longest ID to use as the width
 				var longestIDLen int
 				for _, tkn := range tokens {
@@ -112,24 +114,27 @@ func get() action.Pair {
 				return sb.String(), nil
 			},
 			ValidateArgs: func(fs *pflag.FlagSet) (invalid string, err error) {
-				tokens = []types.Token{} // clear cache
 				if len(fs.Args()) < 1 {
 					return "you must provide at least one token ID", nil
-				}
-				// fetch and cache the tokens
-				for _, id := range fs.Args() {
-					t, err := connection.Client.GetToken(id)
-					if err != nil {
-						if errors.Is(err, client.ErrNotFound) || strings.Contains(err.Error(), "Not Found") {
-							return "unknown token ID: " + id, nil
-						}
-						return "", fmt.Errorf("failed to get token %v: %w", id, err)
-					}
-					tokens = append(tokens, t)
 				}
 				return "", nil
 			},
 		})
+}
+
+func getTokens(bare []string, params scaffoldlist.DataParameters) ([]types.Token, error) {
+	var tokens = make([]types.Token, len(bare))
+	for i, id := range bare {
+		t, err := connection.Client.GetTokenEx(id, params.QueryOpts)
+		if err != nil {
+			if phrases.IsNotFoundErr(err) {
+				return nil, phrases.ErrUnknownIdentifier(id, "token ID")
+			}
+			return nil, fmt.Errorf("failed to get token %v: %w", id, err)
+		}
+		tokens[i] = t
+	}
+	return tokens, nil
 }
 
 // prettyTokens pretty-prints the given token and returns it.

--- a/gwcli/utilities/scaffold/options.go
+++ b/gwcli/utilities/scaffold/options.go
@@ -12,6 +12,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/lipgloss"
+	"github.com/gravwell/gravwell/v4/client/types"
+	"github.com/gravwell/gravwell/v4/gwcli/clilog"
+	"github.com/gravwell/gravwell/v4/gwcli/connection"
+	ft "github.com/gravwell/gravwell/v4/gwcli/stylesheet/flagtext"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -69,4 +74,79 @@ func (co CommonOptions) Apply(cmd *cobra.Command) {
 	if co.AddtlFlags != nil {
 		cmd.Flags().AddFlagSet(co.AddtlFlags())
 	}
+}
+
+//#region OmitFlags
+
+const (
+	FlagNameAllData string = "all"   // fetch data from all users instead of just the current user
+	FlagNameLimit   string = "limit" // limit the number of elements returned
+)
+
+// OmitFlags allows disabling flags for a specific action.
+// Anything set to true in here will have its equivalent flag turned off for this action.
+// For example: if an asset type doesn't tombstone, --include-delete should probably be disabled.
+type OmitFlags struct {
+	Everything bool // disable everything. This is useful if the ListDataFunc doesn't take query opts.
+
+	AllData        bool
+	IncludeDeleted bool
+	Limit          bool
+}
+
+// this can be extracted if we find ourselves using it more
+var italics = lipgloss.NewStyle().Italic(true)
+
+// InstallQueryOptionsFlags attaches query option flags to the flagset if there were not omitted.
+//
+// Should be paired with GetQueryOptions.
+func InstallQueryOptionsFlags(fs *pflag.FlagSet, omit OmitFlags) {
+	if omit.Everything {
+		return
+	}
+	// attach query option flags, depending on their omit state
+
+	if !omit.AllData {
+		fs.Bool(FlagNameAllData, false, "Requests that results include data from "+italics.Render("all")+" users and groups instead of just yours.\n"+
+			"Ignored if you are not an admin.\n"+
+			"Implied by admin mode")
+	}
+	if !omit.IncludeDeleted {
+		ft.IncludeDeleted.Register(fs)
+	}
+	if !omit.Limit {
+		fs.Int(FlagNameLimit, 0, "Limit the number of items to return")
+	}
+}
+
+// GetQueryOptions extracts QueryOptions from the given flagset.
+//
+// Should be paired with InstallQueryOptionsFlags().
+func GetQueryOptions(fs *pflag.FlagSet, omit OmitFlags) *types.QueryOptions {
+	var err error
+	var qo = &types.QueryOptions{}
+	if omit.Everything {
+		return qo
+	}
+
+	if !omit.IncludeDeleted {
+		qo.IncludeDeleted, err = fs.GetBool(ft.IncludeDeleted.Name())
+		clilog.GetFlag(err)
+	}
+	if !omit.AllData {
+		qo.AdminMode = connection.AdminMode()
+		if !qo.AdminMode { // check for --all override
+			qo.AdminMode, err = fs.GetBool(FlagNameAllData)
+			clilog.GetFlag(err)
+		}
+	}
+	if !omit.Limit {
+		lim, err := fs.GetInt(FlagNameLimit)
+		clilog.GetFlag(err)
+		if lim > 0 {
+			qo.Limit = lim
+		}
+	}
+
+	return qo
 }

--- a/gwcli/utilities/scaffold/options.go
+++ b/gwcli/utilities/scaffold/options.go
@@ -85,7 +85,7 @@ const (
 
 // OmitFlags allows disabling flags for a specific action.
 // Anything set to true in here will have its equivalent flag turned off for this action.
-// For example: if an asset type doesn't tombstone, --include-delete should probably be disabled.
+// For example: if an asset type doesn't tombstone, --include-deleted should probably be disabled.
 type OmitFlags struct {
 	Everything bool // disable everything. This is useful if the ListDataFunc doesn't take query opts.
 

--- a/gwcli/utilities/scaffold/options.go
+++ b/gwcli/utilities/scaffold/options.go
@@ -12,10 +12,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/gravwell/gravwell/v4/client/types"
 	"github.com/gravwell/gravwell/v4/gwcli/clilog"
 	"github.com/gravwell/gravwell/v4/gwcli/connection"
+	"github.com/gravwell/gravwell/v4/gwcli/stylesheet"
 	ft "github.com/gravwell/gravwell/v4/gwcli/stylesheet/flagtext"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -94,9 +94,6 @@ type OmitFlags struct {
 	Limit          bool
 }
 
-// this can be extracted if we find ourselves using it more
-var italics = lipgloss.NewStyle().Italic(true)
-
 // InstallQueryOptionsFlags attaches query option flags to the flagset if there were not omitted.
 //
 // Should be paired with GetQueryOptions.
@@ -107,7 +104,7 @@ func InstallQueryOptionsFlags(fs *pflag.FlagSet, omit OmitFlags) {
 	// attach query option flags, depending on their omit state
 
 	if !omit.AllData {
-		fs.Bool(FlagNameAllData, false, "Requests that results include data from "+italics.Render("all")+" users and groups instead of just yours.\n"+
+		fs.Bool(FlagNameAllData, false, "Requests that results include data from "+stylesheet.Italicize("all")+" users and groups instead of just yours.\n"+
 			"Ignored if you are not an admin.\n"+
 			"Implied by admin mode")
 	}

--- a/gwcli/utilities/scaffold/scaffoldcreate/create.go
+++ b/gwcli/utilities/scaffold/scaffoldcreate/create.go
@@ -157,6 +157,8 @@ func NewCreateAction(singular string, fields map[string]Field, createFunc Create
 			} else if inv != "" { // some of the flags were invalid
 				fmt.Fprintln(c.OutOrStdout(), inv)
 				return errors.New(inv)
+			} else if opts.IDIsSuccessMessage {
+				fmt.Fprint(c.OutOrStdout(), id)
 			} else {
 				fmt.Fprint(c.OutOrStdout(), phrases.SuccessfullyCreatedItem(singular, id))
 			}
@@ -213,6 +215,8 @@ type createModel struct {
 	// current state of the flagset, Reset to addtlFlagFunc + installFlags
 	fs pflag.FlagSet
 	cf CreateFuncT // function to create the new entity
+
+	IDIsSuccessMessage bool
 }
 
 // SubmitSelect returns if the select button is currently selected by the user.
@@ -230,8 +234,9 @@ func newCreateModel(fields map[string]Field, singular string, createFunc CreateF
 		inputs: inputs{
 			ordered: slices.Collect(maps.Keys(fields)),
 		},
-		addtlFlagFunc: opts.AddtlFlags,
-		cf:            createFunc,
+		addtlFlagFunc:      opts.AddtlFlags,
+		cf:                 createFunc,
+		IDIsSuccessMessage: opts.IDIsSuccessMessage,
 	}
 
 	// set flags by mining fields and, if applicable, tacking on additional flags
@@ -318,6 +323,9 @@ func (c *createModel) Update(msg tea.Msg) tea.Cmd {
 		}
 		// done, die
 		c.mode = quitting
+		if c.IDIsSuccessMessage {
+			return tea.Println(id)
+		}
 		return tea.Println(phrases.SuccessfullyCreatedItem(c.singular, id))
 	}
 	if c.SubmitSelected() { // if submit is selected and it wasn't handled above, we don't care about it

--- a/gwcli/utilities/scaffold/scaffoldcreate/create_test.go
+++ b/gwcli/utilities/scaffold/scaffoldcreate/create_test.go
@@ -69,7 +69,7 @@ func TestOptions(t *testing.T) {
 	act := scaffoldcreate.NewCreateAction("test",
 		map[string]scaffoldcreate.Field{
 			"name": scaffoldcreate.FieldName("test"),
-			"path": scaffoldcreate.FieldPath("test"),
+			"path": scaffoldcreate.FieldPath("test", true),
 			"cust": { // converted into an int
 				Required: false,
 				Title:    "customs",

--- a/gwcli/utilities/scaffold/scaffoldcreate/field.go
+++ b/gwcli/utilities/scaffold/scaffoldcreate/field.go
@@ -212,9 +212,15 @@ func FieldLabels() Field {
 // Returns nil if the field was not populated
 func GetLabelsFromField(f Field) []string {
 	var lbls []string
-	if exploded := strings.Split(strings.TrimSpace(f.Provider.Get()), ","); len(exploded) > 0 {
-		lbls = exploded
+	exploded := strings.SplitSeq(strings.TrimSpace(f.Provider.Get()), ",")
+	for s := range exploded {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		lbls = append(lbls, s)
 	}
+
 	return lbls
 }
 
@@ -263,4 +269,3 @@ var DefaultFieldGroupSelectionFlags = FlagConfig{
 	Name:  "groups",
 	Usage: "Groups IDs to associate to the item",
 }
-

--- a/gwcli/utilities/scaffold/scaffoldcreate/field.go
+++ b/gwcli/utilities/scaffold/scaffoldcreate/field.go
@@ -170,10 +170,10 @@ func FieldDescription(singular string) Field {
 
 // FieldPath returns a struct suited for file path specification inputs.
 // Order == 80.
-func FieldPath(singular string) Field {
+func FieldPath(singular string, required bool) Field {
 	return Field{
 		Title:    ft.Path.Name(),
-		Required: true,
+		Required: required,
 		Flag: FlagConfig{
 			Name:      ft.Path.Name(),
 			Usage:     ft.Path.Usage(singular),

--- a/gwcli/utilities/scaffold/scaffoldcreate/field.go
+++ b/gwcli/utilities/scaffold/scaffoldcreate/field.go
@@ -129,6 +129,9 @@ func setValuesFromFlags(fs *pflag.FlagSet, fields map[string]Field) (missingRequ
 			return nil, err
 		}
 
+		// ensure SetArgs has been called here in case we need to late-populate
+		// This is a hack while we await mono#2448.
+		fields[key].Provider.SetArgs(80, 60)
 		if invalid := fields[key].Provider.Set(v); invalid != "" {
 			return nil, fmt.Errorf("%s is not a valid input to --%s: %s", v, fields[key].Flag.Name, invalid)
 		}

--- a/gwcli/utilities/scaffold/scaffoldcreate/field.go
+++ b/gwcli/utilities/scaffold/scaffoldcreate/field.go
@@ -11,6 +11,7 @@ package scaffoldcreate
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/gravwell/gravwell/v4/gwcli/clilog"
@@ -204,6 +205,16 @@ func FieldLabels() Field {
 	}
 }
 
+// GetLabelsFromField extracts the actual labels from a FieldLabels.
+// Returns nil if the field was not populated
+func GetLabelsFromField(f Field) []string {
+	var lbls []string
+	if exploded := strings.Split(strings.TrimSpace(f.Provider.Get()), ","); len(exploded) > 0 {
+		lbls = exploded
+	}
+	return lbls
+}
+
 // FieldFrequency returns a struct suitable for taking in the frequency of something occurring as a cron string.
 // Attaches uniques.CronRuneValidator and shorthand -c.
 // Order == 50.
@@ -244,3 +255,9 @@ func FieldPassword(required bool, fc FlagConfig, order int) Field {
 		},
 	}
 }
+
+var DefaultFieldGroupSelectionFlags = FlagConfig{
+	Name:  "groups",
+	Usage: "Groups IDs to associate to the item",
+}
+

--- a/gwcli/utilities/scaffold/scaffoldcreate/options.go
+++ b/gwcli/utilities/scaffold/scaffoldcreate/options.go
@@ -19,6 +19,8 @@ type Options struct {
 	Short string
 	// Override scaffoldcreate's default action description.
 	Long string
+	// If set, the any "id" returned from CreateFunc will be printed bare, rather than being fed into phrases.SuccessfullyCreatedItem.
+	IDIsSuccessMessage bool
 }
 
 // Apply alters the given cmd such that all set Options are effectual.

--- a/gwcli/utilities/scaffold/scaffoldcreate/providers.go
+++ b/gwcli/utilities/scaffold/scaffoldcreate/providers.go
@@ -386,13 +386,16 @@ func (p *MSLProvider) Set(val string) (invalid string) {
 	if val == "" {
 		return ""
 	}
-	vals := strings.Split(val, ",")
+	vals := strings.Split(val, MSLProviderSeparator)
 	_, notFound := p.msl.SelectItems(vals)
 	if len(notFound) > 0 {
 		return fmt.Sprintf("IDs %v not found", notFound)
 	}
 	return ""
 }
+
+// MSLProviderSeparator is the separator used to split values given to Set and returned from Get.
+const MSLProviderSeparator string = ","
 
 // Get returns the set of selected items as a comma-separated list.
 func (p *MSLProvider) Get() string {
@@ -401,7 +404,7 @@ func (p *MSLProvider) Get() string {
 	for i, di := range dis {
 		ss[i] = di.ID()
 	}
-	return strings.Join(ss, ",")
+	return strings.Join(ss, MSLProviderSeparator)
 }
 
 func (p *MSLProvider) ToggleFocus(_ bool) {

--- a/gwcli/utilities/scaffold/scaffoldcreate/providers_test.go
+++ b/gwcli/utilities/scaffold/scaffoldcreate/providers_test.go
@@ -54,11 +54,14 @@ func TestTextProvider(t *testing.T) {
 	t.Run("full mother cycle + hook set args to alter the TI", func(t *testing.T) {
 		t.Parallel()
 		// tests that TextProvider both successfully applies a CustomSetArgs and operates as expected over the course of a full Mother cycle
-		var invocationCount = 0
+		var (
+			invocationCount = 0
+			charLimit       = 2
+		)
 		provider := &scaffoldcreate.TextProvider{CustomSetArgs: func(m textinput.Model) textinput.Model {
-			// count invocations and set the TI's char limit to invocation count so we have something to check that TIs are being updated
+			// count invocations and set the TI's char limit so we have something to check that TIs are being updated
 			invocationCount += 1
-			m.CharLimit = invocationCount
+			m.CharLimit = charLimit
 			return m
 		}}
 		f := scaffoldcreate.NewField("invoke", false, provider)
@@ -105,9 +108,11 @@ func TestTextProvider(t *testing.T) {
 		if x := provider.Get(); x != "" {
 			t.Fatal("provider value not destroyed by Reset. Lingering value: ", x)
 		}
-		testsupport.CheckSetArgs(t, pair.Model.SetArgs, &pflag.FlagSet{}, []string{"-t=YungVenuz"}, 0, 0, false, nil, false)
-		if x := provider.Get(); x != "Yun" { // should be limited by our CharLimit
-			t.Fatal("bad value after second SetArgs", testsupport.ExpectedActual("Yun", x))
+		charLimit = 5
+
+		testsupport.CheckSetArgs(t, pair.Model.SetArgs, &pflag.FlagSet{}, []string{"-t=Wo hui ying wen"}, 0, 0, false, nil, false)
+		if x := provider.Get(); x != "Wo hu" { // should be limited by our CharLimit
+			t.Fatal("bad value after second SetArgs", testsupport.ExpectedActual("Wo hu", x))
 		}
 
 	})

--- a/gwcli/utilities/scaffold/scaffoldlist/actor.go
+++ b/gwcli/utilities/scaffold/scaffoldlist/actor.go
@@ -19,7 +19,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gravwell/gravwell/v4/gwcli/action"
 	"github.com/gravwell/gravwell/v4/gwcli/clilog"
-	ft "github.com/gravwell/gravwell/v4/gwcli/stylesheet/flagtext"
 	"github.com/gravwell/gravwell/v4/gwcli/stylesheet/phrases"
 	"github.com/spf13/pflag"
 )
@@ -31,8 +30,9 @@ type ListAction[dataStruct any] struct {
 	showColumns bool           // print columns and exit
 	fs          *pflag.FlagSet // current flagset, parsed or unparsed
 	outFile     *os.File       // file to output results to (or nil)
+	format      outputFormat
 
-	// individualized for each use of scaffoldlist
+	// individualized for each use of scaffoldlist (shielded from .Reset())
 	defaultColumnsDQ []string                 // columns to output if --all and --columns=<> are unspecified
 	dqToAlias        map[string]string        // DQ column names -> alias (alias will be "" if a column does not have an alias)
 	aliasToDQ        map[string]string        // inverse of dqToAlias
@@ -63,12 +63,9 @@ func newListAction[dataStruct_t any](
 	return la
 }
 
-// SetArgs is called when the action is invoked by the user and Mother *enters* handoff mode.
-// Mother parses flags and provides us a handle to check against.
 func (la *ListAction[T]) SetArgs(fs *pflag.FlagSet, tokens []string, width, height int) (
 	invalid string, onStart tea.Cmd, err error) {
-	// refresh flags
-	la.fs = buildFlagSet(la.options.Pretty != nil, aliasColumns(la.defaultColumnsDQ, la.dqToAlias))
+	la.fs = buildFlagSet(la.options.Pretty != nil, aliasColumns(la.defaultColumnsDQ, la.dqToAlias), la.options.Omit)
 	if la.options.AddtlFlags != nil {
 		la.fs.AddFlagSet(la.options.AddtlFlags())
 	}
@@ -77,13 +74,12 @@ func (la *ListAction[T]) SetArgs(fs *pflag.FlagSet, tokens []string, width, heig
 		return err.Error(), nil, nil
 	}
 
-	// check for --show-columns
-	if la.showColumns, err = la.fs.GetBool(ft.ShowColumns.Name()); err != nil {
-		return "", nil, err
-	} else if la.showColumns { // all done
+	la.showColumns, la.columns, la.outFile, la.format, invalid = getFlags(la.fs, la.dqToAlias, la.aliasToDQ, la.options.Pretty != nil)
+	if invalid != "" {
+		return invalid, nil, nil
+	} else if la.showColumns {
 		return "", nil, nil
 	}
-
 	// run custom validation
 	if la.options.ValidateArgs != nil {
 		if invalid, err := la.options.ValidateArgs(la.fs); err != nil {
@@ -93,22 +89,11 @@ func (la *ListAction[T]) SetArgs(fs *pflag.FlagSet, tokens []string, width, heig
 		}
 	}
 
-	if la.columns, err = getColumns(la.fs, la.dqToAlias, la.aliasToDQ); err != nil {
-		// treat these errors as invalids
-		return err.Error(), nil, nil
-	}
-
-	if f, err := initOutFile(la.fs); err != nil {
-		return "", nil, err
-	} else {
-		la.outFile = f
-	}
-
-	return "", nil, nil
+	return invalid, nil, nil
 }
 
-// Update takes in a msg (some event that occurred, like a window redraw or a key press) and acts on it.
-// List only ever needs to update once; it figures out what data is to be displayed, fetches it, and spits it out above the prompt.
+// Update drives interactivity.
+// List only ever needs to update once; it figures out what data to display, fetches it, and spits it out above the prompt.
 func (la *ListAction[T]) Update(msg tea.Msg) tea.Cmd {
 	if la.done {
 		return nil
@@ -129,7 +114,7 @@ func (la *ListAction[T]) Update(msg tea.Msg) tea.Cmd {
 		la.columns,
 		la.dataFunc,
 		la.options.Pretty,
-		la.dqToAlias)
+		la.dqToAlias, la.options.Omit)
 	if err != nil {
 		// log and print the error
 		clilog.Writer.Error(err.Error())
@@ -174,12 +159,12 @@ func (la *ListAction[T]) Reset() error {
 	la.done = false
 	la.columns = la.defaultColumnsDQ
 	la.showColumns = false
+	la.fs = &pflag.FlagSet{}
 	if la.outFile != nil {
 		la.outFile.Close()
 	}
 	la.outFile = nil
-
-	// flags are refreshed in SetArgs to guarantee they are built even on first run
+	la.format = 0
 
 	return nil
 }

--- a/gwcli/utilities/scaffold/scaffoldlist/list.go
+++ b/gwcli/utilities/scaffold/scaffoldlist/list.go
@@ -58,7 +58,7 @@ import (
 	"github.com/crewjam/rfc5424"
 	"github.com/gravwell/gravwell/v4/gwcli/action"
 	"github.com/gravwell/gravwell/v4/gwcli/clilog"
-	"github.com/gravwell/gravwell/v4/gwcli/stylesheet"
+	"github.com/gravwell/gravwell/v4/gwcli/internal/state"
 	ft "github.com/gravwell/gravwell/v4/gwcli/stylesheet/flagtext"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/treeutils"
@@ -101,16 +101,20 @@ const (
 	outFilePerm         os.FileMode = 0644
 	exportedColumnsOnly bool        = true // only allow users to query for exported fields as columns?
 	ShowColumnSep       string      = "; " // separator between column names when printing list of available columns
+
+	FlagNameSelectAllColumns string = "all-columns"  // fetch data for all columns, ignoring defaults
+	FlagNameShowColumns      string = "show-columns" // display available columns instead of fetching data
+	FlagNameSelectColumns    string = "columns"      // select which columns to display data for instead of using the defaults.
 )
 
 // ListDataFunc is a function that retrieves an array of structs of type dataStruct
-type ListDataFunc[dataStruct_t any] func(*pflag.FlagSet) ([]dataStruct_t, error)
+type ListDataFunc[dataStruct_t any] func(addtlFlags *pflag.FlagSet, params DataParameters) ([]dataStruct_t, error)
 
 // AddtlFlagFunc (if not nil) bolts additional flags onto this action for later during the data func.
 type AddtlFlagFunc func() pflag.FlagSet
 
 // A PrettyPrinterFunc defines a free-form function for outputting a pretty string for human consumption.
-type PrettyPrinterFunc func(DQColumns []string, DQToAlias map[string]string) (string, error)
+type PrettyPrinterFunc func(addtlFlags *pflag.FlagSet, DQColumns []string, DQToAlias map[string]string, params DataParameters) (string, error)
 
 // NewListAction creates and returns a cobra.Command suitable for use as a list action,
 // complete with common flags and a generic run function operating off the given ListDataFunc.
@@ -190,22 +194,36 @@ func NewListAction[dataStruct_t any](short, long string,
 	var defaultColumnsDQ = findDefaultColumns(options, DQToAlias)
 
 	// generate a non-interactive action
-	run := generateRunE(dataFunc, options, DQToAlias, AliasToDQ)
+	runE := generateRunE(dataFunc, options, DQToAlias, AliasToDQ)
 
-	// generate usage and example
-	actionOptions := treeutils.GenerateActionOptions{Example: "--" + ft.JSON.Name() + " --" + ft.AllColumns.Name()}
+	// generate default usage and example
+	var actionOptions treeutils.GenerateActionOptions
 	{
+		actionOptions.Example = "--" + ft.JSON.Name() + " --" + FlagNameSelectAllColumns
+
 		formats := []string{"--" + ft.CSV.Name(), "--" + ft.JSON.Name(), "--" + ft.Table.Name()}
 		if options.Pretty != nil {
 			formats = append(formats, "--pretty")
 		}
-		actionOptions.Usage = fmt.Sprintf("%v %v", ft.MutuallyExclusive(formats), ft.Optional("--"+ft.SelectColumns.Name()+"=col1,col2,..."))
+		actionOptions.Usage = fmt.Sprintf("%s %s %s %s",
+			ft.Optional("--"+FlagNameShowColumns),
+			ft.Optional(
+				ft.MutuallyExclusive(formats),
+			),
+			ft.Optional(
+				ft.MutuallyExclusive([]string{
+					"--" + FlagNameSelectColumns + "=col1,col2,...",
+					"--" + FlagNameSelectAllColumns,
+				}),
+			),
+			ft.Optional("FLAGS"),
+		)
 	}
 
-	cmd := treeutils.GenerateAction("list", short, long, nil, run, actionOptions)
+	cmd := treeutils.GenerateAction("list", short, long, nil, runE, actionOptions)
 	options.Apply(cmd)
 
-	cmd.Flags().AddFlagSet(buildFlagSet(options.Pretty != nil, aliasColumns(defaultColumnsDQ, DQToAlias)))
+	cmd.Flags().AddFlagSet(buildFlagSet(options.Pretty != nil, aliasColumns(defaultColumnsDQ, DQToAlias), options.Omit))
 	cmd.Flags().SortFlags = false // does not seem to be respected
 	cmd.MarkFlagsMutuallyExclusive(ft.CSV.Name(), ft.JSON.Name(), ft.Table.Name())
 
@@ -257,6 +275,20 @@ func generateRunE[dataStruct_t any](
 	dataFn ListDataFunc[dataStruct_t], opts Options,
 	DQToAlias, AliasToDQ map[string]string) func(c *cobra.Command, _ []string) error {
 	return func(c *cobra.Command, _ []string) error {
+		// this runs prior to validation as:
+		// 1) show-columns skips validation
+		// 2) scaffoldlist validation should fire first
+		showColumns, columns, outFile, format, inv := getFlags(c.Flags(), DQToAlias, AliasToDQ, opts.Pretty != nil)
+		if inv != "" {
+			return errors.New(inv)
+		} else if showColumns {
+			fmt.Fprintln(c.OutOrStdout(), ShowColumns(DQToAlias))
+			return nil
+		}
+		if outFile != nil {
+			defer outFile.Close()
+		}
+
 		// run custom validation
 		if opts.ValidateArgs != nil {
 			if invalid, err := opts.ValidateArgs(c.Flags()); err != nil {
@@ -266,51 +298,16 @@ func generateRunE[dataStruct_t any](
 			}
 		}
 
-		// check for --show-columns
-		if sc, err := c.Flags().GetBool(ft.ShowColumns.Name()); err != nil {
-			clilog.GetFlag(err)
-			return err
-		} else if sc {
-			fmt.Fprintln(c.OutOrStdout(), ShowColumns(DQToAlias))
-			return nil
-		}
-
-		var (
-			noInteractive bool
-			outFile       *os.File
-			format        outputFormat
-			columns       []string
-		)
-		// gather flags and set up variables required for listOutput
-		var err error
-		noInteractive, err = c.Flags().GetBool(ft.NoInteractive.Name())
-		if err != nil {
-			clilog.GetFlag(err)
-		}
-		outFile, err = initOutFile(c.Flags())
-		if err != nil {
-			return err
-		} else if outFile != nil {
-			defer outFile.Close()
-			// ensure color is disabled.
-			stylesheet.Cur = stylesheet.Plain()
-		}
-		columns, err = getColumns(c.Flags(), DQToAlias, AliasToDQ)
-		if err != nil {
-			return err
-		}
-		format = determineFormat(c.Flags(), opts.Pretty != nil)
-
 		// execute the actual list and format call
-		s, err := listOutput(c.Flags(), format, columns, dataFn, opts.Pretty, DQToAlias)
+		s, err := listOutput(c.Flags(), format, columns, dataFn, opts.Pretty, DQToAlias, opts.Omit)
 		if err != nil {
 			return err
 		}
 
 		// if we generated no output, make that explicit to the user via the empty message
-		// (unless we are in no-interactive mode, where our output is likely to be piped, or writing to a file).
+		// (unless we are in no-interactive mode (where our output is likely to be piped) or writing to a file).
 		if s == "" {
-			if outFile == nil && !noInteractive {
+			if outFile == nil && !state.Interactive() {
 				fmt.Fprintln(c.OutOrStdout(), opts.EmptyMessage)
 			}
 			return nil

--- a/gwcli/utilities/scaffold/scaffoldlist/list_test.go
+++ b/gwcli/utilities/scaffold/scaffoldlist/list_test.go
@@ -4,14 +4,19 @@ package scaffoldlist_test
 
 import (
 	"maps"
+	"os"
+	"path"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/Pallinder/go-randomdata"
 	"github.com/gravwell/gravwell/v4/client/types"
 	"github.com/gravwell/gravwell/v4/gwcli/clilog"
+	"github.com/gravwell/gravwell/v4/gwcli/internal/state"
 	"github.com/gravwell/gravwell/v4/gwcli/internal/testsupport"
 	ft "github.com/gravwell/gravwell/v4/gwcli/stylesheet/flagtext"
 	"github.com/gravwell/gravwell/v4/gwcli/stylesheet/phrases"
@@ -20,6 +25,7 @@ import (
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/uniques"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {
@@ -68,7 +74,7 @@ func TestShowColumns_AllFlag(t *testing.T) {
 	})
 
 	// now test it from the outside
-	t.Run("via --"+ft.ShowColumns.Name(), func(t *testing.T) {
+	t.Run("via --"+scaffoldlist.FlagNameSelectColumns, func(t *testing.T) {
 		data := []nuclearThrone{} // the data itself doesn't matter
 
 		aliased := maps.Clone(ntDQs)
@@ -76,13 +82,13 @@ func TestShowColumns_AllFlag(t *testing.T) {
 		aliased["Export.YV.YungCuz"] = "YC"
 
 		pair := scaffoldlist.NewListAction("test function", "this is a test function",
-			nuclearThrone{}, func(fs *pflag.FlagSet) ([]nuclearThrone, error) {
+			nuclearThrone{}, func(fs *pflag.FlagSet, _ scaffoldlist.DataParameters) ([]nuclearThrone, error) {
 				return data, nil
 			},
 			maps.Clone(aliased), scaffoldlist.Options{})
 
 		uniques.AttachPersistentFlags(pair.Action)
-		testsupport.CheckSetArgs(t, pair.Model.SetArgs, pair.Action.Flags(), []string{"--" + ft.ShowColumns.Name()}, 80, 80,
+		testsupport.CheckSetArgs(t, pair.Model.SetArgs, pair.Action.Flags(), []string{"--" + scaffoldlist.FlagNameShowColumns}, 80, 80,
 			false, nil, false)
 		// all is returned from a tea.Cmd from Update
 		cmd := pair.Model.Update(nil)
@@ -171,13 +177,19 @@ func TestMotherCycle(t *testing.T) {
 				"(3.14-2.4i),plant2",
 		},
 		{"default pretty",
-			scaffoldlist.Options{Pretty: func(DQColumns []string, DQToAlias map[string]string) (string, error) { return "pretty", nil }},
+			scaffoldlist.Options{
+				Pretty: func(fs *pflag.FlagSet, DQColumns []string, DQToAlias map[string]string, params scaffoldlist.DataParameters) (string, error) {
+					return "pretty", nil
+				}},
 			[]string{},
 			false, false,
 			"pretty",
 		},
 		{"pretty defined, but --table given",
-			scaffoldlist.Options{Pretty: func(DQColumns []string, DQToAlias map[string]string) (string, error) { return "pretty", nil }},
+			scaffoldlist.Options{
+				Pretty: func(fs *pflag.FlagSet, DQColumns []string, DQToAlias map[string]string, params scaffoldlist.DataParameters) (string, error) {
+					return "pretty", nil
+				}},
 			[]string{"--table"},
 			false, false,
 			"┌───────────────┬───────────────┬───────────────┬───────────────┐\n" +
@@ -190,7 +202,9 @@ func TestMotherCycle(t *testing.T) {
 		},
 		{"as JSON with excluded defaults and pretty defined",
 			scaffoldlist.Options{
-				Pretty:                         func(DQColumns []string, DQToAlias map[string]string) (string, error) { return "pretty", nil },
+				Pretty: func(fs *pflag.FlagSet, DQColumns []string, DQToAlias map[string]string, params scaffoldlist.DataParameters) (string, error) {
+					return "pretty", nil
+				},
 				DefaultColumnsFromExcludeRegex: []*regexp.Regexp{regexp.MustCompile("Plant")},
 			},
 			[]string{"--json"},
@@ -251,7 +265,7 @@ func TestMotherCycle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pair := scaffoldlist.NewListAction("test function", "this is a test function",
-				nuclearThrone{}, func(fs *pflag.FlagSet) ([]nuclearThrone, error) {
+				nuclearThrone{}, func(fs *pflag.FlagSet, _ scaffoldlist.DataParameters) ([]nuclearThrone, error) {
 					return data, nil
 				},
 				maps.Clone(aliased),
@@ -371,7 +385,7 @@ func TestNonInteractive(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pair := scaffoldlist.NewListAction("test function", "this is a test function",
-				types.Flow{}, func(fs *pflag.FlagSet) ([]types.Flow, error) {
+				types.Flow{}, func(fs *pflag.FlagSet, _ scaffoldlist.DataParameters) ([]types.Flow, error) {
 					// generate some garbage data
 					ms := make([]types.Flow, 5)
 					for i := range 5 {
@@ -407,6 +421,74 @@ func TestNonInteractive(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("write to output file", func(t *testing.T) {
+		outPath := path.Join(t.ArtifactDir(), "output"+randomdata.Digits(6)+".txt")
+		pair := scaffoldlist.NewListAction("test function", "this is a test function",
+			types.Flow{}, func(fs *pflag.FlagSet, _ scaffoldlist.DataParameters) ([]types.Flow, error) {
+				// generate some garbage data
+				ms := make([]types.Flow, 5)
+				for i := range 5 {
+					iStr := strconv.FormatInt(int64(i), 10)
+					ms[i] = types.Flow{
+						CommonFields: types.CommonFields{
+							Name:      "Name_" + iStr,
+							CreatedAt: time.Unix(5, 0).UTC(),
+							ID:        iStr,
+							Readers:   types.ACL{GIDs: []int32{1, 100}, Global: true},
+						},
+						Flow: "Flow_" + iStr}
+				}
+
+				return ms, nil
+			},
+			map[string]string{"CommonFields.Name": "FlowName"},
+			scaffoldlist.Options{})
+		pair.Action.SetArgs([]string{"--csv", "-o=" + outPath, "--columns=ID,Disabled,Schedule"})
+		assert.Nil(t, pair.Action.Execute())
+		gotContent, err := os.ReadFile(outPath)
+		require.Nil(t, err)
+		assert.Equal(t, string(gotContent), `ID,Disabled,Schedule
+0,false,
+1,false,
+2,false,
+3,false,
+4,false,
+`)
+	})
+}
+
+func TestMutualExclusion(t *testing.T) {
+	t.Run("--"+scaffoldlist.FlagNameSelectAllColumns+"& --"+scaffoldlist.FlagNameSelectColumns, func(t *testing.T) {
+		pair := scaffoldlist.NewListAction("test function", "this is a test function",
+			types.Flow{}, func(fs *pflag.FlagSet, _ scaffoldlist.DataParameters) ([]types.Flow, error) {
+				return nil, nil
+			},
+			map[string]string{"CommonFields.Name": "FlowName"},
+			scaffoldlist.Options{})
+		pair.Action.SetArgs([]string{"--" + scaffoldlist.FlagNameSelectAllColumns, "--" + scaffoldlist.FlagNameSelectColumns + "=Rogue"})
+		err := pair.Action.Execute()
+		assert.ErrorContains(t, err, "mutually exclusive")
+	})
+	t.Run("options: DefaultColumns & DefaultColumnsFromExcludeRegex", func(t *testing.T) {
+		recovered := false
+		defer func() {
+			assert.True(t, recovered)
+		}()
+		defer func() {
+			recover()
+			recovered = true
+		}()
+		scaffoldlist.NewListAction("test function", "this is a test function",
+			types.Flow{}, func(fs *pflag.FlagSet, _ scaffoldlist.DataParameters) ([]types.Flow, error) {
+				return nil, nil
+			},
+			map[string]string{"CommonFields.Name": "FlowName"},
+			scaffoldlist.Options{
+				DefaultColumns:                 []string{"a", "b", "c"},
+				DefaultColumnsFromExcludeRegex: []*regexp.Regexp{regexp.MustCompile("d")},
+			})
+	})
 }
 
 // Collection of tests to check that the "CommonFields." and "AutomationCommonFields." prefixes are not visible to a user.
@@ -487,7 +569,7 @@ func TestAutoAliasPrefix(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pair := scaffoldlist.NewListAction("test function", "this is a test function",
-				types.Flow{}, func(fs *pflag.FlagSet) ([]types.Flow, error) {
+				types.Flow{}, func(fs *pflag.FlagSet, _ scaffoldlist.DataParameters) ([]types.Flow, error) {
 					// generate some garbage data
 					ms := make([]types.Flow, 5)
 					for i := range 5 {
@@ -526,7 +608,7 @@ func TestAutoAliasPrefix(t *testing.T) {
 func TestHelpGeneration(t *testing.T) {
 	// generate help text we can parse
 	pair := scaffoldlist.NewListAction("test function", "this is a test function",
-		types.Macro{}, func(fs *pflag.FlagSet) ([]types.Macro, error) {
+		types.Macro{}, func(fs *pflag.FlagSet, _ scaffoldlist.DataParameters) ([]types.Macro, error) {
 			// generate some garbage data
 			ms := make([]types.Macro, 5)
 			for i := range 5 {
@@ -562,20 +644,16 @@ func TestHelpGeneration(t *testing.T) {
 	}
 
 	t.Run("default columns are shown inline with --columns", func(t *testing.T) {
-		// identify the end of flag usage, as default values should be listed directly after
-		usageLines := strings.Split(ft.SelectColumns.Usage(), "\n")
-		_, after, found := strings.Cut(help, usageLines[len(usageLines)-1])
-		if !found {
-			t.Fatal("failed to find the end of the usage line")
-		}
-		// we should find defaults appended to this line
+		want := []string{"ItemID", "Name", "Expansion"} // should be aliases, including auto-aliasing for "CommonFields."
 
-		wantDefaultColumns := "ItemID,Name,Expansion" // should be aliases, including auto-aliasing for "CommonFields."
-		if !strings.Contains(after, wantDefaultColumns) {
-			t.Fatalf("default columns are not properly represented."+
-				"Substring \"%v\" not found in default columns chunk \"%v\"",
-				wantDefaultColumns, after)
-		}
+		rgx := regexp.MustCompile(`\(default\s\[(.*)\]`)
+		capGroups := rgx.FindStringSubmatch(help)
+		t.Log("capture groups: ", capGroups)
+		require.Len(t, capGroups, 2) // 0 should be entire expression, 1 should be cap
+		s := capGroups[1]
+		require.NotEmpty(t, s)
+		got := strings.Split(s, ",")
+		assert.True(t, slices.Equal(want, got), "want:%v\ngot:%v", want, got)
 	})
 	t.Run("custom example shown", func(t *testing.T) {
 		// find the "example" line
@@ -586,6 +664,54 @@ func TestHelpGeneration(t *testing.T) {
 		exampleLine, _, _ := strings.Cut(after, "\n")
 		if !strings.Contains(exampleLine, "use tkn1 tkn2 --csv") {
 			t.Fatalf("custom example text not found in example line: %v", exampleLine)
+		}
+	})
+	t.Run("omitting flags removes them from help text", func(t *testing.T) {
+		tests := []struct {
+			name string
+			omit scaffold.OmitFlags
+		}{
+			{"no omissions includes all", scaffold.OmitFlags{}},
+			{"omit --all", scaffold.OmitFlags{AllData: true}},
+			{"omit --limit", scaffold.OmitFlags{Limit: true}},
+			{"omit --all and --include-deleted", scaffold.OmitFlags{AllData: true, IncludeDeleted: true}},
+			{"omit everything", scaffold.OmitFlags{Everything: true}},
+		}
+		var sbOut, sbErr strings.Builder
+		// the "--all" prefix is likely be used in multiple ways, so we can't just for contents
+		rgxAllData := regexp.MustCompile(`\s+--all\s+`)
+		for _, tt := range tests {
+			sbOut.Reset()
+			sbErr.Reset()
+			t.Run(tt.name, func(t *testing.T) {
+				pair := scaffoldlist.NewListAction("test", "test", nuclearThrone{},
+					func(addtlFlags *pflag.FlagSet, params scaffoldlist.DataParameters) ([]nuclearThrone, error) {
+						return []nuclearThrone{}, nil
+					},
+					nil,
+					scaffoldlist.Options{Omit: tt.omit})
+				pair.Action.SetOut(&sbOut)
+				pair.Action.SetErr(&sbErr)
+				uniques.Help(pair.Action, nil)
+				help := sbOut.String()
+
+				if tt.omit.AllData || tt.omit.Everything {
+					assert.NotRegexp(t, rgxAllData, help)
+				} else {
+					assert.Regexp(t, rgxAllData, help)
+				}
+				if tt.omit.IncludeDeleted || tt.omit.Everything {
+					assert.NotContains(t, help, "--"+ft.IncludeDeleted.Name())
+				} else {
+					assert.Contains(t, help, "--"+ft.IncludeDeleted.Name())
+				}
+
+				if tt.omit.Limit || tt.omit.Everything {
+					assert.NotContains(t, help, "--"+scaffold.FlagNameLimit)
+				} else {
+					assert.Contains(t, help, "--"+scaffold.FlagNameLimit)
+				}
+			})
 		}
 	})
 }
@@ -603,7 +729,7 @@ func TestEmptyMessage(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				pair := scaffoldlist.NewListAction("test function", "this is a test function",
-					types.Flow{}, func(fs *pflag.FlagSet) ([]types.Flow, error) {
+					types.Flow{}, func(fs *pflag.FlagSet, _ scaffoldlist.DataParameters) ([]types.Flow, error) {
 						// always return nil
 						return nil, nil
 					},
@@ -630,9 +756,14 @@ func TestEmptyMessage(t *testing.T) {
 			{"override set with -x", scaffoldlist.Options{EmptyMessage: "override set"}, []string{"-x"}, ""},
 		}
 		for _, tt := range tests {
+			state.SetInteractive(false)
 			t.Run(tt.name, func(t *testing.T) {
+				if slices.Contains(tt.setArgs, "-x") {
+					state.SetInteractive(true)
+				}
+
 				pair := scaffoldlist.NewListAction("test function", "this is a test function",
-					types.Flow{}, func(fs *pflag.FlagSet) ([]types.Flow, error) {
+					types.Flow{}, func(fs *pflag.FlagSet, _ scaffoldlist.DataParameters) ([]types.Flow, error) {
 						// always return nil
 						return nil, nil
 					},
@@ -654,4 +785,223 @@ func TestEmptyMessage(t *testing.T) {
 		}
 	})
 
+}
+
+func TestOmitFlags(t *testing.T) {
+	t.Run("omitted flags errors if invoked", func(t *testing.T) {
+		t.Run("non-interactive", func(t *testing.T) {
+			tests := []struct {
+				name    string
+				omit    scaffold.OmitFlags
+				setArgs []string
+
+				expectError    bool
+				expectedParams scaffoldlist.DataParameters // only checked if !error
+			}{
+				{"all flags can be set with no omissions",
+					scaffold.OmitFlags{},
+					[]string{
+						"--" + scaffold.FlagNameAllData, "--" + ft.IncludeDeleted.Name(),
+						"--" + scaffoldlist.FlagNameSelectColumns + "=Rogue", // include an unrelated flag just for better coverage
+					},
+					false,
+					scaffoldlist.DataParameters{
+						&types.QueryOptions{
+							IncludeDeleted: true,
+							AdminMode:      true,
+						},
+					},
+				},
+				{"--all cannot be set when omitted",
+					scaffold.OmitFlags{AllData: true},
+					[]string{
+						"--" + scaffold.FlagNameAllData,
+						"--" + scaffoldlist.FlagNameSelectColumns + "=Rogue", // include an unrelated flag just for better coverage
+					},
+					true,
+					scaffoldlist.DataParameters{
+						&types.QueryOptions{},
+					},
+				},
+				{"--all cannot be set when omit.Everything",
+					scaffold.OmitFlags{Everything: true},
+					[]string{
+						"--" + scaffold.FlagNameAllData,
+						"--" + scaffoldlist.FlagNameSelectColumns + "=Rogue", // include an unrelated flag just for better coverage
+					},
+					true,
+					scaffoldlist.DataParameters{
+						&types.QueryOptions{},
+					},
+				},
+				{"--include-deleted cannot be set when omitted",
+					scaffold.OmitFlags{IncludeDeleted: true},
+					[]string{
+						"--" + ft.IncludeDeleted.Name(),
+						"--" + scaffoldlist.FlagNameSelectColumns + "=Rogue", // include an unrelated flag just for better coverage
+					},
+					true,
+					scaffoldlist.DataParameters{
+						&types.QueryOptions{},
+					},
+				},
+				{"--include-deleted cannot be set when omit.Everything",
+					scaffold.OmitFlags{Everything: true},
+					[]string{
+						"--" + ft.IncludeDeleted.Name(),
+						"--" + scaffoldlist.FlagNameSelectColumns + "=Rogue", // include an unrelated flag just for better coverage
+					},
+					true,
+					scaffoldlist.DataParameters{
+						&types.QueryOptions{},
+					},
+				},
+				{"--limit can be set when omitted",
+					scaffold.OmitFlags{},
+					[]string{
+						"--" + scaffold.FlagNameLimit + "=8",
+						"--" + scaffoldlist.FlagNameSelectColumns + "=Rogue", // include an unrelated flag just for better coverage
+					},
+					false,
+					scaffoldlist.DataParameters{
+						&types.QueryOptions{Limit: 8},
+					},
+				},
+				{"--limit cannot be set when omitted",
+					scaffold.OmitFlags{Limit: true},
+					[]string{
+						"--" + scaffold.FlagNameLimit,
+						"--" + scaffoldlist.FlagNameSelectColumns + "=Rogue", // include an unrelated flag just for better coverage
+					},
+					true,
+					scaffoldlist.DataParameters{
+						&types.QueryOptions{},
+					},
+				},
+			}
+			var sbOut, sbErr strings.Builder
+			for _, tt := range tests {
+				sbOut.Reset()
+				sbErr.Reset()
+				t.Run(tt.name, func(t *testing.T) {
+					var gotParams scaffoldlist.DataParameters
+					pair := scaffoldlist.NewListAction("test", "test", nuclearThrone{},
+						func(addtlFlags *pflag.FlagSet, params scaffoldlist.DataParameters) ([]nuclearThrone, error) {
+							gotParams = params
+							return []nuclearThrone{}, nil
+						},
+						nil,
+						scaffoldlist.Options{Omit: tt.omit})
+					pair.Action.SetOut(&sbOut)
+					pair.Action.SetErr(&sbErr)
+					pair.Action.SetArgs(tt.setArgs)
+					err := pair.Action.Execute()
+					require.Equal(t, tt.expectError, err != nil, err)
+					if err != nil { // nothing should be set if we failed
+						require.Zero(t, gotParams)
+						return
+					}
+					require.Equal(t, tt.expectedParams, gotParams)
+				})
+
+			}
+		})
+	})
+
+	t.Run("omitted flags errors if invoked", func(t *testing.T) {
+		t.Run("non-interactive", func(t *testing.T) {
+			tests := []struct {
+				name    string
+				omit    scaffold.OmitFlags
+				setArgs []string
+
+				expectSetArgsInv, expectSetArgsError bool
+				expectedParams                       scaffoldlist.DataParameters // only checked if !error
+			}{
+				{"all flags can be set with no omissions",
+					scaffold.OmitFlags{},
+					[]string{
+						"--" + scaffold.FlagNameAllData, "--" + ft.IncludeDeleted.Name(),
+						"--" + scaffoldlist.FlagNameSelectColumns + "=Rogue", // include an unrelated flag just for better coverage
+					},
+					false, false,
+					scaffoldlist.DataParameters{
+						&types.QueryOptions{
+							IncludeDeleted: true,
+							AdminMode:      true,
+						},
+					},
+				},
+				{"--all cannot be set when omitted",
+					scaffold.OmitFlags{AllData: true},
+					[]string{
+						"--" + scaffold.FlagNameAllData,
+						"--" + scaffoldlist.FlagNameSelectColumns + "=Rogue", // include an unrelated flag just for better coverage
+					},
+					true, false,
+					scaffoldlist.DataParameters{
+						&types.QueryOptions{},
+					},
+				},
+				{"--all cannot be set when omit.Everything",
+					scaffold.OmitFlags{Everything: true},
+					[]string{
+						"--" + scaffold.FlagNameAllData,
+						"--" + scaffoldlist.FlagNameSelectColumns + "=Rogue", // include an unrelated flag just for better coverage
+					},
+					true, false,
+					scaffoldlist.DataParameters{
+						&types.QueryOptions{},
+					},
+				},
+				{"--include-deleted cannot be set when omitted",
+					scaffold.OmitFlags{IncludeDeleted: true},
+					[]string{
+						"--" + ft.IncludeDeleted.Name(),
+						"--" + scaffoldlist.FlagNameSelectColumns + "=Rogue", // include an unrelated flag just for better coverage
+					},
+					true, false,
+					scaffoldlist.DataParameters{
+						&types.QueryOptions{},
+					},
+				},
+				{"--include-deleted cannot be set when omit.Everything",
+					scaffold.OmitFlags{Everything: true},
+					[]string{
+						"--" + ft.IncludeDeleted.Name(),
+						"--" + scaffoldlist.FlagNameSelectColumns + "=Rogue", // include an unrelated flag just for better coverage
+					},
+					true, false,
+					scaffoldlist.DataParameters{
+						&types.QueryOptions{},
+					},
+				},
+			}
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					var gotParams scaffoldlist.DataParameters
+					pair := scaffoldlist.NewListAction("test", "test", nuclearThrone{},
+						func(addtlFlags *pflag.FlagSet, params scaffoldlist.DataParameters) ([]nuclearThrone, error) {
+							gotParams = params
+							return []nuclearThrone{}, nil
+						},
+						nil,
+						scaffoldlist.Options{Omit: tt.omit})
+
+					uniques.AttachPersistentFlags(pair.Action)
+					inv, _, err := pair.Model.SetArgs(pair.Action.Flags(), tt.setArgs, 80, 60)
+					require.Equal(t, tt.expectSetArgsError, (err != nil), err)
+					require.Equal(t, tt.expectSetArgsInv, (inv != ""), inv)
+
+					if tt.expectSetArgsError || tt.expectSetArgsInv {
+						return
+					}
+
+					pair.Model.Update(nil)
+					require.Equal(t, tt.expectedParams, gotParams)
+				})
+			}
+
+		})
+	})
 }

--- a/gwcli/utilities/scaffold/scaffoldlist/options.go
+++ b/gwcli/utilities/scaffold/scaffoldlist/options.go
@@ -9,9 +9,17 @@
 package scaffoldlist
 
 import (
+	"fmt"
+	"maps"
+	"os"
 	"regexp"
+	"slices"
 
+	"github.com/gravwell/gravwell/v4/client/types"
+	"github.com/gravwell/gravwell/v4/gwcli/clilog"
+	ft "github.com/gravwell/gravwell/v4/gwcli/stylesheet/flagtext"
 	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold"
+	"github.com/gravwell/gravwell/v4/ingest/log"
 	"github.com/spf13/pflag"
 )
 
@@ -54,4 +62,113 @@ type Options struct {
 	// The message that will be printed if the listFunc returns no data (and no error).
 	// Uses DefaultEmptyMessage if unset.
 	EmptyMessage string
+
+	// Omit allows disabling flags for this action, causing their values to always default to false/nil and the flags themselves to not be shown in help text.
+	Omit scaffold.OmitFlags
+}
+
+// buildFlagSet returns a flagset composed of the default list flags,
+// additional flags defined for this action,
+// and --pretty if a prettyFunc was defined.
+//
+// defaultColumnsAliased are the columns to display as defaults alongside --columns.
+// They are expected to have aliases applied and will not be coerced.
+func buildFlagSet(prettyDefined bool, defaultColumnsAliased []string, omit scaffold.OmitFlags) *pflag.FlagSet {
+	fs := pflag.FlagSet{}
+	ft.CSV.Register(&fs)
+	ft.JSON.Register(&fs)
+	ft.Table.Register(&fs)
+
+	fs.StringSliceP(FlagNameSelectColumns, "", defaultColumnsAliased,
+		"Comma-separated list of columns to include in the results.\n"+
+			"Use --"+FlagNameShowColumns+" to see the full list of columns.\n"+
+			"Mutually exclusive with --"+FlagNameSelectAllColumns)
+
+	fs.Bool(FlagNameShowColumns, false, "Display available columns (for use with --columns) and exit.\n"+
+		"Causes all other flags to be ignored")
+
+	ft.Output.Register(&fs)
+	ft.Append.Register(&fs)
+	fs.Bool(FlagNameSelectAllColumns, false,
+		"Displays data from all columns, ignoring the default column set.\n"+
+			"Mutually exclusive with --"+FlagNameSelectColumns)
+
+	scaffold.InstallQueryOptionsFlags(&fs, omit)
+
+	// if prettyFunc was defined, bolt on pretty
+	if prettyDefined {
+		fs.Bool("pretty", false, "Display results as prettified text.\n"+
+			"Takes precedence over other format flags.\n"+
+			"May or may not respect columns, default or selected")
+	}
+
+	return &fs
+}
+
+// fetches values from the flagset that scaffoldlist uses directly (as opposed to getQueryOptions()).
+func getFlags(fs *pflag.FlagSet, DQToAlias, AliasToDQ map[string]string, prettyDefined bool) (
+	showColumns bool, columns []string, outFile *os.File, format outputFormat, invalid string,
+) {
+	show, err := fs.GetBool(FlagNameShowColumns)
+	clilog.GetFlag(err)
+	if show { // job's done
+		return true, nil, nil, 0, ""
+	}
+	if outFile, err = initOutFile(fs); err != nil {
+		return true, nil, nil, 0, err.Error()
+	}
+	if columns, invalid = getColumns(fs, DQToAlias, AliasToDQ); invalid != "" {
+		return true, nil, nil, 0, invalid
+	}
+	format = determineFormat(fs, prettyDefined)
+	return
+}
+
+// getColumns figures out which columns this request should receive and returns the DQ version of each.
+//
+// In order of priority:
+//
+//  1. all columns (if --all), sorted alphabetically
+//
+//  2. selected columns (if --columns=<>), retaining given order
+//
+//  3. default columns, sorted alphabetically
+func getColumns(fs *pflag.FlagSet, DQToAlias, AliasToDQ map[string]string) (_ []string, invalid string) {
+	selectAll, err := fs.GetBool(FlagNameSelectAllColumns)
+	clilog.GetFlag(err)
+	selectColumns, err := fs.GetStringSlice(FlagNameSelectColumns) // this will return either the user-spec'd columns or the default columns
+	clilog.GetFlag(err)
+
+	// MX check
+	if selectAll && fs.Changed(FlagNameSelectColumns) {
+		return nil, ft.ErrMutuallyExclusive(FlagNameSelectAllColumns, FlagNameSelectColumns).Error()
+	}
+
+	// collect columns
+	if selectAll {
+		// normalize all column names
+		normal, unknown := normalizeToDQ(sortColumns(slices.Collect(maps.Keys(DQToAlias))), DQToAlias, AliasToDQ)
+		// we should never get unknown columns when giving the full set; this is a developer error
+		if len(unknown) > 0 {
+			clilog.Writer.Error("got unknown columns while normalizing the full column set.",
+				log.KV("unknown columns", unknown),
+				scaffold.IdentifyCaller())
+			return nil, clilog.ErrInternal{}.Error() // this isn't technically an invalid but its also super unlikely to ever happen so...
+		}
+		return normal, ""
+	}
+
+	normalized, unknown := normalizeToDQ(selectColumns, DQToAlias, AliasToDQ)
+	if len(unknown) > 0 {
+		return nil, fmt.Sprintf("unknown columns: %v", unknown)
+	}
+	return normalized, ""
+}
+
+// DataParameters is the set of information that a user may provide the action that is unhandled by scaffoldlist itself.
+//
+// For example, --show-columns will not be included as it is handled automatically,
+// but --all will be as it must be handled by the ListDataFunc itself.
+type DataParameters struct {
+	QueryOpts *types.QueryOptions
 }

--- a/gwcli/utilities/scaffold/scaffoldlist/shared.go
+++ b/gwcli/utilities/scaffold/scaffoldlist/shared.go
@@ -19,9 +19,8 @@ import (
 	"github.com/gravwell/gravwell/v4/gwcli/clilog"
 	"github.com/gravwell/gravwell/v4/gwcli/stylesheet"
 	ft "github.com/gravwell/gravwell/v4/gwcli/stylesheet/flagtext"
-	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold"
-	"github.com/gravwell/gravwell/v4/ingest/log"
 	"github.com/gravwell/gravwell/v4/utils/weave"
+	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold"
 	"github.com/spf13/pflag"
 )
 
@@ -84,17 +83,20 @@ func listOutput[struct_t any](
 	dataFunc ListDataFunc[struct_t],
 	prettyFunc PrettyPrinterFunc,
 	DQToAlias map[string]string,
+	omit scaffold.OmitFlags,
 ) (string, error) {
+	params := DataParameters{QueryOpts: scaffold.GetQueryOptions(fs, omit)}
+
 	// hand off control to pretty
 	if format == formatPretty {
 		if prettyFunc == nil {
 			return "", errors.New("format is pretty, but prettyFunc is nil")
 		}
-		return prettyFunc(dqColumns, DQToAlias)
+		return prettyFunc(fs, dqColumns, DQToAlias, params)
 	}
 
 	// massage the data for weave
-	data, err := dataFunc(fs)
+	data, err := dataFunc(fs, params)
 	if err != nil {
 		return "", err
 	}
@@ -124,40 +126,6 @@ func listOutput[struct_t any](
 	return toRet, err
 }
 
-// buildFlagSet returns a flagset composed of the default list flags,
-// additional flags defined for this action,
-// and --pretty if a prettyFunc was defined.
-//
-// defaultColumnsAliased are the columns to display as defaults alongside --columns.
-// They are expected to have aliases applied and will not be coerced.
-func buildFlagSet(prettyDefined bool, defaultColumnsAliased []string) *pflag.FlagSet {
-	fs := pflag.FlagSet{}
-	ft.CSV.Register(&fs)
-	ft.JSON.Register(&fs)
-	ft.Table.Register(&fs)
-	fs.StringSliceP( // manually register string slice so we can set a default
-		ft.SelectColumns.Name(),
-		ft.SelectColumns.Shorthand(),
-		defaultColumnsAliased,
-		ft.SelectColumns.Usage())
-
-	ft.ShowColumns.Register(&fs)
-
-	ft.Output.Register(&fs)
-	ft.Append.Register(&fs)
-	ft.AllColumns.Register(&fs)
-
-	// if prettyFunc was defined, bolt on pretty
-	if prettyDefined {
-		fs.Bool("pretty", false, "display results as prettified text.\n"+
-			"Takes precedence over other format flags.\n"+
-			"May or may not respect columns, default or selected via --"+ft.SelectColumns.Name()+".")
-	}
-
-	return &fs
-
-}
-
 // Opens a file, per the given --output and --append flags in the flagset, and returns its handle.
 // Returns nil if the flags do not call for a file.
 func initOutFile(fs *pflag.FlagSet) (*os.File, error) {
@@ -171,9 +139,9 @@ func initOutFile(fs *pflag.FlagSet) (*os.File, error) {
 		return nil, nil
 	}
 	var flags = os.O_CREATE | os.O_WRONLY
-	if append, err := fs.GetBool(ft.Append.Name()); err != nil {
-		return nil, err
-	} else if append {
+	append, err := fs.GetBool(ft.Append.Name())
+	clilog.GetFlag(err)
+	if append {
 		flags |= os.O_APPEND
 	} else {
 		flags |= os.O_TRUNC
@@ -203,44 +171,6 @@ func normalizeToDQ(columns []string, DQToAlias map[string]string, AliasToDQ map[
 		unknown = append(unknown, col)
 	}
 	return normalized, unknown
-}
-
-// getColumns figures out which columns this request should receive and returns the DQ version of each.
-//
-// In order of priority:
-//
-//  1. all columns (if --all), sorted alphabetically
-//
-//  2. selected columns (if --columns=<>), retaining given order
-//
-//  3. default columns, sorted alphabetically
-//
-// ! default columns are *not* normalized; they are expected to already be DQ'd.
-func getColumns(fs *pflag.FlagSet, DQToAlias, AliasToDQ map[string]string) ([]string, error) {
-	if all, err := fs.GetBool(ft.AllColumns.Name()); err != nil {
-		return nil, clilog.GetFlag(err) // does not return the actual 'use' of the action, but I don't want to include it as a param just for this super rare case
-	} else if all {
-		// normalize all
-		normal, unknown := normalizeToDQ(sortColumns(slices.Collect(maps.Keys(DQToAlias))), DQToAlias, AliasToDQ)
-		// we should never get unknown columns when giving the full set; this is a developer error
-		if len(unknown) > 0 {
-			clilog.Writer.Error("got unknown columns while normalizing the full column set.",
-				log.KV("unknown columns", unknown),
-				scaffold.IdentifyCaller())
-			return nil, clilog.ErrInternal{}
-		}
-		return normal, nil
-	}
-	// even if --columns was not specified, we can use it to fetch defaults
-	selectedCols, err := fs.GetStringSlice(ft.SelectColumns.Name())
-	if err != nil {
-		return nil, clilog.GetFlag(err) // does not return the actual 'use' of the action, but I don't want to include it as a param just for this super rare case
-	}
-	normalized, unknown := normalizeToDQ(selectedCols, DQToAlias, AliasToDQ)
-	if len(unknown) > 0 {
-		return nil, fmt.Errorf("--%s has unknown columns/aliases: %v", ft.SelectColumns.Name(), unknown)
-	}
-	return normalized, nil
 }
 
 // The sorting mechanism list uses when an order is not specified (ex: --columns is not given).

--- a/gwcli/utilities/scaffold/scaffoldlist/shared_internal_test.go
+++ b/gwcli/utilities/scaffold/scaffoldlist/shared_internal_test.go
@@ -23,10 +23,11 @@ import (
 	"github.com/gravwell/gravwell/v4/gwcli/clilog"
 	"github.com/gravwell/gravwell/v4/gwcli/internal/testsupport"
 	ft "github.com/gravwell/gravwell/v4/gwcli/stylesheet/flagtext"
+	"github.com/gravwell/gravwell/v4/gwcli/utilities/scaffold"
 	"github.com/spf13/pflag"
 )
 
-// Testing for unexported functions in shared, as many of these are critical.
+// While most testing should be done in the standalone Testing for unexported functions, as many of these are critical.
 
 func Test_initOutFile(t *testing.T) {
 	tDir := t.TempDir()
@@ -40,7 +41,7 @@ func Test_initOutFile(t *testing.T) {
 		}
 	})
 	t.Run("whitespace path", func(t *testing.T) {
-		fs := buildFlagSet(false, nil)
+		fs := buildFlagSet(false, nil, scaffold.OmitFlags{})
 		fs.Parse([]string{"-o", ""})
 		if f, err := initOutFile(fs); err != nil {
 			t.Error("unexpected error", testsupport.ExpectedActual(nil, err))
@@ -49,7 +50,7 @@ func Test_initOutFile(t *testing.T) {
 		}
 	})
 	t.Run("whitespace path with pretty defined", func(t *testing.T) {
-		fs := buildFlagSet(true, nil)
+		fs := buildFlagSet(true, nil, scaffold.OmitFlags{})
 		fs.Parse([]string{"-o", ""})
 		if f, err := initOutFile(fs); err != nil {
 			t.Error("unexpected error", testsupport.ExpectedActual(nil, err))
@@ -69,7 +70,7 @@ func Test_initOutFile(t *testing.T) {
 		orig.Sync()
 		orig.Close()
 
-		fs := buildFlagSet(false, nil)
+		fs := buildFlagSet(false, nil, scaffold.OmitFlags{})
 		fs.Parse([]string{"-o", path})
 		if f, err := initOutFile(fs); err != nil {
 			t.Error("unexpected error", testsupport.ExpectedActual(nil, err))
@@ -90,7 +91,7 @@ func TestInvertedMaps(t *testing.T) {
 		t.Fatal("failed to spawn logger:", err)
 	}
 	pair := NewListAction("test", "test", types.Flow{},
-		func(fs *pflag.FlagSet) ([]types.Flow, error) {
+		func(fs *pflag.FlagSet, _ DataParameters) ([]types.Flow, error) {
 			return nil, nil
 		},
 		map[string]string{"CommonFields.Can.Delete": "DeleteCap", "AutomationCommonFields.Timezone": "TZ"},
@@ -159,7 +160,7 @@ func Test_determineFormat(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// generate flagset
-			fs := buildFlagSet(tt.prettyDefined, nil)
+			fs := buildFlagSet(tt.prettyDefined, nil, scaffold.OmitFlags{})
 			fs.Parse(tt.args)
 			if got := determineFormat(fs, tt.prettyDefined); got != tt.want {
 				t.Errorf("determineFormat() = %v, want %v", got, tt.want)
@@ -237,13 +238,13 @@ func Test_getColumns(t *testing.T) {
 	}
 
 	t.Run("--all", func(t *testing.T) {
-		fs := buildFlagSet(false, nil) // default cols shouldn't matter for this
-		if err := fs.Parse([]string{"--" + ft.AllColumns.Name()}); err != nil {
+		fs := buildFlagSet(false, nil, scaffold.OmitFlags{}) // default cols shouldn't matter for this
+		if err := fs.Parse([]string{"--" + FlagNameSelectAllColumns}); err != nil {
 			t.Fatal(err)
 		}
-		got, err := getColumns(fs, DQToAlias, AliasToDQ)
-		if err != nil {
-			t.Fatal(err)
+		got, inv := getColumns(fs, DQToAlias, AliasToDQ)
+		if inv != "" {
+			t.Fatal(inv)
 		}
 		want := []string{"Alexander", "Marika", "Morgot", "Ranni"} // aliases don't affect all
 		if !slices.Equal(got, want) {
@@ -251,32 +252,32 @@ func Test_getColumns(t *testing.T) {
 		}
 	})
 	t.Run("--columns selects only DQ, duplicate columns", func(t *testing.T) {
-		fs := buildFlagSet(false, nil) // default cols shouldn't matter for this
+		fs := buildFlagSet(false, nil, scaffold.OmitFlags{}) // default cols shouldn't matter for this
 
 		requestedColumns := []string{"Alexander", "Ranni", "Ranni", "Marika"}
 
-		if err := fs.Parse([]string{"--" + ft.SelectColumns.Name() + "=" + strings.Join(requestedColumns, ",")}); err != nil {
+		if err := fs.Parse([]string{"--" + FlagNameSelectColumns + "=" + strings.Join(requestedColumns, ",")}); err != nil {
 			t.Fatal(err)
 		}
-		got, err := getColumns(fs, DQToAlias, AliasToDQ)
-		if err != nil {
-			t.Fatal(err)
+		got, inv := getColumns(fs, DQToAlias, AliasToDQ)
+		if inv != "" {
+			t.Fatal(inv)
 		}
 		if !slices.Equal(got, requestedColumns) {
 			t.Fatal(testsupport.ExpectedActual(requestedColumns, got))
 		}
 	})
 	t.Run("--columns selects DQ+Alias mix", func(t *testing.T) {
-		fs := buildFlagSet(false, nil)
+		fs := buildFlagSet(false, nil, scaffold.OmitFlags{})
 
 		requestedColumns := []string{"Radagon", "Alexander", "Ranni", "Margit"}
 
-		if err := fs.Parse([]string{"--" + ft.SelectColumns.Name() + "=" + strings.Join(requestedColumns, ",")}); err != nil {
+		if err := fs.Parse([]string{"--" + FlagNameSelectColumns + "=" + strings.Join(requestedColumns, ",")}); err != nil {
 			t.Fatal(err)
 		}
-		got, err := getColumns(fs, DQToAlias, AliasToDQ)
-		if err != nil {
-			t.Fatal(err)
+		got, inv := getColumns(fs, DQToAlias, AliasToDQ)
+		if inv != "" {
+			t.Fatal(inv)
 		}
 		want := []string{"Marika", "Alexander", "Ranni", "Morgot"}
 		if !slices.Equal(got, want) {
@@ -287,14 +288,14 @@ func Test_getColumns(t *testing.T) {
 		// default columns are expected to be DQ
 		defaultColumns := []string{"Morgot"}
 
-		fs := buildFlagSet(false, defaultColumns)
+		fs := buildFlagSet(false, defaultColumns, scaffold.OmitFlags{})
 
 		if err := fs.Parse([]string{}); err != nil {
 			t.Fatal(err)
 		}
-		got, err := getColumns(fs, DQToAlias, AliasToDQ)
-		if err != nil {
-			t.Fatal(err)
+		got, inv := getColumns(fs, DQToAlias, AliasToDQ)
+		if inv != "" {
+			t.Fatal(inv)
 		}
 		if !slices.Equal(got, defaultColumns) {
 			t.Fatal(testsupport.ExpectedActual(defaultColumns, got))
@@ -328,10 +329,10 @@ var ntDQs = map[string]string{
 
 func Test_listOutput(t *testing.T) {
 	t.Run("pretty", func(t *testing.T) {
-		ppf := func(_ []string, _ map[string]string) (string, error) {
+		ppf := func(_ *pflag.FlagSet, _ []string, _ map[string]string, _ DataParameters) (string, error) {
 			return "pretty", nil
 		}
-		out, err := listOutput[struct{}](buildFlagSet(true, nil), formatPretty, nil, nil, ppf, nil)
+		out, err := listOutput[struct{}](buildFlagSet(true, nil, scaffold.OmitFlags{}), formatPretty, nil, nil, ppf, nil, scaffold.OmitFlags{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -347,7 +348,7 @@ func Test_listOutput(t *testing.T) {
 		{Plant: "no popo", Rogue: complex64(9i + -1)},
 	}
 
-	dataFunc := func(fs *pflag.FlagSet) ([]nuclearThrone, error) { return data, nil }
+	dataFunc := func(fs *pflag.FlagSet, _ DataParameters) ([]nuclearThrone, error) { return data, nil }
 
 	aliased := maps.Clone(ntDQs)
 	aliased["Robot"] = "munch"
@@ -378,7 +379,7 @@ func Test_listOutput(t *testing.T) {
 	}
 	for i, tt := range tests {
 		t.Run(strconv.FormatInt(int64(i+1), 10), func(t *testing.T) {
-			out, err := listOutput(buildFlagSet(false, nil), tt.format, tt.dqColumns, dataFunc, nil, aliased)
+			out, err := listOutput(buildFlagSet(false, nil, scaffold.OmitFlags{}), tt.format, tt.dqColumns, dataFunc, nil, aliased, scaffold.OmitFlags{})
 			if err != nil {
 				t.Error(err)
 			}

--- a/gwcli/utilities/scaffold/scaffoldselect/scaffoldselect.go
+++ b/gwcli/utilities/scaffold/scaffoldselect/scaffoldselect.go
@@ -38,14 +38,25 @@ import (
 )
 
 // CollectItemsFunc is used in interactive mode to populate the list of selectable items.
+// It will NOT be called if DirectInvoked or NoInteractive.
 //
 // ! addtlFlags will be nil if you do not define an addtlFlagFunc in Options.
 type CollectItemsFunc[ID_t scaffold.Id_t] func(addtlFlags *pflag.FlagSet) ([]multiselectlist.SelectableItem[ID_t], error)
 
-// OperateFunc performs the actual operation (toggling, cloning, updating, etc) on a given ID.
+// OperateFunc performs the actual operation (toggling, cloning, updating, etc) on the final set of selected IDs.
+//
+// - IDs is the set of identifiers the user provided as bare arguments or interactively selected from the items in CollectItems.
+// As a user can bypass CollectItems by prioviding bare arguments, these IDs are not guaranteed to be valid.
 //
 // ! addtlFlags will be nil if you do not define an addtlFlagFunc in Options.
-type OperateFunc[ID_t scaffold.Id_t] func(id ID_t, addtlFlags *pflag.FlagSet) (success string, _ error)
+//
+// results will be printed as they are given, in the order given.
+// You may return one result per ID (in which case, the ID should be included in output) or a single result;
+// scaffoldselect does no further processing of this output aside from printing to stderr or stdout (if non-interactive).
+// You may return no results and a nil error; scaffoldselect will simply exit silently.
+//
+// an error should be used for a fatal error where processing cannot continue; invalid arguments and non-fatal errors can go in results.
+type OperateFunc[ID_t scaffold.Id_t] func(IDs []ID_t, addtlFlags *pflag.FlagSet) (results []scaffold.Result, _ error)
 
 func NewSelectAction[ID_t scaffold.Id_t](short, long string,
 	selectedItemSingular string,
@@ -85,18 +96,18 @@ func NewSelectAction[ID_t scaffold.Id_t](short, long string,
 			return errors.New(phrases.Exactly1ArgRequired(selectedItemSingular))
 		}
 
-		results, inv := autonomous(cmd.Flags(), op, selectedItemSingular)
-		if inv != "" {
-			return errors.New(inv)
+		results, err := autonomous(cmd.Flags(), op, selectedItemSingular)
+		if err != nil {
+			return err
 		}
 		var numSuccesses, numErrors uint
 		for _, res := range results {
-			if res.success {
+			if res.Success {
 				numSuccesses += 1
-				fmt.Fprintln(cmd.OutOrStdout(), res.out)
+				fmt.Fprintln(cmd.OutOrStdout(), res.Output)
 			} else {
 				numErrors += 1
-				fmt.Fprintln(cmd.ErrOrStderr(), res.out)
+				fmt.Fprintln(cmd.ErrOrStderr(), res.Output)
 			}
 		}
 		return finalError(numSuccesses, numErrors)
@@ -133,17 +144,10 @@ func NewSelectAction[ID_t scaffold.Id_t](short, long string,
 // Assumes NArg has already been checked.
 // Every result will have out set; successful operations with no success string are not returned.
 //
-// Returns inv iff any of the arguments fail the FromString conversion.
-func autonomous[ID_t scaffold.Id_t](fs *pflag.FlagSet, op OperateFunc[ID_t], singular string) (results []struct {
-	out     string
-	success bool
-}, inv string) {
-	results = make([]struct {
-		out     string
-		success bool
-	}, 0, fs.NArg())
-
-	for _, a := range fs.Args() {
+// Returns iff any of the arguments fail the FromString conversion.
+func autonomous[ID_t scaffold.Id_t](fs *pflag.FlagSet, op OperateFunc[ID_t], singular string) (_ []scaffold.Result, fatal error) {
+	var casts = make([]ID_t, fs.NArg())
+	for i, a := range fs.Args() {
 		cast, err := scaffold.FromString[ID_t](a)
 		if err != nil {
 			var zero ID_t
@@ -152,23 +156,16 @@ func autonomous[ID_t scaffold.Id_t](fs *pflag.FlagSet, op OperateFunc[ID_t], sin
 				log.KV("target type", reflect.TypeOf(zero)),
 				scaffold.IdentifyCaller(),
 			)
-			return nil, a + " is not a valid " + singular
+			return nil, errors.New(a + " is not a valid " + singular)
 		}
-
-		if success, err := op(cast, fs); err != nil {
-			results = append(results, struct {
-				out     string
-				success bool
-			}{err.Error(), false})
-		} else if success != "" {
-			results = append(results, struct {
-				out     string
-				success bool
-			}{success, true})
-		}
+		casts[i] = cast
+	}
+	results, err := op(casts, fs)
+	if err != nil {
+		return nil, err
 	}
 
-	return slices.Clip(results), ""
+	return slices.Clip(results), nil
 }
 
 // finalError returns an error based on the number of errors.
@@ -221,28 +218,13 @@ func (m *selectModel[ID_t]) SetArgs(_ *pflag.FlagSet, args []string, width, heig
 		if m.fs.NArg() > 1 && m.options.Exactly1 {
 			return phrases.Exactly1ArgRequired(m.singular), nil, nil
 		}
-		results, inv := autonomous(m.fs, m.op, m.singular)
-		if inv != "" {
-			return inv, nil, nil
+		results, err := autonomous(m.fs, m.op, m.singular)
+		if err != nil {
+			return "", nil, err
 		}
+
 		m.done = true
-		var (
-			numSuccesses, numErrors uint
-			cmds                    []tea.Cmd
-		)
-		for _, res := range results {
-			if res.success {
-				numSuccesses += 1
-				cmds = append(cmds, tea.Println(res.out))
-			} else {
-				numErrors += 1
-				cmds = append(cmds, tea.Println(stylesheet.Cur.ErrorText.Render(res.out)))
-			}
-		}
-		if err := finalError(numSuccesses, numErrors); err != nil {
-			cmds = append(cmds, tea.Println(err.Error()))
-		}
-		return "", tea.Sequence(cmds...), nil
+		return "", teaPrintlnResults(results), nil
 	}
 
 	// we were not given any arguments; spool up the selection list
@@ -272,11 +254,34 @@ func (m *selectModel[ID_t]) SetArgs(_ *pflag.FlagSet, args []string, width, heig
 	return "", nil, nil
 }
 
+// teaPrintlnResults returns a set of tea Cmds to print the results (color-coded) and suffixes finalError
+func teaPrintlnResults(results []scaffold.Result) tea.Cmd {
+	if len(results) == 0 {
+		return nil
+	}
+	cmds := make([]tea.Cmd, len(results))
+	var numSuccesses, numErrors uint
+	for i, res := range results {
+		if res.Success {
+			numSuccesses += 1
+			cmds[i] = tea.Println(res.Output)
+		} else {
+			numErrors += 1
+			cmds[i] = tea.Println(stylesheet.Cur.ErrorText.Render(res.Output))
+		}
+	}
+	if err := finalError(numSuccesses, numErrors); err != nil {
+		cmds = append(cmds, tea.Println(err.Error()))
+	}
+	return tea.Sequence(cmds...)
+}
+
 func (m *selectModel[ID_t]) Update(msg tea.Msg) tea.Cmd {
 	var cmd tea.Cmd
 	if m.options.Exactly1 {
 		if hotkeys.ButtonPressed(msg) { // accept invoke or select
 			m.done = true
+			// collect the set of IDs
 			itm := m.l.SelectedItem()
 			if itm == nil {
 				clilog.Writer.Error("nil item selected from list.Model")
@@ -287,14 +292,11 @@ func (m *selectModel[ID_t]) Update(msg tea.Msg) tea.Cmd {
 				var zero multiselectlist.SelectableItem[ID_t]
 				return tea.Println(clilog.TypeAssert(itm, zero).Error())
 			}
-			success, err := m.op(selItm.ID(), m.fs)
+			results, err := m.op([]ID_t{selItm.ID()}, m.fs)
 			if err != nil {
 				return tea.Println(err.Error())
 			}
-			if success != "" {
-				return tea.Println(success)
-			}
-			return nil
+			return teaPrintlnResults(results)
 		}
 
 		m.l, cmd = m.l.Update(msg)
@@ -314,25 +316,16 @@ func (m *selectModel[ID_t]) Update(msg tea.Msg) tea.Cmd {
 		m.msl.Undone()
 		return m.msl.NewStatusMessage("select at least 1 " + m.singular)
 	}
-	var cmds = make([]tea.Cmd, 0, len(itms))
-	atLeastOneSuccess := false
-	for _, itm := range itms {
-		if success, err := m.op(itm.ID(), m.fs); err != nil {
-			cmds = append(cmds, tea.Println(err))
-		} else {
-			atLeastOneSuccess = true
-			if success != "" {
-				cmds = append(cmds, tea.Println(success))
-			}
-		}
+	IDs := make([]ID_t, len(itms))
+	// collect IDs
+	for i, itm := range itms {
+		IDs[i] = itm.ID()
 	}
-	cmds = slices.Clip(cmds)
-	if !atLeastOneSuccess {
-		cmds = append(cmds, tea.Println("all operations failed"))
+	results, err := m.op(IDs, m.fs)
+	if err != nil {
+		return tea.Println(stylesheet.Cur.ErrorText.Render(err.Error()))
 	}
-
-	return tea.Sequence(cmds...)
-
+	return teaPrintlnResults(results)
 }
 
 func (m *selectModel[ID_t]) View() string {

--- a/gwcli/utilities/scaffold/scaffoldselect/scaffoldselect.go
+++ b/gwcli/utilities/scaffold/scaffoldselect/scaffoldselect.go
@@ -46,7 +46,7 @@ type CollectItemsFunc[ID_t scaffold.Id_t] func(addtlFlags *pflag.FlagSet) ([]mul
 // OperateFunc performs the actual operation (toggling, cloning, updating, etc) on the final set of selected IDs.
 //
 // - IDs is the set of identifiers the user provided as bare arguments or interactively selected from the items in CollectItems.
-// As a user can bypass CollectItems by prioviding bare arguments, these IDs are not guaranteed to be valid.
+// As a user can bypass CollectItems by providing bare arguments, these IDs are not guaranteed to be valid.
 //
 // ! addtlFlags will be nil if you do not define an addtlFlagFunc in Options.
 //

--- a/gwcli/utilities/scaffold/scaffoldselect/scaffoldselect_test.go
+++ b/gwcli/utilities/scaffold/scaffoldselect/scaffoldselect_test.go
@@ -32,22 +32,44 @@ func TestMain(m *testing.M) {
 	m.Run()
 }
 
-func operate(ID int, afs *pflag.FlagSet) (success string, _ error) {
-	isCursed, err := afs.GetBool("cursed")
-	if err != nil {
-		clilog.GetFlag(err)
+var errTestFatal = errors.New("fatal triggered")
+
+func operate(IDs []int, afs *pflag.FlagSet) (_ []scaffold.Result, _ error) {
+	if fatal, err := afs.GetBool("fatal"); err != nil {
+		return nil, errors.New("fail to fetch fatal flag! Something is broken in the test!")
+	} else if fatal {
+		return nil, errTestFatal
 	}
 	var cursed string
-	if isCursed {
+	if isCursed, err := afs.GetBool("cursed"); err != nil {
+		clilog.GetFlag(err)
+	} else if isCursed {
 		cursed = ", but they carry the crimson curse!"
 	}
-	if ID < 10 {
-		return "recruited vagrant " + strconv.FormatInt(int64(ID), 10) + cursed, nil
+	results := make([]scaffold.Result, len(IDs))
+	for i, ID := range IDs {
+		var r = scaffold.Result{}
+		if ID < 10 {
+			r.Output = "recruited vagrant " + strconv.FormatInt(int64(ID), 10) + cursed
+			r.Success = true
+		} else {
+			r.Output = "unknown vagrant (" + strconv.FormatInt(int64(ID), 10) + ") on the old road"
+		}
+
+		results[i] = r
 	}
-	return "", errors.New("unknown vagrant (" + strconv.FormatInt(int64(ID), 10) + ") on the old road")
+	return results, nil
 }
 
 func TestNonInteractive(t *testing.T) {
+	afsFunc := func() *pflag.FlagSet {
+		fs := &pflag.FlagSet{}
+		fs.Bool("cursed", false,
+			"These swarming fiends carry a pernicious plague! A sickness so virulent, so insidious, it is more a curse than a mere disease.")
+		fs.Bool("fatal", false,
+			"Another life wasted in the pursuit of glory and gold.")
+		return fs
+	}
 	t.Run("1+", func(t *testing.T) {
 		tests := []struct {
 			name    string
@@ -63,6 +85,7 @@ func TestNonInteractive(t *testing.T) {
 			{"select unknown", []string{"100"}, "", "unknown vagrant (100) on the old road"},
 			{"select unparsable", []string{"Crusader"}, "", "Crusader is not a valid item"},
 			{"invalid arguments", []string{"1", "3", "5", "7", "9"}, "", "the party may contain no more than 4 members"},
+			{"trigger fatal (in op, once args are validated)", []string{"--fatal", "2"}, "", errTestFatal.Error()},
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
@@ -70,12 +93,7 @@ func TestNonInteractive(t *testing.T) {
 				pair := scaffoldselect.NewSelectAction("short test", "long test", "item",
 					func(addtlFlags *pflag.FlagSet) ([]multiselectlist.SelectableItem[int], error) { return nil, nil }, operate, scaffoldselect.Options{
 						CommonOptions: scaffold.CommonOptions{
-							AddtlFlags: func() *pflag.FlagSet {
-								fs := &pflag.FlagSet{}
-								fs.Bool("cursed", false,
-									"These swarming fiends carry a pernicious plague! A sickness so virulent, so insidious, it is more a curse than a mere disease.")
-								return fs
-							},
+							AddtlFlags: afsFunc,
 						},
 						ValidateArgs: func(fs *pflag.FlagSet) (invalid string, err error) {
 							if fs.NArg() > 4 {
@@ -123,12 +141,7 @@ func TestNonInteractive(t *testing.T) {
 				pair := scaffoldselect.NewSelectAction("short test", "long test", "item",
 					func(addtlFlags *pflag.FlagSet) ([]multiselectlist.SelectableItem[int], error) { return nil, nil }, operate, scaffoldselect.Options{
 						CommonOptions: scaffold.CommonOptions{
-							AddtlFlags: func() *pflag.FlagSet {
-								fs := &pflag.FlagSet{}
-								fs.Bool("cursed", false,
-									"These swarming fiends carry a pernicious plague! A sickness so virulent, so insidious, it is more a curse than a mere disease.")
-								return fs
-							},
+							AddtlFlags: afsFunc,
 						},
 						ValidateArgs: func(fs *pflag.FlagSet) (invalid string, err error) {
 							if fs.NArg() > 4 {
@@ -161,7 +174,7 @@ func TestNonInteractive(t *testing.T) {
 		pair := scaffoldselect.NewSelectAction("short test", "long test", "item",
 			func(*pflag.FlagSet) ([]multiselectlist.SelectableItem[int], error) {
 				return nil, nil
-			}, operate, scaffoldselect.Options{})
+			}, operate, scaffoldselect.Options{CommonOptions: scaffold.CommonOptions{AddtlFlags: afsFunc}})
 		uniques.AttachPersistentFlags(pair.Action)
 		pair.Action.SetOut(&sbOut)
 		pair.Action.SetErr(&sbErr)
@@ -217,34 +230,56 @@ func collectItems(fs *pflag.FlagSet) ([]multiselectlist.SelectableItem[int], err
 }
 
 func TestInteractiveCycle(t *testing.T) {
+	afsFunc := func() *pflag.FlagSet {
+		fs := &pflag.FlagSet{}
+		fs.Bool("cursed", false,
+			"These swarming fiends carry a pernicious plague! A sickness so virulent, so insidious, it is more a curse than a mere disease.")
+		fs.Uint("single", 0, "select a single vagabond instead of the whole wagon.")
+		fs.Bool("no-data", false, "try to leave without a party in tow.")
+		fs.Bool("fatal", false,
+			"Another life wasted in the pursuit of glory and gold.")
+		return fs
+	}
 	t.Run("1+", func(t *testing.T) {
 		t.Run("no data returned uses custom EmptyError", func(t *testing.T) {
 			pair := scaffoldselect.NewSelectAction("short test", "long test", "item",
 				collectItems, operate, scaffoldselect.Options{CommonOptions: scaffold.CommonOptions{
-					AddtlFlags: func() *pflag.FlagSet {
-						fs := &pflag.FlagSet{}
-						fs.Bool("cursed", false,
-							"These swarming fiends carry a pernicious plague! A sickness so virulent, so insidious, it is more a curse than a mere disease.")
-						fs.Uint("single", 0, "select a single vagabond instead of the whole wagon.")
-						fs.Bool("no-data", false, "try to leave without a party in tow.")
-						return fs
-					},
+					AddtlFlags: afsFunc,
 				},
 					NoItemsError: func(fs *pflag.FlagSet) string { return "you cannot leave with an empty party!" }})
 			args := []string{"--no-data"}
 			testsupport.CheckSetArgs(t, pair.Model.SetArgs, nil, args, 50, 20, false, nil, true)
 		})
+		t.Run("validate func is called and can fail out properly", func(t *testing.T) {
+			pair := scaffoldselect.NewSelectAction("short test", "long test", "item",
+				collectItems, operate, scaffoldselect.Options{CommonOptions: scaffold.CommonOptions{
+					AddtlFlags: afsFunc,
+				},
+					ValidateArgs: func(fs *pflag.FlagSet) (invalid string, err error) {
+						switch len(fs.Args()) {
+						case 1:
+							return "only one argument means invalid!", nil
+						case 2:
+							return "", errors.New("but two arguments is a hard error!")
+						}
+						return "", nil
+					},
+				},
+			)
+			t.Run("invalid", func(t *testing.T) {
+				args := []string{"--no-data", "one"}
+				testsupport.CheckSetArgs(t, pair.Model.SetArgs, nil, args, 50, 20, true, nil, false)
+			})
+			t.Run("error", func(t *testing.T) {
+				args := []string{"--no-data", "one", "two"}
+				testsupport.CheckSetArgs(t, pair.Model.SetArgs, nil, args, 50, 20, false, nil, true)
+			})
+
+		})
 		t.Run("without cursed", func(t *testing.T) {
 			pair := scaffoldselect.NewSelectAction("short test", "long test", "item",
 				collectItems, operate, scaffoldselect.Options{CommonOptions: scaffold.CommonOptions{
-					AddtlFlags: func() *pflag.FlagSet {
-						fs := &pflag.FlagSet{}
-						fs.Bool("cursed", false,
-							"These swarming fiends carry a pernicious plague! A sickness so virulent, so insidious, it is more a curse than a mere disease.")
-						fs.Uint("single", 0, "select a single vagabond instead of the whole wagon.")
-						fs.Bool("no-data", false, "try to leave without a party in tow.")
-						return fs
-					},
+					AddtlFlags: afsFunc,
 				}})
 			args := []string{}
 			wantInv := false
@@ -289,14 +324,7 @@ func TestInteractiveCycle(t *testing.T) {
 		t.Run("with cursed", func(t *testing.T) {
 			pair := scaffoldselect.NewSelectAction("short test", "long test", "item",
 				collectItems, operate, scaffoldselect.Options{CommonOptions: scaffold.CommonOptions{
-					AddtlFlags: func() *pflag.FlagSet {
-						fs := &pflag.FlagSet{}
-						fs.Bool("cursed", false,
-							"These swarming fiends carry a pernicious plague! A sickness so virulent, so insidious, it is more a curse than a mere disease.")
-						fs.Uint("single", 0, "select a single vagabond instead of the whole wagon.")
-						fs.Bool("no-data", false, "try to leave without a party in tow.")
-						return fs
-					},
+					AddtlFlags: afsFunc,
 				}})
 			args := []string{"--cursed"}
 			wantInv := false
@@ -363,14 +391,7 @@ func TestInteractiveCycle(t *testing.T) {
 			pair := scaffoldselect.NewSelectAction("short test", "long test", "item",
 				collectItems, operate, scaffoldselect.Options{
 					CommonOptions: scaffold.CommonOptions{
-						AddtlFlags: func() *pflag.FlagSet {
-							fs := &pflag.FlagSet{}
-							fs.Bool("cursed", false,
-								"These swarming fiends carry a pernicious plague! A sickness so virulent, so insidious, it is more a curse than a mere disease.")
-							fs.Uint("single", 0, "select a single vagabond instead of the whole wagon.")
-							fs.Bool("no-data", false, "try to leave without a party in tow.")
-							return fs
-						},
+						AddtlFlags: afsFunc,
 					},
 					Exactly1: true,
 				})
@@ -414,14 +435,7 @@ func TestInteractiveCycle(t *testing.T) {
 			pair := scaffoldselect.NewSelectAction("short test", "long test", "item",
 				collectItems, operate, scaffoldselect.Options{
 					CommonOptions: scaffold.CommonOptions{
-						AddtlFlags: func() *pflag.FlagSet {
-							fs := &pflag.FlagSet{}
-							fs.Bool("cursed", false,
-								"These swarming fiends carry a pernicious plague! A sickness so virulent, so insidious, it is more a curse than a mere disease.")
-							fs.Uint("single", 0, "select a single vagabond instead of the whole wagon.")
-							fs.Bool("no-data", false, "try to leave without a party in tow.")
-							return fs
-						},
+						AddtlFlags: afsFunc,
 					},
 					Exactly1: true,
 				})
@@ -516,6 +530,8 @@ func TestInteractiveDirectInvoke(t *testing.T) {
 								"These swarming fiends carry a pernicious plague! A sickness so virulent, so insidious, it is more a curse than a mere disease.")
 							fs.Uint("single", 0, "select a single vagabond instead of the whole wagon.")
 							fs.Bool("no-data", false, "try to leave without a party in tow.")
+							fs.Bool("fatal", false,
+								"Another life wasted in the pursuit of glory and gold.")
 							return fs
 						},
 					},

--- a/gwcli/utilities/scaffold/shared.go
+++ b/gwcli/utilities/scaffold/shared.go
@@ -119,3 +119,9 @@ func IdentifyCaller() rfc5424.SDParam {
 
 	return identifier
 }
+
+// Result is a helper struct for passing around outcomes. It may be used slightly differently between each implementation.
+type Result struct {
+	Output  string // the actual, text result.
+	Success bool   // dictates (stdout or stderr) and/or text color
+}

--- a/gwcli/utilities/validate/validate.go
+++ b/gwcli/utilities/validate/validate.go
@@ -21,6 +21,16 @@ import (
 	"github.com/robfig/cron"
 )
 
+// NegativeNumber returns an error if s is not a negative number.
+// Returns nil if s is empty.
+func NegativeNumber(s string) (err error) {
+	if s = strings.TrimSpace(s); s == "" {
+		return nil
+	}
+	_, err = strconv.ParseInt(s, 10, 64)
+	return err
+}
+
 // Numeric returns an error if s is not composed solely of digits.
 func Numeric(s string) (err error) {
 	s = strings.TrimSpace(s)

--- a/gwcli/utilities/validate/validate.go
+++ b/gwcli/utilities/validate/validate.go
@@ -23,11 +23,14 @@ import (
 
 // NegativeNumber returns an error if s is not a negative number.
 // Returns nil if s is empty.
-func NegativeNumber(s string) (err error) {
+func NegativeNumber(s string) error {
 	if s = strings.TrimSpace(s); s == "" {
 		return nil
 	}
-	_, err = strconv.ParseInt(s, 10, 64)
+	i, err := strconv.ParseInt(s, 10, 64)
+	if i > -1 {
+		return errors.New(s + " is not negative")
+	}
 	return err
 }
 


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses #1138 & https://github.com/gravwell/gravwell/issues/2182 and is a follow up to #2425 .

>[!Important]
>This is the parity portion of the parity-part3 upgrades. The cleanup portion comes in the next PR.

## This PR introduces the remaining actions for feature parity, with two caveats.

- admin/
  - status
  - search-storage
  - ~~validate-backup~~ (see caveats below)
  - mass-chown
  - chown
- cbac/
  - capabilities
  - templates
  - my
  - get
  - edit
  - set
- flows/
  - create
- queries/
  - scheduled/
    - cancel
    - backfill
    - clear
    - script
  - info
  - list
  - stop
  - import
  - save
  - background
  - delete
  - set-group
- resources/
  - replace
- self/
  - logout-all
  - admin (alias for `admin/status`)
- templates/
  - show
  - create
  - json
- ~~script~~ (execute anko scripts) (see caveats below)

### Caveats

- Kits is still being implemented into registry, so I'm keeping the kits actions I have for the TUI in my back pocket until John is done.
- [impersonation](#2145)
- `execute-script` is currently a non-starter and has been disabled. The old CLI had access to functionality not exposed by backend. Being in Mono, gwcli does not. We will need to come to a decision on how to handle this.
  - Per John:
    > IMO:
    >     1. Scripts are deprecated in general
    >     2. execute-script was a poor choice in the first place
    >     I don't think we should include it in the new client.
  - validate-backup is similarly afflicted.

## Scaffoldselect operates on batches

This PR upgrades scaffoldselect to operate on batches of IDs instead of calling the operatorFunc on each ID. While this adds a small amount of redundant code within certain actions, it much improves the flexibility of scaffoldselect and is required for a handful of the above actions.

## Support for some query options

This PR introduces the OmitFlags options and installs them in scaffoldlist. These flags provide a standardized mechanism for users to specify query options for many actions where the underlying call supports them.

Currently, `all`, `include-deleted`, and `limit` are supported.

## PR Tasks

<!-- Add tasks to this list as needed -->

- [x] e2e and/or unit tests included. If not, please provide an explanation.
  - There are a lot of tests scattered around. *Some* of the new actions are covered. 

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
