### PR TITLE
fix(mono#2344): prefer entered username over -u value

### DIFF
--- a/gwcli/connection/connection.go
+++ b/gwcli/connection/connection.go
@@ -205,12 +205,14 @@ func Login(username string, password, apiToken *string, noInteractive bool) erro
 			if noInteractive {
 				return ErrNonInteractiveRequiresDifferentLogin
 			}
-			if mfa, err := promptForMissingCredentials(username); err != nil {
+			finalUsername, mfa, err := promptForMissingCredentials(username)
+			if err != nil {
 				return err
-			} else if mfa {
-				method = "prompt+mfa"
-			} else {
-				method = "prompt"
+			}
+			username = finalUsername
+			method = "prompt"
+			if mfa {
+				method += "+mfa"
 			}
 		} else {
 			method = "JWT"

--- a/gwcli/connection/connection.go
+++ b/gwcli/connection/connection.go
@@ -318,38 +318,39 @@ func loginViaJWT(username string) (err error) {
 }
 
 // Spins up a bubble tea prompt to interactively collect u/p and another to collect MFA (if applicable).
-// Returns if the MFA prompt was displayed and filled out (if !mfa, the Client successfully auth'd without MFA)
-// Only prints to the log on critical failures
+// Returns the final username a user gave, if the MFA prompt was displayed and filled out (if !mfa, the Client successfully auth'd without MFA), and if an error occurred.
+//
+// Only prints to the log on critical failures.
 //
 // ! Not to be called in script mode.
-func promptForMissingCredentials(prepopUsername string) (mfa bool, err error) {
+func promptForMissingCredentials(prepopUsername string) (finalUsername string, mfa bool, err error) {
 	// prompt for user name and password
 	u, p, err := credprompt.Collect(prepopUsername)
 	if err != nil {
-		return false, err
+		return "", false, err
 	}
 
 	// log in via u/p
 	resp, err := Client.LoginEx(u, p)
 	if mfa, ufErr := testLoginError(resp, err); ufErr != nil {
-		return false, ufErr
+		return "", false, ufErr
 	} else if mfa {
 		// prompt for TOTP or recovery code
 		code, authType, err := mfaprompt.Collect()
 		if err != nil {
-			return true, err
+			return "", true, err
 		}
 		resp, err = Client.MFALogin(u, p, authType, code)
 		if err != nil {
-			return true, err
+			return "", true, err
 		} else if !resp.LoginStatus {
 			// we logged in via MFA, didn't get an error, but still failed to actually log in
 			clilog.Writer.Criticalf("failed to login, unknown response state: %+v", resp)
-			return false, clilog.ErrInternal{}
+			return "", false, clilog.ErrInternal{}
 		}
 	}
 
-	return mfa, nil
+	return u, mfa, nil
 
 }
 


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR closes https://github.com/gravwell/gravwell/issues/2344

## This PR fixes username priority

When insufficient credentials are given, `-u` prepopulates the 'username' prompt. This fix makes the final value of the prompt takes precedence when sanity checking the return user (on successful login).

## PR Tasks

<!-- Add tasks to this list as needed -->

- [x] e2e and/or unit tests included. If not, please provide an explanation.
  - Because this requires spinning up a cred prompt tea.Program, the main gwcli tea.Program, *and* concurrent I/O, testing this requires a deeper edit to gwcli's testing hooks.
    - Fell down a rabbit hole trying to pipe gwcli's IO consistently. ~~Some interesting ideas came up, but they require changes too extensive for just this. The experiments are on my [gwcli_IO_testing branch](https://github.com/rory-landau-gravwell/gravwell/tree/gwcli_IO_testing).~~ I came up with a way to test this (and any aspect of gwcli via arbitrary IO): [gist](https://gist.github.com/rory-landau-gravwell/cf185171bf06a02cc3a26ea2ec6274e8). Still too big a change for this PR; I'll throw out a different issue or PR for it.
- [x] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
