### PR TITLE
fix(2525): allow targeted http listener debugging

### DIFF
--- a/e2e/ingesters/HttpIngester/hec_test.go
+++ b/e2e/ingesters/HttpIngester/hec_test.go
@@ -110,13 +110,7 @@ func TestHecNoDebug(t *testing.T) {
 		SendHecEvent(t, endpoint, strings.NewReader(data))
 
 		c := e2e.GetClient(t)
-		ent := e2e.WaitForEntries(t, c, "tag=hec-no-debug words -e DATA hec no debug", time.Minute, 1, 30*time.Second)
-		if len(ent) != 1 {
-			e2e.Fatalf(t, "got %d entries, want 1", len(ent))
-		}
-		if string(ent[0].Data) != "hec no debug" {
-			e2e.Fatalf(t, "got %s, want %s", string(ent[0].Data), "hec no debug")
-		}
+		assert(t, e2e.WaitForEntries(t, c, "tag=hec-no-debug words -e DATA hec no debug", time.Minute, 1, 30*time.Second), 1, "hec no debug")
 	})
 
 	t.Run("raw ingest", func(t *testing.T) {
@@ -124,13 +118,7 @@ func TestHecNoDebug(t *testing.T) {
 		SendHecRaw(t, endpoint, strings.NewReader(data))
 
 		c := e2e.GetClient(t)
-		ent := e2e.WaitForEntries(t, c, "tag=hec-no-debug words -e DATA raw hec no debug", time.Minute, 1, 30*time.Second)
-		if len(ent) != 1 {
-			e2e.Fatalf(t, "got %d entries, want 1", len(ent))
-		}
-		if string(ent[0].Data) != data {
-			e2e.Fatalf(t, "got %s, want %s", string(ent[0].Data), data)
-		}
+		assert(t, e2e.WaitForEntries(t, c, "tag=hec-no-debug words -e DATA raw hec no debug", time.Minute, 1, 30*time.Second), 1, data)
 	})
 }
 

--- a/e2e/ingesters/HttpIngester/http_test.go
+++ b/e2e/ingesters/HttpIngester/http_test.go
@@ -1,32 +1,242 @@
 package HttpIngester
 
 import (
+	"encoding/base64"
+	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
 
 	"gravwell/e2e"
+
+	"github.com/gravwell/gravwell/v3/ingesters/utils"
 )
 
 func TestHttp(t *testing.T) {
 	_, endpoint := setup(t, "http")
-	data := `{"data": "passed"}`
-	resp, err := http.Post(endpoint+"/ingest", "application/json", strings.NewReader(data))
+	t.Run("basic ingest", func(t *testing.T) {
+		data := `{"data": "passed"}`
+		SendHttpNoAuth(t, endpoint+"/ingest", strings.NewReader(data))
+
+		c := e2e.GetClient(t)
+		assert(t, e2e.WaitForEntries(t, c, "tag=http", time.Minute, 1, 30*time.Second), 1, data)
+	})
+	t.Run("basic auth ingest", func(t *testing.T) {
+		data := `{"data": "passed"}`
+		SendHttpBasicAuth(t, endpoint+"/ingest/auth", "username:password", strings.NewReader(data), http.StatusOK)
+
+		c := e2e.GetClient(t)
+		assert(t, e2e.WaitForEntries(t, c, "tag=http-auth", time.Minute, 1, 30*time.Second), 1, data)
+	})
+	t.Run("basic auth fails with bad username", func(t *testing.T) {
+		data := `{"data": "passed"}`
+		SendHttpBasicAuth(t, endpoint+"/ingest/auth", "blah:password", strings.NewReader(data), http.StatusUnauthorized)
+	})
+	t.Run("basic auth fails with bad password", func(t *testing.T) {
+		data := `{"data": "passed"}`
+		SendHttpBasicAuth(t, endpoint+"/ingest/auth", "username:blah", strings.NewReader(data), http.StatusUnauthorized)
+	})
+	t.Run("jwt auth ingest", func(t *testing.T) {
+		data := `{"data": "passed"}`
+		jwt := JwtLogin(t, endpoint+"/jwt/login", "username", "password", http.StatusOK)
+		SendHttpJwtAuth(t, endpoint+"/jwt", jwt, strings.NewReader(data), http.StatusOK)
+
+		c := e2e.GetClient(t)
+		assert(t, e2e.WaitForEntries(t, c, "tag=http-jwt", time.Minute, 1, 30*time.Second), 1, data)
+	})
+	t.Run("jwt login fails with bad username", func(t *testing.T) {
+		JwtLogin(t, endpoint+"/jwt/login", "blah", "password", http.StatusForbidden)
+	})
+	t.Run("jwt login fails with bad password", func(t *testing.T) {
+		JwtLogin(t, endpoint+"/jwt/login", "username", "blah", http.StatusForbidden)
+	})
+	t.Run("jwt auth fails with bad value", func(t *testing.T) {
+		data := `{"data": "passed"}`
+		SendHttpJwtAuth(t, endpoint+"/jwt", "my.fake.jwt", strings.NewReader(data), http.StatusUnauthorized)
+	})
+	t.Run("cookie auth ingest", func(t *testing.T) {
+		data := `{"data": "passed"}`
+		jwt := CookieLogin(t, endpoint+"/cookie/login", "username", "password", http.StatusOK)
+		SendHttpCookieAuth(t, endpoint+"/cookie", jwt, strings.NewReader(data), http.StatusOK)
+
+		c := e2e.GetClient(t)
+		assert(t, e2e.WaitForEntries(t, c, "tag=http-cookie", time.Minute, 1, 30*time.Second), 1, data)
+	})
+	t.Run("cookie login fails with bad username", func(t *testing.T) {
+		CookieLogin(t, endpoint+"/cookie/login", "blah", "password", http.StatusForbidden)
+	})
+	t.Run("cookie login fails with bad password", func(t *testing.T) {
+		CookieLogin(t, endpoint+"/cookie/login", "username", "blah", http.StatusForbidden)
+	})
+	t.Run("cookie auth fails with bad value", func(t *testing.T) {
+		data := `{"data": "passed"}`
+		SendHttpCookieAuth(t, endpoint+"/cookie", "my.fake.cookie", strings.NewReader(data), http.StatusUnauthorized)
+	})
+	t.Run("token auth ingest", func(t *testing.T) {
+		data := `{"data": "passed"}`
+		SendHttpTokenAuth(t, endpoint+"/token", "Secret", strings.NewReader(data), http.StatusOK)
+
+		c := e2e.GetClient(t)
+		assert(t, e2e.WaitForEntries(t, c, "tag=http-token", time.Minute, 1, 30*time.Second), 1, data)
+	})
+	t.Run("token auth fails with bad value", func(t *testing.T) {
+		data := `{"data": "passed"}`
+		SendHttpTokenAuth(t, endpoint+"/token", "blah", strings.NewReader(data), http.StatusUnauthorized)
+	})
+	t.Run("param auth ingest", func(t *testing.T) {
+		data := `{"data": "passed"}`
+		SendHttpParamAuth(t, endpoint+"/param", "Secret", strings.NewReader(data), http.StatusOK)
+
+		c := e2e.GetClient(t)
+		assert(t, e2e.WaitForEntries(t, c, "tag=http-param", time.Minute, 1, 30*time.Second), 1, data)
+	})
+	t.Run("param auth fails with bad value", func(t *testing.T) {
+		data := `{"data": "passed"}`
+		SendHttpParamAuth(t, endpoint+"/param", "blah", strings.NewReader(data), http.StatusUnauthorized)
+	})
+	t.Run("header auth ingest", func(t *testing.T) {
+		data := `{"data": "passed"}`
+		SendHttpHeaderAuth(t, endpoint+"/header", "Secret", strings.NewReader(data), http.StatusOK)
+
+		c := e2e.GetClient(t)
+		assert(t, e2e.WaitForEntries(t, c, "tag=http-header", time.Minute, 1, 30*time.Second), 1, data)
+	})
+	t.Run("header auth fails with bad value", func(t *testing.T) {
+		data := `{"data": "passed"}`
+		SendHttpHeaderAuth(t, endpoint+"/header", "blah", strings.NewReader(data), http.StatusUnauthorized)
+	})
+}
+
+func sendHttp(t *testing.T, req *http.Request, expectedStatus int) {
+	t.Helper()
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("got bad http status %d", resp.StatusCode)
+	defer utils.DrainResponse(resp)
+	if resp.StatusCode != expectedStatus {
+		t.Fatalf("got status %d, expected %d", resp.StatusCode, expectedStatus)
+	}
+}
+
+func SendHttpNoAuth(t *testing.T, endpoint string, body io.Reader) {
+	t.Helper()
+	req, err := http.NewRequest("POST", endpoint, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sendHttp(t, req, http.StatusOK)
+}
+
+func SendHttpBasicAuth(t *testing.T, endpoint, auth string, body io.Reader, expectedStatus int) {
+	t.Helper()
+	req, err := http.NewRequest("POST", endpoint, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(auth)))
+	sendHttp(t, req, expectedStatus)
+}
+
+func JwtLogin(t *testing.T, endpoint, username, password string, expectedStatus int) string {
+	t.Helper()
+	resp, err := http.PostForm(endpoint, url.Values{
+		"username": []string{username},
+		"password": []string{password},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer utils.DrainResponse(resp)
+	if resp.StatusCode != expectedStatus {
+		t.Fatalf("got status %d, expected %d", resp.StatusCode, expectedStatus)
+	}
+	bytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(bytes)
+}
+
+func SendHttpJwtAuth(t *testing.T, endpoint, jwt string, body io.Reader, expectedStatus int) {
+	t.Helper()
+	req, err := http.NewRequest("POST", endpoint, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+jwt)
+	sendHttp(t, req, expectedStatus)
+}
+
+func CookieLogin(t *testing.T, endpoint, username, password string, expectedStatus int) string {
+	t.Helper()
+	resp, err := http.PostForm(endpoint, url.Values{
+		"username": []string{username},
+		"password": []string{password},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer utils.DrainResponse(resp)
+	if resp.StatusCode != expectedStatus {
+		t.Fatalf("got status %d, expected %d", resp.StatusCode, expectedStatus)
+	}
+	c := resp.Cookies()
+	for _, cookie := range c {
+		if cookie.Name == "_gravauth" {
+			return cookie.Value
+		}
 	}
 
-	c := e2e.GetClient(t)
-	ent := e2e.WaitForEntries(t, c, "tag=http", time.Minute, 1, 30*time.Second)
-	if len(ent) != 1 {
-		e2e.Fatalf(t, "got %d entries, want 1", len(ent))
+	return ""
+}
+
+func SendHttpCookieAuth(t *testing.T, endpoint, cookie string, body io.Reader, expectedStatus int) {
+	t.Helper()
+	req, err := http.NewRequest("POST", endpoint, body)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if string(ent[0].Data) != data {
-		e2e.Fatalf(t, "got %s, want %s", string(ent[0].Data), data)
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{
+		Name:  "_gravauth",
+		Value: cookie,
+	})
+	sendHttp(t, req, expectedStatus)
+}
+
+func SendHttpTokenAuth(t *testing.T, endpoint, token string, body io.Reader, expectedStatus int) {
+	t.Helper()
+	req, err := http.NewRequest("POST", endpoint, body)
+	if err != nil {
+		t.Fatal(err)
 	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Add("Authorization", "Gravwell "+token)
+	sendHttp(t, req, expectedStatus)
+}
+
+func SendHttpHeaderAuth(t *testing.T, endpoint, token string, body io.Reader, expectedStatus int) {
+	t.Helper()
+	req, err := http.NewRequest("POST", endpoint, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Add("Gravwell", token)
+	sendHttp(t, req, expectedStatus)
+}
+
+func SendHttpParamAuth(t *testing.T, endpoint, token string, body io.Reader, expectedStatus int) {
+	t.Helper()
+	req, err := http.NewRequest("POST", endpoint+"?Gravwell="+token, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	sendHttp(t, req, expectedStatus)
 }

--- a/e2e/ingesters/HttpIngester/testdata/http.conf
+++ b/e2e/ingesters/HttpIngester/testdata/http.conf
@@ -9,62 +9,55 @@
     Log-File=/opt/gravwell/log/http_ingester.log #optional log file
     Health-Check-URL="/health/check"
 
-[Listener "test1"]
+[Listener "ingest"]
 	URL="/ingest"
 	Tag-Name=http
 
-# Example using basic authentication
-[Listener "basicAuthExample"]
+[Listener "auth"]
 	URL="/ingest/auth"
 	Tag-Name=http-auth
 	AuthType=basic
 	Username=username
 	Password=password
-#
-# Example using JWT based authentication
-#[Listener "jwtAuthExample"]
-#	URL="/jwt"
-#	Tag-Name=jwtstuff
-#	AuthType=jwt
-#	LoginURL="/jwt/login"
-#	Username=user1
-#	Password=pass1
-#	Method=PUT #alternate method, data is still expected in the body of the request
-#
-# Example using cookie based authentication
-#[Listener "cookieAuthExample"]
-#	URL="/cookie"
-#	Tag-Name=cookiestuff
-#	AuthType=cookie
-#	LoginURL="/cookie/login"
-#	Username=user1
-#	Password=pass1
-#	Method=PUT #alternate method, data is still expected in the body of the request
-#
-#
-# Example using an authorization token that is preshared, no login
-#[Listener "presharedTokenAuthExample"]
-#	URL="/preshared/token"
-#	Tag-Name=pretoken
-#	AuthType="preshared-token"
-#	TokenName=Gravwell
-#	TokenValue=Secret
-#
+
+[Listener "jwt"]
+	URL="/jwt"
+	Tag-Name=http-jwt
+	AuthType=jwt
+	LoginURL="/jwt/login"
+	Username=username
+	Password=password
+
+[Listener "cookie"]
+	URL="/cookie"
+	Tag-Name=http-cookie
+	AuthType=cookie
+	LoginURL="/cookie/login"
+	Username=username
+	Password=password
+
+[Listener "token"]
+	URL="/token"
+	Tag-Name=http-token
+	AuthType="preshared-token"
+	TokenName=Gravwell
+	TokenValue=Secret
+
 # Example using a token in a query parameter that is preshared, no login
-#[Listener "presharedTokenAuthExample"]
-#	URL="/preshared/param"
-#	Tag-Name=preparam
-#	AuthType="preshared-parameter"
-#	TokenName=Gravwell
-#	TokenValue=Secret
+[Listener "param"]
+	URL="/param"
+	Tag-Name=http-param
+	AuthType="preshared-parameter"
+	TokenName=Gravwell
+	TokenValue=Secret
 #
 # Example using a preshared value in a header
-#[Listener "presharedHeaderAuthExample"]
-#	URL="/preshared/header"
-#	Tag-Name=preheader
-#	AuthType="preshared-header"
-#	TokenName=Gravwell
-#	TokenValue=Secret
+[Listener "header"]
+	URL="/header"
+	Tag-Name=http-header
+	AuthType="preshared-header"
+	TokenName=Gravwell
+	TokenValue=Secret
 #
 # Example that creates a listener that is API compatible with the Splunk HEC
 ; [HEC-Compatible-Listener "testing"]

--- a/ingesters/HttpIngester/amazon_firehose.go
+++ b/ingesters/HttpIngester/amazon_firehose.go
@@ -166,7 +166,7 @@ func sendAFHOk(w http.ResponseWriter, id string) {
 }
 
 func includeAFHListeners(hnd *handler, igst *ingest.IngestMuxer, cfg *cfgType, lgr *log.Logger) (err error) {
-	for _, v := range cfg.AFHListener {
+	for k, v := range cfg.AFHListener {
 		hcfg := routeHandler{
 			handler:    handleAFH,
 			debugPosts: v.Debug_Posts,
@@ -187,6 +187,10 @@ func includeAFHListeners(hnd *handler, igst *ingest.IngestMuxer, cfg *cfgType, l
 		}
 		if hcfg.auth, err = newPresharedHeaderTokenHandler(afhAuthTokenHeader, v.TokenValue, lgr); err != nil {
 			return fmt.Errorf("failed to generate Amazon Firehose auth %w", err)
+		}
+		if *debugListener == k {
+			hcfg.handler = newDebugLoggingHandler(hcfg.handler, DefaultDebugLogger).Handle
+			hcfg.auth = newDebugLoggingAuther(hcfg.auth, DefaultDebugLogger)
 		}
 		if hnd.addHandler(http.MethodPost, v.URL, hcfg); err != nil {
 			return fmt.Errorf("failed to add handler for %q %w", v.URL, err)

--- a/ingesters/HttpIngester/config.go
+++ b/ingesters/HttpIngester/config.go
@@ -341,6 +341,35 @@ func (c *cfgType) MaxBody() int {
 	return c.Max_Body
 }
 
+func (c *cfgType) HasDebugListener() bool {
+	for _, v := range c.Listener {
+		if v.Debug_Posts {
+			return true
+		}
+	}
+	for _, v := range c.HECListener {
+		if v.Debug_Posts {
+			return true
+		}
+	}
+	for _, v := range c.AFHListener {
+		if v.Debug_Posts {
+			return true
+		}
+	}
+	for _, v := range c.OtelListener {
+		if v.Debug_Posts {
+			return true
+		}
+	}
+	for _, v := range c.OtelLogsListener {
+		if v.Debug_Posts {
+			return true
+		}
+	}
+	return false
+}
+
 func (g gbl) ValidateTLS() (err error) {
 	if !g.TLSEnabled() {
 		//not enabled

--- a/ingesters/HttpIngester/debug.go
+++ b/ingesters/HttpIngester/debug.go
@@ -1,31 +1,122 @@
 package main
 
 import (
+	"fmt"
 	"io"
+	"net"
 	"net/http"
-	"time"
+	"os"
 
 	"github.com/crewjam/rfc5424"
 	"github.com/gravwell/gravwell/v3/ingest/log"
 )
 
+var DefaultDebugLogger debugLogger
+
+func init() {
+	l := log.New(os.Stdout)
+	l.SetLevel(log.DEBUG)
+	DefaultDebugLogger = l
+}
+
 type debugLogger interface {
 	Debug(msg string, sds ...rfc5424.SDParam) error
 }
 
-type debugMiddleware struct {
+type debugLoggingMiddlware struct {
 	logger debugLogger
 	next   http.Handler
 }
 
-func newDebugMiddleware(logger debugLogger, next http.Handler) *debugMiddleware {
-	return &debugMiddleware{
+func newDebugLoggingMiddleware(next http.Handler, logger debugLogger) *debugLoggingMiddlware {
+	return &debugLoggingMiddlware{
 		logger: logger,
 		next:   next,
 	}
 }
 
-func (d *debugMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (d *debugLoggingMiddlware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	d.next.ServeHTTP(w, r)
+
+	rkv := requestKV(w, r)
+	d.logger.Debug("http debug", rkv...)
+	for k, v := range r.Header {
+		d.logger.Debug(fmt.Sprintf("%v: %v", k, v))
+	}
+}
+
+type debugLoggingHandler struct {
+	logger debugLogger
+	next   handleFunc
+}
+
+func newDebugLoggingHandler(next handleFunc, logger debugLogger) *debugLoggingHandler {
+	return &debugLoggingHandler{
+		logger: logger,
+		next:   next,
+	}
+}
+
+func (d *debugLoggingHandler) Handle(h *handler, rh routeHandler, w http.ResponseWriter, r *http.Request, rdr io.Reader, ip net.IP) {
+	d.next(h, rh, w, r, rdr, ip)
+
+	rkv := requestKV(w, r)
+	d.logger.Debug("http debug", rkv...)
+	for k, v := range r.Header {
+		d.logger.Debug(fmt.Sprintf("%v: %v", k, v))
+	}
+}
+
+type debugLoggingAuther struct {
+	logger debugLogger
+	next   authHandler
+}
+
+func newDebugLoggingAuther(next authHandler, logger debugLogger) *debugLoggingAuther {
+	return &debugLoggingAuther{
+		logger: logger,
+		next:   next,
+	}
+}
+
+func (d *debugLoggingAuther) AuthRequest(r *http.Request) error {
+	err := d.next.AuthRequest(r)
+	// This is really wacky. We only handle the error case as otherwise the
+	// request continues to another handler...
+	if err != nil {
+		rw := &trackingRW{
+			code: http.StatusUnauthorized, // lie because custom interfaces...
+		}
+		rkv := requestKV(rw, r)
+		d.logger.Debug("http debug", rkv...)
+		for k, v := range r.Header {
+			d.logger.Debug(fmt.Sprintf("%v: %v", k, v))
+		}
+	}
+
+	return err
+}
+
+func (d *debugLoggingAuther) Login(w http.ResponseWriter, r *http.Request) {
+	d.next.Login(w, r)
+	rkv := requestKV(w, r)
+	d.logger.Debug("http debug", rkv...)
+	for k, v := range r.Header {
+		d.logger.Debug(fmt.Sprintf("%v: %v", k, v))
+	}
+}
+
+type trackingMiddleware struct {
+	next http.Handler
+}
+
+func newTrackingMiddleware(next http.Handler) *trackingMiddleware {
+	return &trackingMiddleware{
+		next: next,
+	}
+}
+
+func (d *trackingMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	wrapped := &trackingRW{
 		ResponseWriter: w,
 	}
@@ -35,15 +126,6 @@ func (d *debugMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r.Body = body
 
 	d.next.ServeHTTP(wrapped, r)
-
-	rkv := requestKV(wrapped, r)
-	d.logger.Debug("http debug", rkv...)
-	debugout("http debug: %s %v\n", time.Now().Format(time.RFC3339), rkv)
-	// We don't want to log the headers as that likely makes it to a gravwell instance.
-	// This would result in token leaks.
-	for k, v := range r.Header {
-		debugout("\t%v: %v\n", k, v)
-	}
 }
 
 // trackingRC wraps an io.ReadCloser and keeps track of how many bytes were read.

--- a/ingesters/HttpIngester/debug.go
+++ b/ingesters/HttpIngester/debug.go
@@ -24,24 +24,28 @@ type debugLogger interface {
 }
 
 type debugLoggingMiddlware struct {
-	logger debugLogger
-	next   http.Handler
+	logger      debugLogger
+	next        http.Handler
+	allRequests bool
 }
 
-func newDebugLoggingMiddleware(next http.Handler, logger debugLogger) *debugLoggingMiddlware {
+func newDebugLoggingMiddleware(next http.Handler, logger debugLogger, all bool) *debugLoggingMiddlware {
 	return &debugLoggingMiddlware{
-		logger: logger,
-		next:   next,
+		logger:      logger,
+		next:        next,
+		allRequests: all,
 	}
 }
 
 func (d *debugLoggingMiddlware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	d.next.ServeHTTP(w, r)
 
-	rkv := requestKV(w, r)
-	d.logger.Debug("http debug", rkv...)
-	for k, v := range r.Header {
-		d.logger.Debug(fmt.Sprintf("%v: %v", k, v))
+	if d.allRequests || responseCode(w) >= 400 {
+		rkv := requestKV(w, r)
+		d.logger.Debug("http debug", rkv...)
+		for k, v := range r.Header {
+			d.logger.Debug(fmt.Sprintf("%v: %v", k, v))
+		}
 	}
 }
 
@@ -60,10 +64,12 @@ func newDebugLoggingHandler(next handleFunc, logger debugLogger) *debugLoggingHa
 func (d *debugLoggingHandler) Handle(h *handler, rh routeHandler, w http.ResponseWriter, r *http.Request, rdr io.Reader, ip net.IP) {
 	d.next(h, rh, w, r, rdr, ip)
 
-	rkv := requestKV(w, r)
-	d.logger.Debug("http debug", rkv...)
-	for k, v := range r.Header {
-		d.logger.Debug(fmt.Sprintf("%v: %v", k, v))
+	if responseCode(w) >= 400 {
+		rkv := requestKV(w, r)
+		d.logger.Debug("http debug", rkv...)
+		for k, v := range r.Header {
+			d.logger.Debug(fmt.Sprintf("%v: %v", k, v))
+		}
 	}
 }
 
@@ -99,10 +105,12 @@ func (d *debugLoggingAuther) AuthRequest(r *http.Request) error {
 
 func (d *debugLoggingAuther) Login(w http.ResponseWriter, r *http.Request) {
 	d.next.Login(w, r)
-	rkv := requestKV(w, r)
-	d.logger.Debug("http debug", rkv...)
-	for k, v := range r.Header {
-		d.logger.Debug(fmt.Sprintf("%v: %v", k, v))
+	if responseCode(w) >= 400 {
+		rkv := requestKV(w, r)
+		d.logger.Debug("http debug", rkv...)
+		for k, v := range r.Header {
+			d.logger.Debug(fmt.Sprintf("%v: %v", k, v))
+		}
 	}
 }
 
@@ -174,7 +182,6 @@ func requestKV(w http.ResponseWriter, r *http.Request) []rfc5424.SDParam {
 	params := make([]rfc5424.SDParam, 0, 5)
 	if trw, ok := w.(*trackingRW); ok {
 		params = append(params, log.KV("code", trw.code))
-
 	}
 	if trc, ok := r.Body.(*trackingRC); ok {
 		params = append(params, log.KV("bytes", trc.bytes))
@@ -184,4 +191,11 @@ func requestKV(w http.ResponseWriter, r *http.Request) []rfc5424.SDParam {
 		log.KV("url", r.URL.RequestURI()),
 		log.KV("ip", getRemoteIP(r)),
 	)
+}
+
+func responseCode(w http.ResponseWriter) int {
+	if trw, ok := w.(*trackingRW); ok {
+		return trw.code
+	}
+	return 0
 }

--- a/ingesters/HttpIngester/handlers.go
+++ b/ingesters/HttpIngester/handlers.go
@@ -194,8 +194,8 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if h.igst.WillBlock() {
 			w.WriteHeader(http.StatusInsufficientStorage)
 		}
-		//just return, this is an implied 200 or we already wrote the insufficient storage response
-		r.Body.Close() // close, we aren't reading this
+		drainAndClose(r.Body) // close, we aren't reading this
+		w.WriteHeader(http.StatusOK)
 		return
 	}
 
@@ -402,6 +402,7 @@ func handleMulti(h *handler, cfg routeHandler, w http.ResponseWriter, r *http.Re
 		h.lgr.Warn("failed to handle multiline upload", log.KVErr(err))
 		w.WriteHeader(http.StatusBadRequest)
 	}
+	w.WriteHeader(http.StatusOK)
 }
 
 func handleSingle(h *handler, cfg routeHandler, w http.ResponseWriter, r *http.Request, rdr io.Reader, ip net.IP) {
@@ -441,4 +442,5 @@ func handleSingle(h *handler, cfg routeHandler, w http.ResponseWriter, r *http.R
 		return
 	}
 	entries++
+	w.WriteHeader(http.StatusOK)
 }

--- a/ingesters/HttpIngester/hec_config.go
+++ b/ingesters/HttpIngester/hec_config.go
@@ -238,10 +238,18 @@ func includeHecListeners(hnd *handler, igst *ingest.IngestMuxer, cfg *cfgType) (
 			return fmt.Errorf("HEC authentication error %w", err)
 		}
 		hh.hecHealth.auth = hh.auth // give the health handler access to the auth struct pointer too
+		var h handleFunc = hh.handle
+		var raw handleFunc = hh.handleRaw
+		var a authHandler = hh.auth
+		if *debugListener == k {
+			h = newDebugLoggingHandler(h, DefaultDebugLogger).Handle
+			raw = newDebugLoggingHandler(raw, DefaultDebugLogger).Handle
+			a = newDebugLoggingAuther(a, DefaultDebugLogger)
+		}
 		hcfg := routeHandler{
-			handler:       hh.handle,
+			handler:       h,
 			paramAttacher: getAttacher(v.Attach_URL_Parameter),
-			auth:          hh.auth,
+			auth:          a,
 			debugPosts:    v.Debug_Posts,
 		}
 
@@ -295,7 +303,7 @@ func includeHecListeners(hnd *handler, igst *ingest.IngestMuxer, cfg *cfgType) (
 			return fmt.Errorf("failed to add HEC-Compatible-Listener ACK health handler %w", err)
 		}
 		// add in the raw handler
-		hcfg.handler = hh.handleRaw
+		hcfg.handler = raw
 		if err = hnd.addHandler(http.MethodPost, path.Join(bp, `raw`), hcfg); err != nil {
 			return fmt.Errorf("failed to add HEC-Compatible-Listener handler %w", err)
 		}

--- a/ingesters/HttpIngester/main.go
+++ b/ingesters/HttpIngester/main.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	dlog "log"
@@ -48,6 +49,7 @@ var (
 	maxBody int
 
 	exitCtx, exitFn = context.WithCancel(context.Background())
+	debugListener   = flag.String("debug", "", "listener to debug")
 )
 
 func main() {
@@ -69,6 +71,11 @@ func main() {
 		fmt.Fprintf(os.Stderr, "failed to assign configuration %v %v\n", err, cfg == nil)
 		return
 	}
+
+	if !flag.Parsed() { // config should have handled this, but be sure
+		flag.Parse()
+	}
+
 	debugOn = ib.Verbose
 	lg = ib.Logger
 
@@ -119,7 +126,12 @@ func main() {
 
 	var chain http.Handler = hnd
 	if debugOn {
-		chain = newDebugMiddleware(lg, hnd)
+		chain = newDebugLoggingMiddleware(hnd, DefaultDebugLogger)
+	}
+	// little wacky to check debugOn again, but we only want to add the
+	// tracking once, and it needs to be first.
+	if debugOn || cfg.HasDebugListener() || *debugListener != "" {
+		chain = newTrackingMiddleware(chain)
 	}
 
 	srv := &http.Server{
@@ -301,15 +313,19 @@ func (is *instrumentListener) Accept() (net.Conn, error) {
 }
 
 func includeStdListeners(hnd *handler, igst *ingest.IngestMuxer, cfg *cfgType) (err error) {
-	for _, v := range cfg.Listener {
+	for k, v := range cfg.Listener {
+		var h handleFunc = handleSingle
+		if v.Multiline {
+			h = handleMulti
+		}
+		if *debugListener == k {
+			h = newDebugLoggingHandler(h, DefaultDebugLogger).Handle
+		}
 		hcfg := routeHandler{
-			handler:       handleSingle,
+			handler:       h,
 			paramAttacher: getAttacher(v.Attach_URL_Parameter),
 			debugPosts:    v.Debug_Posts,
 			bufferSize:    v.Buffer_Size,
-		}
-		if v.Multiline {
-			hcfg.handler = handleMulti
 		}
 		if hcfg.tag, err = igst.NegotiateTag(v.Tag_Name); err != nil {
 			return fmt.Errorf("failed to negotiate tag %s %w", v.Tag_Name, err)
@@ -357,6 +373,9 @@ func includeStdListeners(hnd *handler, igst *ingest.IngestMuxer, cfg *cfgType) (
 		if pth, ah, err := v.NewAuthHandler(lg); err != nil {
 			return fmt.Errorf("failed to get a new authentication handler %w", err)
 		} else if hnd != nil {
+			if *debugListener == k {
+				ah = newDebugLoggingAuther(ah, DefaultDebugLogger)
+			}
 			if pth != `` {
 				if err = hnd.addAuthHandler(http.MethodPost, pth, ah); err != nil {
 					return fmt.Errorf("failed to add auth handler url %q %w", pth, err)

--- a/ingesters/HttpIngester/main.go
+++ b/ingesters/HttpIngester/main.go
@@ -126,7 +126,7 @@ func main() {
 
 	var chain http.Handler = hnd
 	if debugOn {
-		chain = newDebugLoggingMiddleware(hnd, DefaultDebugLogger)
+		chain = newDebugLoggingMiddleware(hnd, DefaultDebugLogger, true)
 	}
 	// little wacky to check debugOn again, but we only want to add the
 	// tracking once, and it needs to be first.

--- a/ingesters/HttpIngester/otel_logs.go
+++ b/ingesters/HttpIngester/otel_logs.go
@@ -385,8 +385,13 @@ func includeOtelLogsListeners(hnd *handler, igst *ingest.IngestMuxer, cfg *cfgTy
 			return fmt.Errorf("TimestampWindow is invalid %w", err)
 		}
 
+		var h handleFunc = oh.handle
+		if *debugListener == k {
+			h = newDebugLoggingHandler(h, DefaultDebugLogger).Handle
+		}
+
 		hcfg := routeHandler{
-			handler:    oh.handle,
+			handler:    h,
 			debugPosts: v.Debug_Posts,
 		}
 
@@ -417,6 +422,9 @@ func includeOtelLogsListeners(hnd *handler, igst *ingest.IngestMuxer, cfg *cfgTy
 		if pth, ah, err := v.NewAuthHandler(hnd.lgr); err != nil {
 			return fmt.Errorf("failed to get a new authentication handler %w", err)
 		} else {
+			if *debugListener == k {
+				ah = newDebugLoggingAuther(ah, DefaultDebugLogger)
+			}
 			if pth != `` {
 				// add custom auth handler for this URL
 				if err = hnd.addAuthHandler(http.MethodPost, pth, ah); err != nil {

--- a/ingesters/HttpIngester/otel_metrics.go
+++ b/ingesters/HttpIngester/otel_metrics.go
@@ -729,8 +729,13 @@ func includeOtelMetricsListeners(hnd *handler, igst *ingest.IngestMuxer, cfg *cf
 			return fmt.Errorf("TimestampWindow is invalid %w", err)
 		}
 
+		var h handleFunc = oh.handle
+		if *debugListener == k {
+			h = newDebugLoggingHandler(h, DefaultDebugLogger).Handle
+		}
+
 		hcfg := routeHandler{
-			handler:    oh.handle,
+			handler:    h,
 			debugPosts: v.Debug_Posts,
 		}
 
@@ -761,6 +766,9 @@ func includeOtelMetricsListeners(hnd *handler, igst *ingest.IngestMuxer, cfg *cf
 		if pth, ah, err := v.NewAuthHandler(hnd.lgr); err != nil {
 			return fmt.Errorf("failed to get a new authentication handler %w", err)
 		} else {
+			if *debugListener == k {
+				ah = newDebugLoggingAuther(ah, DefaultDebugLogger)
+			}
 			if pth != `` {
 				if err = hnd.addAuthHandler(http.MethodPost, pth, ah); err != nil {
 					return fmt.Errorf("failed to add auth handler url %q %w", pth, err)


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses https://github.com/gravwell/issues/issues/2525

## This PR proposes...

This build on https://github.com/gravwell/gravwell/pull/2479 by adjusting where logging actually happens and making the new logging only occur for errors. This should make it easier to troubleshoot when there are a large number of listeners by only enabling debug logging on one at a time. This is done via a new flag `-debug=[listener name]` matching the name from the config stanza.

This also adds a number of tests around authed http listeners as this got a little more invasive on the changes to individual listeners. 

A few places have been updated to explicitly write a `200` as relying on the default behavior means we don't see the code in the debug logs. 

## PR Tasks

<!-- Add tasks to this list as needed -->

- [x] e2e and/or unit tests included. If not, please provide an explanation.
- [x] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
