### PR TITLE
fix: hosted ingester logs not writing to file

### DIFF
--- a/e2e/hosted/tester_test.go
+++ b/e2e/hosted/tester_test.go
@@ -1,6 +1,8 @@
 package hosted
 
 import (
+	"bufio"
+	"strings"
 	"testing"
 	"time"
 
@@ -36,4 +38,18 @@ func TestTesterPlugin(t *testing.T) {
 	if len(ent) == 0 {
 		t.Fatal("No entries found")
 	}
+
+	t.Run("Check Logs", func(t *testing.T) {
+		r, err := fetcher.CopyFileFromContainer(t.Context(), "/opt/gravwell/log/hosted_runner.log")
+		if err != nil {
+			t.Fatal(err)
+		}
+		scanner := bufio.NewScanner(r)
+		for scanner.Scan() {
+			if strings.Contains(scanner.Text(), "testing errors") {
+				return
+			}
+		}
+		t.Fatal("failed to find testing errors in log file")
+	})
 }

--- a/hosted/plugins/tester/example.conf
+++ b/hosted/plugins/tester/example.conf
@@ -1,0 +1,27 @@
+[Global]
+	Ingest-Secret = "IngestSecrets"
+	Connection-Timeout = 0
+	Insecure-Skip-TLS-Verify=false
+
+	Cleartext-Backend-Target=127.0.0.1:4023 #example of adding a cleartext connection
+	#Cleartext-Backend-Target=127.1.0.1:4023 #example of adding another cleartext connection
+	#Encrypted-Backend-Target=127.1.1.1:4024 #example of adding an encrypted connection
+
+	##a named pipe connection, this should be used when ingester is on the same machine as a backend
+	#Pipe-Backend-Target=/opt/gravwell/comms/pipe
+
+	# always enable the cache for hosted ingesters
+	Ingest-Cache-Path=/opt/gravwell/cache/hosted_runner.cache
+	Max-Ingest-Cache=1024 #Number of MB to store, localcache will only store 1GB before stopping.  This is a safety net
+
+	# log levels and output files
+	Log-Level=INFO
+	Log-File=/opt/gravwell/log/hosted_runner.log
+
+# configure the state file for hosted ingesters
+[State]
+	Path="/opt/gravwell/etc/hosted_runner.state"
+	Sync=false #do NOT flush to disk on every sync (sync=true mode can be expensive if disks are slow)
+
+[Tester "hosted test"]
+    Interval=2s

--- a/hosted/plugins/tester/tester.go
+++ b/hosted/plugins/tester/tester.go
@@ -4,6 +4,7 @@ package tester
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/google/uuid"
@@ -74,5 +75,6 @@ func (tt *TesterIngester) Handle(_ context.Context, rt hosted.Runtime) (*hosted.
 	}); err != nil {
 		rt.Error("failed to write entry", log.KVErr(err))
 	}
+	rt.Error("testing errors", log.KVErr(errors.New("test err")))
 	return hosted.ContinueAfter(tt.interval()), nil
 }

--- a/ingest/log/kvlog.go
+++ b/ingest/log/kvlog.go
@@ -68,6 +68,36 @@ func (kvl *KVLogger) Critical(msg string, sds ...rfc5424.SDParam) error {
 	return kvl.outputStructured(DEFAULT_DEPTH, CRITICAL, msg, append(kvl.sds, sds...)...)
 }
 
+// DebugWithDepth writes a DEBUG level log to the underlying writer,
+// if the logging level is higher than DEBUG no action is taken
+func (kvl *KVLogger) DebugWithDepth(d int, msg string, sds ...rfc5424.SDParam) error {
+	return kvl.outputStructured(d, DEBUG, msg, append(kvl.sds, sds...)...)
+}
+
+// InfoWithDepth writes an INFO level log to the underlying writer,
+// if the logging level is higher than DEBUG no action is taken
+func (kvl *KVLogger) InfoWithDepth(d int, msg string, sds ...rfc5424.SDParam) error {
+	return kvl.outputStructured(d, INFO, msg, append(kvl.sds, sds...)...)
+}
+
+// WarnWithDepth writes an WARN level log to the underlying writer,
+// if the logging level is higher than DEBUG no action is taken
+func (kvl *KVLogger) WarnWithDepth(d int, msg string, sds ...rfc5424.SDParam) error {
+	return kvl.outputStructured(d, WARN, msg, append(kvl.sds, sds...)...)
+}
+
+// ErrorWithDepth writes an ERROR level log to the underlying writer,
+// if the logging level is higher than DEBUG no action is taken
+func (kvl *KVLogger) ErrorWithDepth(d int, msg string, sds ...rfc5424.SDParam) error {
+	return kvl.outputStructured(d, ERROR, msg, append(kvl.sds, sds...)...)
+}
+
+// CriticalWithDepth writes a CRITICAL info level log to the underlying writer,
+// if the logging level is higher than DEBUG no action is taken
+func (kvl *KVLogger) CriticalWithDepth(d int, msg string, sds ...rfc5424.SDParam) error {
+	return kvl.outputStructured(d, CRITICAL, msg, append(kvl.sds, sds...)...)
+}
+
 // AddKV allows for adding additional KVs to the KV logger
 func (kvl *KVLogger) AddKV(sds ...rfc5424.SDParam) {
 	kvl.sds = append(kvl.sds, sds...)

--- a/ingest/log/kvlog_test.go
+++ b/ingest/log/kvlog_test.go
@@ -1,0 +1,163 @@
+package log
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/crewjam/rfc5424"
+)
+
+func TestKVLogger_Base(t *testing.T) {
+	filename := filepath.Join(t.ArtifactDir(), "base.log")
+	logger, err := NewFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kvl := NewLoggerWithKV(logger, KV("all", "value"))
+
+	tests := []struct {
+		name string
+		kv   []rfc5424.SDParam
+		// method should be ref to func on kvl. ex: kvl.Debug
+		// this is a bit wacky
+		method func(string, ...rfc5424.SDParam) error
+		match  string
+	}{
+		{
+			name:   "plain info",
+			kv:     []rfc5424.SDParam{},
+			method: kvl.Info,
+			match:  "",
+		},
+		{
+			name:   "info with extra kv",
+			kv:     []rfc5424.SDParam{KV("test", "exists")},
+			method: kvl.Info,
+			match:  `test="exists"`,
+		},
+		{
+			name:   "critical with extra kv",
+			kv:     []rfc5424.SDParam{KV("extra", "exists")},
+			method: kvl.Critical,
+			match:  `test="exists"`,
+		},
+		{
+			name:   "plain critical",
+			kv:     []rfc5424.SDParam{},
+			method: kvl.Critical,
+			match:  ``,
+		},
+	}
+
+	for _, tt := range tests {
+		if err = tt.method("test", tt.kv...); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err = kvl.Close(); err != nil {
+		t.Fatal(err)
+	}
+	bts, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(bts)
+
+	// every line should have the kv from the logger
+	for num, line := range strings.Split(s, "\n") {
+		if line == "" {
+			continue
+		}
+		if !strings.Contains(line, `all="value"`) {
+			t.Errorf("KV %q not found in %s on line %d", `all="value"`, filename, num+1)
+		}
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			if tt.match != "" && !strings.Contains(s, tt.match) {
+				t.Errorf("KV %q not found in %s", tt.match, filename)
+			}
+		})
+	}
+}
+
+func TestKVLogger_WithDepth(t *testing.T) {
+	filename := filepath.Join(t.ArtifactDir(), "depth.log")
+	logger, err := NewFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kvl := NewLoggerWithKV(logger, KV("all", "value"))
+
+	tests := []struct {
+		name string
+		kv   []rfc5424.SDParam
+		// method should be ref to func on kvl. ex: kvl.DebugWithDepth
+		// this is a bit wacky
+		method func(int, string, ...rfc5424.SDParam) error
+		match  string
+	}{
+		{
+			name:   "plain info",
+			kv:     []rfc5424.SDParam{},
+			method: kvl.InfoWithDepth,
+			match:  "",
+		},
+		{
+			name:   "info with extra kv",
+			kv:     []rfc5424.SDParam{KV("test", "exists")},
+			method: kvl.InfoWithDepth,
+			match:  `test="exists"`,
+		},
+		{
+			name:   "critical with extra kv",
+			kv:     []rfc5424.SDParam{KV("extra", "exists")},
+			method: kvl.CriticalWithDepth,
+			match:  `test="exists"`,
+		},
+		{
+			name:   "plain critical",
+			kv:     []rfc5424.SDParam{},
+			method: kvl.CriticalWithDepth,
+			match:  ``,
+		},
+	}
+
+	for _, tt := range tests {
+		if err = tt.method(DEFAULT_DEPTH+1, "test", tt.kv...); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err = kvl.Close(); err != nil {
+		t.Fatal(err)
+	}
+	bts, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(bts)
+
+	// every line should have the kv from the logger
+	for num, line := range strings.Split(s, "\n") {
+		if line == "" {
+			continue
+		}
+		if !strings.Contains(line, `all="value"`) {
+			t.Errorf("KV %q not found in %s on line %d", `all="value"`, filename, num+1)
+		}
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.match != "" && !strings.Contains(s, tt.match) {
+				t.Errorf("KV %q not found in %s", tt.match, filename)
+			}
+		})
+	}
+}

--- a/ingest/log/logging.go
+++ b/ingest/log/logging.go
@@ -169,10 +169,8 @@ func NewDiscardLogger() *Logger {
 }
 
 // Clone creates a new logger based on an existing one, but allows
-// overriding the hostname and appname values
-// embedded WriteClosers are NOT cloned as this will just create a huge race
-// condition were we mux writes in really dumb ways.  This should really only be used in ingesters
-// that are writing up to the host logger.
+// overriding the hostname and appname values. This should really only be used
+// in ingesters that are writing up to the host logger.
 func (l *Logger) Clone(hostname, appname string) (r *Logger, err error) {
 	l.mtx.Lock()
 	defer l.mtx.Unlock()
@@ -539,9 +537,7 @@ func (l *Logger) writeOutput(lvl Level, ts time.Time, ln, msg string) (err error
 	l.mtx.Lock()
 	if err = l.ready(); err == nil {
 		for _, w := range l.wtrs {
-			if _, lerr := io.WriteString(w, ln); lerr != nil {
-				err = lerr
-			} else if _, lerr = io.WriteString(w, "\n"); lerr != nil {
+			if _, lerr := io.WriteString(w, ln+"\n"); lerr != nil {
 				err = lerr
 			}
 		}

--- a/ingest/log/logging.go
+++ b/ingest/log/logging.go
@@ -178,6 +178,7 @@ func (l *Logger) Clone(hostname, appname string) (r *Logger, err error) {
 	defer l.mtx.Unlock()
 	r = &Logger{
 		metadata: l.metadata,
+		wtrs:     make([]io.WriteCloser, len(l.wtrs)),
 		rls:      make([]Relay, len(l.rls)),
 		lrls:     make([]LevelRelay, len(l.lrls)),
 		mtx:      sync.Mutex{},
@@ -185,6 +186,7 @@ func (l *Logger) Clone(hostname, appname string) (r *Logger, err error) {
 		hot:      l.hot,
 		raw:      l.raw,
 	}
+	copy(r.wtrs, l.wtrs)
 	copy(r.rls, l.rls)
 	copy(r.lrls, l.lrls)
 	if hostname != `` {

--- a/ingest/log/logging_test.go
+++ b/ingest/log/logging_test.go
@@ -90,7 +90,7 @@ func TestValue(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	testOutputs(t, lgr)
+	testOutputs(t, lgr, filepath.Join(tempdir, testFile))
 }
 
 func TestRawValue(t *testing.T) {
@@ -100,7 +100,7 @@ func TestRawValue(t *testing.T) {
 		t.Fatal(err)
 	}
 	lgr.raw = true
-	testOutputs(t, lgr)
+	testOutputs(t, lgr, pth)
 	bts, err := os.ReadFile(pth)
 	if err != nil {
 		t.Fatal(err)
@@ -112,7 +112,7 @@ func TestRawValue(t *testing.T) {
 
 }
 
-func testOutputs(t *testing.T, lgr *Logger) {
+func testOutputs(t *testing.T, lgr *Logger, file string) {
 	var err error
 	if err = lgr.Warnf("ERROR test: %d", 99); err != nil {
 		t.Fatal(err)
@@ -138,7 +138,7 @@ func testOutputs(t *testing.T, lgr *Logger) {
 	if err = lgr.Close(); err != nil {
 		t.Fatal(err)
 	}
-	bts, err := os.ReadFile(filepath.Join(tempdir, testFile))
+	bts, err := os.ReadFile(file)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses no issue. 

## This PR proposes...

When cloning a logger include the writers. Despite the initial comment this doesn't appear to create major blocks. Though there is a slight chance of a race where log data in the log file is mis ordered. In practice I don't think this is going to be an issue. This only occurred ~.5% to 1% of the time. This was also observed during normal ingester startup logs before running the testers. This testing did reveal a race condition in our loggers where we write a line and the newline in separate calls. Adjusting this to write them together resolves this. 

Even with one tester running at a 1ms interval we couldn't really keep up logging to a file at that interval. We were able to get about 166-178 entries written a second. With all the below configs that dropped to 110-124, but the intervals 30ms and above logged about as expected per second. 

<img width="492" height="531" alt="image" src="https://github.com/user-attachments/assets/ffb20416-b539-427d-a663-cf62ca263432" />


I used the following config for the concurrency tests:
```
[Global]
	Ingester-UUID="553bb802-1882-4091-b6ff-cffb99afbb73"
	Ingest-Secret = "IngestSecrets"
	Connection-Timeout = 0
	Insecure-Skip-TLS-Verify=false

	Cleartext-Backend-Target=127.0.0.1:4023 #example of adding a cleartext connection
	#Cleartext-Backend-Target=127.1.0.1:4023 #example of adding another cleartext connection
	#Encrypted-Backend-Target=127.1.1.1:4024 #example of adding an encrypted connection

	##a named pipe connection, this should be used when ingester is on the same machine as a backend
	#Pipe-Backend-Target=/opt/gravwell/comms/pipe

	# always enable the cache for hosted ingesters
	Ingest-Cache-Path=/opt/gravwell/cache/hosted_runner.cache
	Max-Ingest-Cache=1024 #Number of MB to store, localcache will only store 1GB before stopping.  This is a safety net

	# log levels and output files
	Log-Level=INFO
	Log-File=/opt/gravwell/log/hosted_runner.log

# configure the state file for hosted ingesters
[State]
	Path="/opt/gravwell/etc/hosted_runner.state"
	Sync=false #do NOT flush to disk on every sync (sync=true mode can be expensive if disks are slow)

[Tester "hosted-100"]
    Ingester-UUID=8d838099-707e-4b6e-9921-8b8d0979f143
    Interval=100ms

[Tester "hosted-10"]
    Ingester-UUID=1777c95e-16f9-43d6-88fd-d4c91b22e3ce
    Interval=10ms

[Tester "hosted-30"]
    Ingester-UUID=c372e628-efe3-442a-a9f0-ef96ce89bb29
    Interval=30ms

[Tester "hosted-40"]
    Ingester-UUID=2488326c-3dee-4f38-b49f-a6bfbc968af7
    Interval=40ms

[Tester "hosted-1"]
    Ingester-UUID=34cfd3ee-c0b3-4718-87d2-ac9baa72f252
    Interval=1ms
```

Finally this also address a bug found with the KVLogger in that it doesn't append the kvs on all log calls. 

## PR Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e and/or unit tests included. If not, please provide an explanation.
- [ ] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
