### PR TITLE
feat(#2539): Results ax generation

### DIFF
--- a/client/explore.go
+++ b/client/explore.go
@@ -15,11 +15,7 @@ import "github.com/gravwell/gravwell/v4/client/types"
 // The map keys are extraction modules, e.g. "json" or "winlog". The map values are arrays of
 // GenerateAXResponse structures, each representing one possible extraction of the data, including
 // an AX definition which can be installed if the user deems the extraction appropriate.
-func (c *Client) ExploreGenerate(tag string, ents []types.SearchEntry) (mp map[string][]types.GenerateAXResponse, err error) {
-	req := types.GenerateAXRequest{
-		Tag:     tag,
-		Entries: ents,
-	}
-	err = c.postStaticURL(exploreGenerateUrl(), req, &mp)
+func (c *Client) ExploreGenerate(sid string) (mp map[string][]types.GenerateAXResponse, err error) {
+	err = c.postStaticURL(exploreGenerateUrl(sid), nil, &mp)
 	return
 }

--- a/client/types/search.go
+++ b/client/types/search.go
@@ -60,14 +60,6 @@ type Element struct {
 	Filters     []string
 }
 
-// A GenerateAXRequest contains a tag name and a set of entries.
-// It is used by clients to request all possible extractions from the given entries.
-// All entries should have the same tag.
-type GenerateAXRequest struct {
-	Tag     string
-	Entries []SearchEntry
-}
-
 // A GenerateAXResponse contains an autoextractor definition
 // and corresponding Element extractions as gathered from a single extraction module
 type GenerateAXResponse struct {

--- a/client/urls.go
+++ b/client/urls.go
@@ -95,6 +95,7 @@ const (
 	SEARCH_CTRL_ENTRIES_URL          = `/api/searchctrl/%s/renderer/%s`
 	SEARCH_CTRL_IMPORT_URL           = `/api/searchctrl/import`
 	SEARCH_CTRL_LAUNCH_URL           = `/api/searchctrl/launch`
+	SEARCH_CTRL_GENERATE_AX_URL      = `/api/searchctrl/%s/generate-extractor`
 	SEARCH_HISTORY_URL               = `/api/searchhistory/%s/%d`
 	NOTIFICATIONS_URL                = `/api/notifications`
 	NOTIFICATIONS_ID_URL             = `/api/notifications/%d`
@@ -160,7 +161,6 @@ const (
 	EXTRACTORS_ID_URL                = `/api/autoextractors/%s`
 	EXTRACTORS_SYNC_URL              = `/api/autoextractors/sync`
 	EXTRACTORS_ENGINES_URL           = `/api/autoextractors/engines`
-	EXPLORE_GENERATE_URL             = `/api/explore/generate`
 	TEMPLATES_URL                    = "/api/templates"
 	TEMPLATES_ID_URL                 = "/api/templates/%s"
 	TEMPLATES_ID_DETAILS_URL         = "/api/templates/%s/details"
@@ -582,8 +582,8 @@ func extractionEnginesUrl() string {
 	return EXTRACTORS_ENGINES_URL
 }
 
-func exploreGenerateUrl() string {
-	return EXPLORE_GENERATE_URL
+func exploreGenerateUrl(sid string) string {
+	return fmt.Sprintf(SEARCH_CTRL_GENERATE_AX_URL, sid)
 }
 
 func templatesUrl() string {


### PR DESCRIPTION
This PR addresses https://github.com/gravwell/issues/issues/2539

## This PR proposes...

- Adds the types and paths according to https://github.com/gravwell/api-docs/pull/705
- Deprecates POST /api/explore/generate.
- Rewires CLI client to use new endpoint.

## PR Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e and/or unit tests included. If not, please provide an explanation.
- [ ] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
