### PR TITLE
Clean up some kit types & return values

### DIFF
--- a/client/kit.go
+++ b/client/kit.go
@@ -112,7 +112,7 @@ func (c *Client) PullKit(id string) (pc types.KitState, err error) {
 }
 
 // ListRemoteKits returns a list of kits available on the kit server.
-func (c *Client) ListRemoteKits(all bool) (mds []types.KitMetadata, err error) {
+func (c *Client) ListRemoteKits(all bool) (mds types.RemoteKitListResponse, err error) {
 	err = c.getStaticURL(remoteKitUrl(all), &mds)
 	return
 }

--- a/client/types/kits.go
+++ b/client/types/kits.go
@@ -121,8 +121,8 @@ type KitState struct {
 	Banner               string //use for banner in a kit
 	Cover                string //use for cover image on a kit
 	Signed               bool
-	MinVersion           CanonicalVersion `json:",omitempty"`
-	MaxVersion           CanonicalVersion `json:",omitempty"`
+	MinVersion           CanonicalVersion
+	MaxVersion           CanonicalVersion
 	Items                []KitItem
 	RequiredDependencies []KitMetadata
 	ConfigMacros         []KitConfigMacro
@@ -153,8 +153,8 @@ type KitBuildRequest struct {
 	KitID                 string
 	Readme                string
 	KitVersion            int
-	MinVersion            CanonicalVersion  `json:",omitempty"`
-	MaxVersion            CanonicalVersion  `json:",omitempty"`
+	MinVersion            CanonicalVersion
+	MaxVersion            CanonicalVersion
 	Dashboards            []string          `json:",omitempty"`
 	Templates             []string          `json:",omitempty"`
 	Actionables           []string          `json:",omitempty"`
@@ -184,9 +184,9 @@ type KitBuildRequestListResponse struct {
 }
 
 type KitBuildResponse struct {
-	UUID string
-	Size int64
-	UID  int32 `json:",omitempty"`
+	ID      string
+	Size    int64
+	OwnerID int32
 }
 
 func (ps *KitState) UpdateItem(name string, tp KitAssetType, id string) error {
@@ -396,6 +396,11 @@ func (kma KitMetadataAsset) String() (s string) {
 	}
 	s += fmt.Sprintf("%s (%s) %s", kma.Type, kma.Source, kma.Legend)
 	return
+}
+
+type RemoteKitListResponse struct {
+	BaseListResponse
+	Results []KitMetadata `json:"results"`
 }
 
 type InstallStatus struct {

--- a/tools/actions/kitmanager/kitwork.go
+++ b/tools/actions/kitmanager/kitwork.go
@@ -41,7 +41,7 @@ func pullKit(cli *client.Client, kbrBase types.KitBuildRequest) (err error) {
 	}
 	// initiate the download request
 	var resp *http.Response
-	if resp, err = cli.KitDownloadRequest(kresp.UUID); err != nil {
+	if resp, err = cli.KitDownloadRequest(kresp.ID); err != nil {
 		err = fmt.Errorf("failed to initiate kit download: %w", err)
 		return
 	}


### PR DESCRIPTION
KitBuildResponse fields changed.

Listing remote kits now returns a ListResponse like many other list endpoints.

