### PR TITLE
fix(2553): allow hosted runner config validation when db is locked

### DIFF
--- a/hosted/storage/bolt.go
+++ b/hosted/storage/bolt.go
@@ -12,9 +12,14 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"syscall"
 	"time"
 
 	bolt "go.etcd.io/bbolt"
+)
+
+var (
+	ErrFileLocked = errors.New("file is locked")
 )
 
 type BoltConfig struct {
@@ -35,16 +40,26 @@ func (s *BoltConfig) Verify() (err error) {
 		return errors.New("missing state path")
 	}
 
-	//go attempt to open and close the state file
+	// go attempt to open and close the state file
 	var sh *BoltHandler
 	if sh, err = OpenBoltHandler(s.Path, s.Sync); err != nil {
-		err = fmt.Errorf("failed to open state file %w", err)
+		// If the file is locked that likely means we're already running.
+		// The config is most likely pointing to a valid db so config is valid.
+		if errors.Is(err, ErrFileLocked) {
+			err = nil
+			return
+		}
+		err = fmt.Errorf("failed to open state file: %w", err)
 	} else if err = sh.Close(); err != nil {
-		err = fmt.Errorf("failed to close state file %w", err)
+		err = fmt.Errorf("failed to close state file: %w", err)
 	}
 	return
 }
 
+// OpenBoltHandler ensures we have read and write permission to the db file
+// before attempting to open it as a bolt db. It also checks for a special case
+// where the db is locked by another process to allow callers to handle this
+// scenario as bolt does not expose this to us.
 func OpenBoltHandler(pth string, sync bool) (sh *BoltHandler, err error) {
 	opt := bolt.Options{
 		NoSync:  !sync,
@@ -59,6 +74,11 @@ func OpenBoltHandler(pth string, sync bool) (sh *BoltHandler, err error) {
 	if exists && info.Mode().Perm()&0o200 == 0 { // exists && !writable
 		return nil, errors.New("existing state file is not writable")
 	}
+	if locked, err := checkLocked(pth); err != nil {
+		return nil, err
+	} else if locked {
+		return nil, ErrFileLocked
+	}
 	var db *bolt.DB
 	if db, err = bolt.Open(pth, 0600, &opt); err == nil {
 		sh = &BoltHandler{
@@ -66,6 +86,27 @@ func OpenBoltHandler(pth string, sync bool) (sh *BoltHandler, err error) {
 		}
 	}
 	return
+}
+
+// checkLocked is used to manually check if a file is locked. The boltdb
+// locking code suppressing the EWOULDBLOCK code and only returns a timeout.
+func checkLocked(path string) (locked bool, err error) {
+	file, err := os.OpenFile(path, os.O_RDONLY|os.O_CREATE, 0600)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+	fd := file.Fd()
+	if err = syscall.Flock(int(fd), syscall.LOCK_NB|syscall.LOCK_SH); err != nil {
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return true, nil
+		}
+		return false, fmt.Errorf("lock check failed: %w", err)
+	}
+	if err = syscall.Flock(int(fd), syscall.LOCK_UN); err != nil {
+		return false, fmt.Errorf("unlock from check failed: %w", err)
+	}
+	return false, nil
 }
 
 func (sh *BoltHandler) check() (err error) {

--- a/hosted/storage/bolt.go
+++ b/hosted/storage/bolt.go
@@ -91,13 +91,13 @@ func OpenBoltHandler(pth string, sync bool) (sh *BoltHandler, err error) {
 // checkLocked is used to manually check if a file is locked. The boltdb
 // locking code suppressing the EWOULDBLOCK code and only returns a timeout.
 func checkLocked(path string) (locked bool, err error) {
-	file, err := os.OpenFile(path, os.O_RDONLY|os.O_CREATE, 0600)
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
 		return
 	}
 	defer file.Close()
 	fd := file.Fd()
-	if err = syscall.Flock(int(fd), syscall.LOCK_NB|syscall.LOCK_SH); err != nil {
+	if err = syscall.Flock(int(fd), syscall.LOCK_NB|syscall.LOCK_EX); err != nil {
 		if errors.Is(err, syscall.EWOULDBLOCK) {
 			return true, nil
 		}

--- a/hosted/storage/bolt.go
+++ b/hosted/storage/bolt.go
@@ -89,7 +89,7 @@ func OpenBoltHandler(pth string, sync bool) (sh *BoltHandler, err error) {
 }
 
 // checkLocked is used to manually check if a file is locked. The boltdb
-// locking code suppressing the EWOULDBLOCK code and only returns a timeout.
+// locking code suppresses the EWOULDBLOCK code and only returns a timeout.
 func checkLocked(path string) (locked bool, err error) {
 	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {

--- a/hosted/storage/bolt_test.go
+++ b/hosted/storage/bolt_test.go
@@ -174,6 +174,20 @@ func TestBoltConfig_Verify(t *testing.T) {
 	}
 }
 
+func TestBoltConfig_VerifyLocked(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "locked_verify.db")
+	sh, err := OpenBoltHandler(dbPath, false)
+	if err != nil {
+		t.Fatalf("Failed to open state handler: %v", err)
+	}
+	defer sh.Close()
+	cfg := &BoltConfig{Path: dbPath, Sync: false}
+	if err := cfg.Verify(); err != nil {
+		t.Fatalf("expected Verify() to succeed when db is locked: %v", err)
+	}
+}
+
 func TestBucketWriter_ByteOperations(t *testing.T) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "bucket_test.db")

--- a/hosted/storage/bolt_test.go
+++ b/hosted/storage/bolt_test.go
@@ -9,6 +9,7 @@
 package storage
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -108,6 +109,21 @@ func TestBoltHandler_OpenReadOnly(t *testing.T) {
 		t.Fatalf("error opening database, perms: %s, err: %v", infoMode, err)
 	}
 	defer b.Close()
+}
+
+func TestBoltHandler_OpenLocked(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "locked.db")
+	sh, err := OpenBoltHandler(dbPath, false)
+	if err != nil {
+		t.Fatalf("Failed to open state handler: %v", err)
+	}
+	defer sh.Close()
+
+	_, err = OpenBoltHandler(dbPath, false)
+	if !errors.Is(err, ErrFileLocked) {
+		t.Fatalf("unexpected err checking for locked state file: %v", err)
+	}
 }
 
 func TestBoltConfig_Verify(t *testing.T) {


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses https://github.com/gravwell/issues/issues/2553

## This PR proposes...

Allow the config validation to pass for the Hosted Runner when another instance is running. This required a little extra work as bolt hides this specific scenario from us behind a vague timeout error.

## PR Tasks

<!-- Add tasks to this list as needed -->

- [x] e2e and/or unit tests included. If not, please provide an explanation.
- [x] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

### Repro
- Start an instance of the runner, eg: `go run ./hosted/runner -config-file ./hosted/plugins/tester/example.conf -v`
- Run the validate `go run ./hosted/runner -config-file ./hosted/plugins/tester/example.conf -validate`
- config should be valid. 

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
