### PR TITLE
fix an issue where we can panic on clearing an emergency queue when r…

### DIFF
--- a/ingest/muxer.go
+++ b/ingest/muxer.go
@@ -1621,7 +1621,9 @@ inputLoop:
 							b[i] = nil //this is safe, we check for this everywhere
 							// first, reverse anything we've translated already
 							for j := 0; j < i; j++ {
-								b[j].Tag = nc.tt.reverse(b[j].Tag)
+								if b[j] != nil {
+									b[j].Tag = nc.tt.reverse(b[j].Tag)
+								}
 							}
 							im.recycleEntryBatch(b) //recycle and save what we can
 						} else {
@@ -1637,7 +1639,9 @@ inputLoop:
 
 							// first, reverse anything we've translated already
 							for j := 0; j < i; j++ {
-								b[j].Tag = nc.tt.reverse(b[j].Tag)
+								if b[j] != nil {
+									b[j].Tag = nc.tt.reverse(b[j].Tag)
+								}
 							}
 							im.recycleEntryBatch(b)
 						}
@@ -1657,7 +1661,9 @@ inputLoop:
 			var n int
 			if n, err = nc.ig.writeBatchEntry(b); err != nil {
 				for i := n; i < len(b); i++ {
-					b[i].Tag = nc.tt.reverse(b[i].Tag)
+					if b[i] != nil {
+						b[i].Tag = nc.tt.reverse(b[i].Tag)
+					}
 				}
 				im.recycleEntryBatch(b[n:])
 				im.syncAndCloseConnection(nc)
@@ -2263,7 +2269,9 @@ func (eq *emergencyQueue) clear(igst *IngestConnection, tt *tagTrans) (ok bool) 
 						// could not translate, push it back on the queue and bail
 						// first we need to reverse the ones we have already translated, ugh
 						for j := 0; j < i; j++ {
-							blk[j].Tag = tt.reverse(blk[j].Tag)
+							if blk[j] != nil {
+								blk[j].Tag = tt.reverse(blk[j].Tag)
+							}
 						}
 						eq.push(e, blk)
 						return

--- a/ingest/utils_test.go
+++ b/ingest/utils_test.go
@@ -14,6 +14,31 @@ import (
 	"github.com/gravwell/gravwell/v3/ingest/entry"
 )
 
+// TestEmergencyQueueClearNilBatchEntry ensures that clear() does not panic when
+// a batch pulled from the emergency queue contains nil entries interspersed
+// with entries that fail tag translation. Previously the tag-reversal loop
+// that runs when a mid-batch translation fails did not skip nil entries,
+// causing a nil pointer dereference (see the AzureEventHubs ingester panic in
+// ingest.(*emergencyQueue).clear -> tt.reverse).
+func TestEmergencyQueueClearNilBatchEntry(t *testing.T) {
+	eq := newEmergencyQueue()
+
+	tt := &tagTrans{
+		active: []entry.EntryTag{5}, // only tag 0 is negotiated
+	}
+
+	blk := []*entry.Entry{
+		nil,
+		{Tag: 0}, // translates fine, gets reversed when the batch bails below
+		{Tag: 1}, // not negotiated, forces the reversal loop to run
+	}
+	eq.push(nil, blk)
+
+	if ok := eq.clear(nil, tt); ok {
+		t.Fatalf("expected clear to report failure for untranslatable tag")
+	}
+}
+
 func TestTagBitMask(t *testing.T) {
 	var tmt tagMaskTracker
 	//make sure its empty


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses #2102 
## This PR proposes...

- add some nil guards on the emergency queue when we get a bad tag
- add a regression test to check it

## PR Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e and/or unit tests included. If not, please provide an explanation.
- [ ] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
