### PR TITLE
Adjustments to Tokens APIs

### DIFF
--- a/client/tokens.go
+++ b/client/tokens.go
@@ -24,7 +24,7 @@ func (c *Client) TokenCapabilities() (cl []string, err error) {
 // CreateToken instantiates a new token. Note that this is the only
 // case in which a TokenFull object (containing the Value field) is
 // returned.
-func (c *Client) CreateToken(tc types.TokenCreate) (tf types.TokenFull, err error) {
+func (c *Client) CreateToken(tc types.Token) (tf types.TokenFull, err error) {
 	err = c.postStaticURL(tokensUrl(), tc, &tf)
 	return
 }
@@ -59,8 +59,8 @@ func (c *Client) GetTokenEx(id string, opts *types.QueryOptions) (types.Token, e
 }
 
 // UpdateToken modifies an existing token.
-func (c *Client) UpdateToken(id string, tr types.TokenCreate) (t types.Token, err error) {
-	err = c.methodStaticPushURL(http.MethodPut, tokenIdUrl(id), tr, &t, nil, nil)
+func (c *Client) UpdateToken(tr types.Token) (t types.Token, err error) {
+	err = c.methodStaticPushURL(http.MethodPut, tokenIdUrl(tr.ID), tr, &t, nil, nil)
 	return
 }
 

--- a/client/tokens.go
+++ b/client/tokens.go
@@ -21,9 +21,9 @@ func (c *Client) TokenCapabilities() (cl []string, err error) {
 	return
 }
 
-// CreateToken instantiates a new token. Note that this is the only
-// case in which a TokenFull object (containing the Value field) is
-// returned.
+// CreateToken instantiates a new token. CreateToken and RegenToken are
+// the only cases in which a TokenFull object (containing the Value field)
+// is returned.
 func (c *Client) CreateToken(tc types.Token) (tf types.TokenFull, err error) {
 	err = c.postStaticURL(tokensUrl(), tc, &tf)
 	return

--- a/client/types/cbac.go
+++ b/client/types/cbac.go
@@ -1012,11 +1012,11 @@ func (ud *UserDetails) CapabilityList() []CapabilityDesc {
 	return CreateUserCapabilityList(ud)
 }
 
-// Token is a complete API compatible token, it contains ownership information and all capabilities associated with the token but does NOT contain the actual secret string.
+// Token is a complete API compatible token, it contains ownership information and all capabilities associated with the token but does NOT contain the actual secret string. It is also the type used to create a new token.
 type Token struct {
 	CommonFields
-	ExpiresAt    time.Time `json:"expiresAt,omitempty"`
-	Capabilities []string  `json:"capabilities"`
+	ExpiresAt    time.Time `json:",omitempty"`
+	Capabilities []string
 }
 
 // TokenListResponse is the type returned when querying a list of tokens.
@@ -1025,17 +1025,9 @@ type TokenListResponse struct {
 	Results []Token `json:"results"`
 }
 
-// TokenCreate is the structure used to ask the API to make a new token, only the request parameters are present
-type TokenCreate struct {
-	Name         string    `json:"name"`
-	Description  string    `json:"description"`
-	ExpiresAt    time.Time `json:"expiresAt,omitempty"`
-	Capabilities []string  `json:"capabilities"`
-}
-
 // TokenRegeneration is the structure used to request regeneration of an existing token
 type TokenRegeneration struct {
-	Expires time.Time `json:"expiresAt,omitempty"`
+	ExpiresAt time.Time `json:",omitempty"`
 }
 
 // TokenFull represents the response value for a token create request.
@@ -1043,7 +1035,7 @@ type TokenRegeneration struct {
 // ONLY provided when creating a new token or regenerating a token.
 type TokenFull struct {
 	Token
-	Value string `json:"token"`
+	Value string
 }
 
 // Expired returns whether a token is expired or not, if no expiration is set then the token is not expired

--- a/gwcli/connection/connection_noci_test.go
+++ b/gwcli/connection/connection_noci_test.go
@@ -477,9 +477,11 @@ func TestJWTRefreshing(t *testing.T) {
 func generateAPIToken(t *testing.T, testclient *grav.Client) (tkn string) {
 	const tknfailVal string = "UNSET"
 	tf, err := testclient.CreateToken(
-		types.TokenCreate{
-			Name:         "LoginMFAToken",
-			Description:  "API token for the LoginMFA tests",
+		types.Token{
+			CommonFields: types.CommonFields{
+				Name:        "LoginMFAToken",
+				Description: "API token for the LoginMFA tests",
+			},
 			ExpiresAt:    time.Now().Add(apiTokenExpiryDur),
 			Capabilities: []string{"ListUsers", "ListGroups", "ListGroupMembers", "MacroRead", "PivotRead"}})
 	if err != nil {

--- a/gwcli/integration_noci_test.go
+++ b/gwcli/integration_noci_test.go
@@ -89,9 +89,11 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "failed to retrieve capabilities list: %v\n", err)
 		os.Exit(1)
 	}
-	tkn, err := client.CreateToken(types.TokenCreate{
-		Name:         "integration_test_login_token",
-		Description:  "grants all capabilities",
+	tkn, err := client.CreateToken(types.Token{
+		CommonFields: types.CommonFields{
+			Name:        "integration_test_login_token",
+			Description: "grants all capabilities",
+		},
 		ExpiresAt:    time.Now().Add(time.Hour),
 		Capabilities: caps,
 	})

--- a/gwcli/tree/tokens/tokens.go
+++ b/gwcli/tree/tokens/tokens.go
@@ -291,9 +291,11 @@ func create() action.Pair {
 
 	return scaffoldcreate.NewCreateAction("token", fields,
 		func(cfg map[string]scaffoldcreate.Field, fs *pflag.FlagSet) (id any, invalid string, err error) {
-			tc := types.TokenCreate{
-				Name:        cfg["name"].Provider.Get(),
-				Description: cfg["desc"].Provider.Get(),
+			tc := types.Token{
+				CommonFields: types.CommonFields{
+					Name:        cfg["name"].Provider.Get(),
+					Description: cfg["desc"].Provider.Get(),
+				},
 			}
 
 			if caps := cfg["capabilities"].Provider.Get(); strings.TrimSpace(caps) != "" {
@@ -431,7 +433,7 @@ func regenerate() action.Pair {
 			},
 			UpdateSub: func(data *types.Token) (identifier string, err error) {
 				tr := types.TokenRegeneration{
-					Expires: data.ExpiresAt,
+					ExpiresAt: data.ExpiresAt,
 				}
 				tf, err := connection.Client.RegenToken(data.ID, tr)
 				if err != nil {


### PR DESCRIPTION
CreateToken now takes a types.Token and UpdateToken takes just types.Token, no separate ID argument. This brings the API in line with all our other assets.

Also removes JSON lowercasing on struct fields, because we want that in general.

Addresses gravwell/issues#2322 (with a corresponding backend PR)
