### PR TITLE
fix(issues#2483): wrap bad status codes with equivalent errors

### DIFF
--- a/client/file.go
+++ b/client/file.go
@@ -62,7 +62,7 @@ func (c *Client) GetFileEx(id string, opts *types.QueryOptions, previewBytes uin
 	resp, err := c.methodParamRequestURL(http.MethodGet, filesIdRawUrl(id), map[string]string{
 		"include_deleted": strconv.FormatBool(opts.IncludeDeleted),
 		"bytes":           strconv.FormatUint(previewBytes, 10),
-	}, nil)
+	})
 	if err != nil {
 		return nil, err
 	} else if err := checkResponse(c, resp); err != nil {

--- a/client/file.go
+++ b/client/file.go
@@ -162,11 +162,11 @@ func (c *Client) PopulateFileFromReader(id string, extension string, data io.Rea
 	if err != nil {
 		return types.File{}, err
 	}
-	defer drainResponse(resp)
 
 	if err := aliasResponseError(c, resp); err != nil {
 		return types.File{}, err
 	}
+	defer drainResponse(resp)
 
 	// decode the metadata response
 	confirmation := types.File{}

--- a/client/file.go
+++ b/client/file.go
@@ -11,7 +11,6 @@ package client
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -65,7 +64,7 @@ func (c *Client) GetFileEx(id string, opts *types.QueryOptions, previewBytes uin
 	})
 	if err != nil {
 		return nil, err
-	} else if err := checkResponse(c, resp); err != nil {
+	} else if err := aliasResponseError(c, resp); err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
@@ -165,15 +164,7 @@ func (c *Client) PopulateFileFromReader(id string, extension string, data io.Rea
 	}
 	defer drainResponse(resp)
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		c.state = STATE_LOGGED_OFF
-		return types.File{}, ErrNotAuthed
-	} else if resp.StatusCode != http.StatusOK {
-		if s := getBodyErr(resp.Body); len(s) > 0 {
-			err = errors.New(s)
-		} else {
-			err = fmt.Errorf("Bad Status %s(%d)", resp.Status, resp.StatusCode)
-		}
+	if err := aliasResponseError(c, resp); err != nil {
 		return types.File{}, err
 	}
 

--- a/client/info.go
+++ b/client/info.go
@@ -389,7 +389,7 @@ func (c *Client) GetLibFile(repo, commit, fn string) (bts []byte, err error) {
 	}
 	mp[`path`] = fn
 	var resp *http.Response
-	if resp, err = c.methodParamRequestURL(http.MethodGet, LIBS_URL, mp, nil); err == nil {
+	if resp, err = c.methodParamRequestURL(http.MethodGet, LIBS_URL, mp); err == nil {
 		if resp.StatusCode != 200 {
 			if err = decodeBodyError(resp.Body); err == nil {
 				err = fmt.Errorf("Invalid response code: %s(%d)", resp.Status, resp.StatusCode)

--- a/client/resources.go
+++ b/client/resources.go
@@ -143,6 +143,7 @@ func (c *Client) PopulateResourceFromReader(id string, extension string, data io
 	} else if err := aliasResponseError(c, resp); err != nil {
 		return types.Resource{}, err
 	}
+	defer drainResponse(resp)
 
 	// decode the metadata response
 	confirmation := types.Resource{}

--- a/client/resources.go
+++ b/client/resources.go
@@ -140,7 +140,7 @@ func (c *Client) PopulateResourceFromReader(id string, extension string, data io
 	resp, err = c.methodRequestURL(http.MethodPut, resourcesIdRawUrl(id), contentType, rdr)
 	if err != nil {
 		return types.Resource{}, err
-	} else if err := checkResponse(c, resp); err != nil {
+	} else if err := aliasResponseError(c, resp); err != nil {
 		return types.Resource{}, err
 	}
 
@@ -214,7 +214,7 @@ func (c *Client) GetResourceEx(name string, opts *types.QueryOptions, previewByt
 	})
 	if err != nil {
 		return nil, err
-	} else if err := checkResponse(c, resp); err != nil {
+	} else if err := aliasResponseError(c, resp); err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()

--- a/client/resources.go
+++ b/client/resources.go
@@ -211,7 +211,7 @@ func (c *Client) GetResourceEx(name string, opts *types.QueryOptions, previewByt
 	resp, err := c.methodParamRequestURL(http.MethodGet, resourcesIdRawUrl(meta.ID), map[string]string{
 		"include_deleted": strconv.FormatBool(opts.IncludeDeleted),
 		"bytes":           strconv.FormatUint(previewBytes, 10),
-	}, nil)
+	})
 	if err != nil {
 		return nil, err
 	} else if err := checkResponse(c, resp); err != nil {

--- a/client/staticActions.go
+++ b/client/staticActions.go
@@ -155,18 +155,9 @@ func (c *Client) staticRequest(req *http.Request, obj interface{}, okResponses [
 		return errors.New("Invalid response")
 	}
 	defer drainResponse(resp)
-	if resp.StatusCode == http.StatusUnauthorized {
-		c.state = STATE_LOGGED_OFF
-		return ErrNotAuthed
-	} else if resp.StatusCode == http.StatusNotFound {
-		return ErrNotFound
-	}
-
-	statOk := respOk(resp.StatusCode, okResponses...)
-	//either its in the list, or the list is empty and StatusOK is implied
-	if !(statOk || (resp.StatusCode == http.StatusOK && len(okResponses) == 0)) {
+	if resp.StatusCode != http.StatusOK && !respOk(resp.StatusCode, okResponses...) {
 		c.objLog.Log("WEB "+req.Method, req.URL.String()+" "+resp.Status, nil)
-		return &ClientError{resp.Status, resp.StatusCode, getBodyErr(resp.Body)}
+		return aliasResponseError(c, resp)
 	}
 
 	if obj != nil {
@@ -233,13 +224,9 @@ func (c *Client) methodStaticPushRawURL(method, url string, data []byte, recvObj
 		return errors.New("Invalid response")
 	}
 	defer drainResponse(resp)
-	if resp.StatusCode == http.StatusUnauthorized {
-		c.state = STATE_LOGGED_OFF
-		return ErrNotAuthed
-	}
 	if resp.StatusCode != http.StatusOK && !respOk(resp.StatusCode, okResps...) {
 		c.objLog.Log("WEB "+method, url+" "+resp.Status, nil)
-		return &ClientError{resp.Status, resp.StatusCode, getBodyErr(resp.Body)}
+		return aliasResponseError(c, resp)
 	}
 
 	if recvObj != nil {
@@ -286,15 +273,10 @@ func (c *Client) methodStaticPushURL(method, url string, sendObj, recvObj interf
 		return errors.New("Invalid response")
 	}
 	defer drainResponse(resp)
-	if resp.StatusCode == http.StatusUnauthorized {
-		c.state = STATE_LOGGED_OFF
-		return ErrNotAuthed
-	}
 	if resp.StatusCode != http.StatusOK && !respOk(resp.StatusCode, okResps...) {
 		c.objLog.Log("WEB "+method, url+" "+resp.Status, nil)
-		return &ClientError{resp.Status, resp.StatusCode, getBodyErr(resp.Body)}
+		return aliasResponseError(c, resp)
 	}
-
 	if recvObj != nil {
 		if err := json.NewDecoder(resp.Body).Decode(&recvObj); err != nil {
 			return err

--- a/client/staticActions.go
+++ b/client/staticActions.go
@@ -154,11 +154,11 @@ func (c *Client) staticRequest(req *http.Request, obj interface{}, okResponses [
 	if resp == nil {
 		return errors.New("Invalid response")
 	}
-	defer drainResponse(resp)
 	if resp.StatusCode != http.StatusOK && !respOk(resp.StatusCode, okResponses...) {
 		c.objLog.Log("WEB "+req.Method, req.URL.String()+" "+resp.Status, nil)
 		return aliasResponseError(c, resp)
 	}
+	defer drainResponse(resp)
 
 	if obj != nil {
 		if err := json.NewDecoder(resp.Body).Decode(&obj); err != nil {
@@ -223,11 +223,11 @@ func (c *Client) methodStaticPushRawURL(method, url string, data []byte, recvObj
 	if resp == nil {
 		return errors.New("Invalid response")
 	}
-	defer drainResponse(resp)
 	if resp.StatusCode != http.StatusOK && !respOk(resp.StatusCode, okResps...) {
 		c.objLog.Log("WEB "+method, url+" "+resp.Status, nil)
 		return aliasResponseError(c, resp)
 	}
+	defer drainResponse(resp)
 
 	if recvObj != nil {
 		if err := json.NewDecoder(resp.Body).Decode(&recvObj); err != nil {
@@ -272,11 +272,12 @@ func (c *Client) methodStaticPushURL(method, url string, sendObj, recvObj interf
 	if resp == nil {
 		return errors.New("Invalid response")
 	}
-	defer drainResponse(resp)
 	if resp.StatusCode != http.StatusOK && !respOk(resp.StatusCode, okResps...) {
 		c.objLog.Log("WEB "+method, url+" "+resp.Status, nil)
 		return aliasResponseError(c, resp)
 	}
+	defer drainResponse(resp)
+
 	if recvObj != nil {
 		if err := json.NewDecoder(resp.Body).Decode(&recvObj); err != nil {
 			return err

--- a/client/staticActions.go
+++ b/client/staticActions.go
@@ -431,7 +431,9 @@ func (c *Client) methodRequestURL(method, url, contentType string, body io.Reade
 	return
 }
 
-func (c *Client) methodParamRequestURL(method, uri string, params map[string]string, body io.Writer) (resp *http.Response, err error) {
+// methodParamRequestURL builds and submits a request against the specified uri.
+// Returns an error iff the request failed. You must check the resp's status code yourself.
+func (c *Client) methodParamRequestURL(method, uri string, params map[string]string) (resp *http.Response, err error) {
 	var req *http.Request
 	if req, err = http.NewRequest(method, fmt.Sprintf("%s://%s%s", c.httpScheme, c.server, uri), nil); err != nil {
 		return

--- a/client/utils.go
+++ b/client/utils.go
@@ -12,7 +12,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -78,9 +77,11 @@ func decodeJWTExpires(jwt string) (r time.Time) {
 	return
 }
 
-// checkResponse tests the given http response for common errors and aliases them as appropriate.
+// aliasResponseError returns the error that corresponds to resp.StatusCode.
 // If a non-200 status code is given, the response's body will be automatically drained.
-func checkResponse(c *Client, resp *http.Response) error {
+//
+// Returns nil iff status code == 200.
+func aliasResponseError(c *Client, resp *http.Response) error {
 	if resp.StatusCode == http.StatusOK {
 		return nil
 	}
@@ -92,10 +93,7 @@ func checkResponse(c *Client, resp *http.Response) error {
 		return ErrNotAuthed
 	case http.StatusNotFound:
 		return ErrNotFound
-	default: // unhandled code; check body for error
-		if s := getBodyErr(resp.Body); len(s) > 0 {
-			return errors.New(s)
-		}
-		return fmt.Errorf("Bad Status %s(%d)", resp.Status, resp.StatusCode)
+	default: // unhandled code
+		return &ClientError{resp.Status, resp.StatusCode, getBodyErr(resp.Body)}
 	}
 }


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses https://github.com/gravwell/issues/issues/2483.

Sister PR to https://github.com/gravwell/backend/pull/4060.

## This PR adds proper error aliases to bad status code

Requests that result in unexpected, non-200 status codes now return the correspondong error, instead of a string error (or *ClientError with the error as a string in the body). This should make errors.Is against our custom errors much more reliable.

This is implemented somewhat unevenly due to the volume of different helper functions for issuing requests. The most popular helpers (like `Client.staticRequest()` and `Client.methodStaticPushRawURL()`), those that return only an error,  automatically check the status response code for the caller. Other helpers, those that return the response and an error, expect the caller to do. This can be tidied up again in the future, as we trim out the fat.

## PR Tasks

<!-- Add tasks to this list as needed -->

- [x] e2e and/or unit tests included. If not, please provide an explanation.
- [x] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).
  - Backend tests have been added in the sister PR.

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
