### PR TITLE
fix: require opt in for hosted tester error logs

### DIFF
--- a/e2e/hosted/testdata/tester.conf
+++ b/e2e/hosted/testdata/tester.conf
@@ -16,3 +16,4 @@
 
 [Tester "test"]
     Interval=1s
+    Test-Errors=true

--- a/hosted/plugins/okta/config.go
+++ b/hosted/plugins/okta/config.go
@@ -36,9 +36,9 @@ var (
 
 type Config struct {
 	hosted.BaseConfig
-	Request_Batch_Size int    // how many entries do we request per HTTP request
-	Request_Per_Minute int    // what is our basic request rate
-	Request_Burst      int    // leaky bucket burstability
+	Request_Batch_Size int // how many entries do we request per HTTP request
+	Request_Per_Minute int // what is our basic request rate
+	Request_Burst      int // leaky bucket burstability
 	Domain             string
 	Token              string `json:"-"` // authentication token - DO NOT send this when marshalling
 }

--- a/hosted/plugins/tester/tester.go
+++ b/hosted/plugins/tester/tester.go
@@ -26,7 +26,8 @@ const (
 
 type Config struct {
 	hosted.BaseConfig
-	Interval string // how often to send an entry; must be parsable by time.ParseDuration
+	Interval    string // how often to send an entry; must be parsable by time.ParseDuration
+	Test_Errors bool
 }
 
 func (c *Config) Verify() (err error) {
@@ -75,6 +76,8 @@ func (tt *TesterIngester) Handle(_ context.Context, rt hosted.Runtime) (*hosted.
 	}); err != nil {
 		rt.Error("failed to write entry", log.KVErr(err))
 	}
-	rt.Error("testing errors", log.KVErr(errors.New("test err")))
+	if tt.Test_Errors {
+		rt.Error("testing errors", log.KVErr(errors.New("test err")))
+	}
 	return hosted.ContinueAfter(tt.interval()), nil
 }

--- a/hosted/plugins/tester/tester_test.go
+++ b/hosted/plugins/tester/tester_test.go
@@ -30,7 +30,7 @@ func TestConfig_Verify(t *testing.T) {
 			name: "valid UUID and interval",
 			config: Config{
 				BaseConfig: hosted.BaseConfig{Ingester_UUID: "550e8400-e29b-41d4-a716-446655440000"},
-				Interval:      "100ms",
+				Interval:   "100ms",
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses no issue

## This PR proposes...

Making the Hosted Tester Logs opt in, instead of all the time. This allows using the tester as a "placeholder" process to keep the runner up. 

Plus a `go fmt ./...` pass. 

## PR Tasks

<!-- Add tasks to this list as needed -->

- [x] e2e and/or unit tests included. If not, please provide an explanation.
- [x] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
