### PR TITLE
feat(issues#2528): include bytes param for previewing contents

### DIFF
--- a/client/file.go
+++ b/client/file.go
@@ -48,17 +48,21 @@ func (c *Client) CreateFile(f types.File) (result types.File, err error) {
 
 // GetFile returns the specified file's contents.
 func (c *Client) GetFile(id string) ([]byte, error) {
-	return c.GetFileEx(id, nil)
+	return c.GetFileEx(id, nil, 0)
 }
 
 // GetFileEx returns the specified file's contents.
 // If opts is not nil, applicable parameters (currently only IncludeDeleted) will be applied to the query.
-func (c *Client) GetFileEx(id string, opts *types.QueryOptions) ([]byte, error) {
+// Up to previewBytes will be returned; if 0, everything is returned.
+func (c *Client) GetFileEx(id string, opts *types.QueryOptions, previewBytes uint64) ([]byte, error) {
 	if opts == nil {
 		opts = &types.QueryOptions{}
 	}
 
-	resp, err := c.methodParamRequestURL(http.MethodGet, filesIdRawUrl(id), map[string]string{"include_deleted": strconv.FormatBool(opts.IncludeDeleted)}, nil)
+	resp, err := c.methodParamRequestURL(http.MethodGet, filesIdRawUrl(id), map[string]string{
+		"include_deleted": strconv.FormatBool(opts.IncludeDeleted),
+		"bytes":           strconv.FormatUint(previewBytes, 10),
+	}, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/file.go
+++ b/client/file.go
@@ -65,18 +65,7 @@ func (c *Client) GetFileEx(id string, opts *types.QueryOptions, previewBytes uin
 	}, nil)
 	if err != nil {
 		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		c.state = STATE_LOGGED_OFF
-		drainResponse(resp)
-		return nil, ErrNotAuthed
-	} else if resp.StatusCode != http.StatusOK {
-		if s := getBodyErr(resp.Body); len(s) > 0 {
-			err = errors.New(s)
-		} else {
-			err = fmt.Errorf("Bad Status %s(%d)", resp.Status, resp.StatusCode)
-		}
-		drainResponse(resp)
+	} else if err := checkResponse(c, resp); err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()

--- a/client/resources.go
+++ b/client/resources.go
@@ -12,8 +12,6 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
-	"errors"
-	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -142,18 +140,7 @@ func (c *Client) PopulateResourceFromReader(id string, extension string, data io
 	resp, err = c.methodRequestURL(http.MethodPut, resourcesIdRawUrl(id), contentType, rdr)
 	if err != nil {
 		return types.Resource{}, err
-	}
-	defer drainResponse(resp)
-
-	if resp.StatusCode == http.StatusUnauthorized {
-		c.state = STATE_LOGGED_OFF
-		return types.Resource{}, ErrNotAuthed
-	} else if resp.StatusCode != http.StatusOK {
-		if s := getBodyErr(resp.Body); len(s) > 0 {
-			err = errors.New(s)
-		} else {
-			err = fmt.Errorf("Bad Status %s(%d)", resp.Status, resp.StatusCode)
-		}
+	} else if err := checkResponse(c, resp); err != nil {
 		return types.Resource{}, err
 	}
 
@@ -206,17 +193,19 @@ func (c *Client) GetResource(name string) ([]byte, error) {
 }
 
 // GetResourceEx returns the contents of the resource with the specified name, up to previewBytes (if 0, everything is returned).
-//
 // Follows the name/ID logic of GetResource.
+//
+// If opts is not nil, applicable parameters (currently only IncludeDeleted) will be applied to the query.
+// Up to previewBytes will be returned; if 0, everything is returned.
 func (c *Client) GetResourceEx(name string, opts *types.QueryOptions, previewBytes uint64) ([]byte, error) {
-	var meta types.Resource
-	err := c.getStaticURL(resourcesLookupUrl(name), &meta)
-	if err != nil {
-		return nil, err
-	}
-
 	if opts == nil {
 		opts = &types.QueryOptions{}
+	}
+
+	var meta types.Resource
+	err := c.getStaticURL(resourcesLookupUrl(name), &meta, ezParam("include_deleted", opts.IncludeDeleted))
+	if err != nil {
+		return nil, err
 	}
 
 	resp, err := c.methodParamRequestURL(http.MethodGet, resourcesIdRawUrl(meta.ID), map[string]string{
@@ -225,6 +214,8 @@ func (c *Client) GetResourceEx(name string, opts *types.QueryOptions, previewByt
 	}, nil)
 	if err != nil {
 		return nil, err
+	} else if err := checkResponse(c, resp); err != nil {
+		return nil, err
 	}
 	defer resp.Body.Close()
 	return io.ReadAll(resp.Body)
@@ -232,13 +223,13 @@ func (c *Client) GetResourceEx(name string, opts *types.QueryOptions, previewByt
 
 // LookupResource attempts to resolve the resource with the specified
 // user-friendly name. It follows precedence as defined on the GetResource method.
-func (c *Client) LookupResource(name string) (string, error) {
-	var id string
-	err := c.getStaticURL(resourcesLookupUrl(name), &id)
+func (c *Client) LookupResource(name string) (types.Resource, error) {
+	var meta types.Resource
+	err := c.getStaticURL(resourcesLookupUrl(name), &meta)
 	if err != nil {
-		return "", err
+		return types.Resource{}, err
 	}
-	return id, nil
+	return meta, nil
 }
 
 // CloneResource creates a copy of an existing resource (specified by ID) with the

--- a/client/resources.go
+++ b/client/resources.go
@@ -202,21 +202,26 @@ func (c *Client) GetResourceMetadata(id string) (types.Resource, error) {
 // 2. Resources shared with a group to which the user belongs are next
 // 3. Global resources are the lowest priority
 func (c *Client) GetResource(name string) ([]byte, error) {
-	return c.GetResourceEx(name, 0)
+	return c.GetResourceEx(name, nil, 0)
 }
 
 // GetResourceEx returns the contents of the resource with the specified name, up to previewBytes (if 0, everything is returned).
 //
 // Follows the name/ID logic of GetResource.
-func (c *Client) GetResourceEx(name string, previewBytes uint64) ([]byte, error) {
+func (c *Client) GetResourceEx(name string, opts *types.QueryOptions, previewBytes uint64) ([]byte, error) {
 	var meta types.Resource
 	err := c.getStaticURL(resourcesLookupUrl(name), &meta)
 	if err != nil {
 		return nil, err
 	}
 
+	if opts == nil {
+		opts = &types.QueryOptions{}
+	}
+
 	resp, err := c.methodParamRequestURL(http.MethodGet, resourcesIdRawUrl(meta.ID), map[string]string{
-		"bytes": strconv.FormatUint(previewBytes, 10),
+		"include_deleted": strconv.FormatBool(opts.IncludeDeleted),
+		"bytes":           strconv.FormatUint(previewBytes, 10),
 	}, nil)
 	if err != nil {
 		return nil, err

--- a/client/resources.go
+++ b/client/resources.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/gravwell/gravwell/v4/client/types"
 )
@@ -201,13 +202,22 @@ func (c *Client) GetResourceMetadata(id string) (types.Resource, error) {
 // 2. Resources shared with a group to which the user belongs are next
 // 3. Global resources are the lowest priority
 func (c *Client) GetResource(name string) ([]byte, error) {
+	return c.GetResourceEx(name, 0)
+}
+
+// GetResourceEx returns the contents of the resource with the specified name, up to previewBytes (if 0, everything is returned).
+//
+// Follows the name/ID logic of GetResource.
+func (c *Client) GetResourceEx(name string, previewBytes uint64) ([]byte, error) {
 	var meta types.Resource
 	err := c.getStaticURL(resourcesLookupUrl(name), &meta)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.methodRequestURL(http.MethodGet, resourcesIdRawUrl(meta.ID), ``, nil)
+	resp, err := c.methodParamRequestURL(http.MethodGet, resourcesIdRawUrl(meta.ID), map[string]string{
+		"bytes": strconv.FormatUint(previewBytes, 10),
+	}, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/utils.go
+++ b/client/utils.go
@@ -12,6 +12,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -75,4 +76,26 @@ func decodeJWTExpires(jwt string) (r time.Time) {
 		}
 	}
 	return
+}
+
+// checkResponse tests the given http response for common errors and aliases them as appropriate.
+// If a non-200 status code is given, the response's body will be automatically drained.
+func checkResponse(c *Client, resp *http.Response) error {
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+	defer drainResponse(resp)
+
+	switch resp.StatusCode {
+	case http.StatusUnauthorized:
+		c.state = STATE_LOGGED_OFF
+		return ErrNotAuthed
+	case http.StatusNotFound:
+		return ErrNotFound
+	default: // unhandled code; check body for error
+		if s := getBodyErr(resp.Body); len(s) > 0 {
+			return errors.New(s)
+		}
+		return fmt.Errorf("Bad Status %s(%d)", resp.Status, resp.StatusCode)
+	}
 }


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses https://github.com/gravwell/issues/issues/2528.

Sister PR to https://github.com/gravwell/backend/pull/3985.

## This PR adds the previewBytes param

Files and Resources can now take a previewBytes param to limit the number of bytes of content returned.

## This PR adds GetResourcesEx

>[!NOTE]
>I am not married to the API (just adding previewBytes as a param). If we forsee more parameters, we should switch to an Options style (ex: `types.GetResourceOptions` with fields `PreviewBytes` and `IncludeDeleted`/QO). I am open to other ideas.

## PR Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e and/or unit tests included. If not, please provide an explanation.
- [ ] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
