### PR TITLE
Improve handling of oversized config blocks by ingest receivers

### DIFF
--- a/ingest/api.go
+++ b/ingest/api.go
@@ -220,12 +220,13 @@ func (s *IngesterState) trimChildConfigs() {
 	trimChildConfigs(s.Children, 8) //anything deeper than 8, just nuke em
 }
 
+// trimChildren caps the reported children at maxCount, discarding an arbitrary subset of the extras.
 func (s *IngesterState) trimChildren(maxCount int) {
 	if len(s.Children) > maxCount {
 		var x int
 		for k := range s.Children {
 			x++
-			if x >= maxCount {
+			if x > maxCount {
 				delete(s.Children, k)
 			}
 		}
@@ -282,7 +283,7 @@ func (s *IngesterState) Read(rdr io.Reader) (err error) {
 		// just read and discard the bytes without updating our internal config or metadata
 		// io.CopyN streams through a small fixed buffer so we never hold the whole block in memory
 		if _, err = io.CopyN(io.Discard, rdr, int64(bsz)); err != nil {
-			err = fmt.Errorf("failed to discard oversized ingest state %w", err)
+			err = fmt.Errorf("failed to discard oversized ingest state: %w", err)
 		}
 		return
 	}

--- a/ingest/api.go
+++ b/ingest/api.go
@@ -29,8 +29,9 @@ const (
 
 const (
 	configurationBlockSize          uint32          = 1
-	maxStreamConfigurationBlockSize uint32          = 1024 * 1024 //just a sanity check
-	maxIngestStateSize              uint32          = 1024 * 1024
+	maxStreamConfigurationBlockSize uint32          = 1024 * 1024      //just a sanity check
+	maxIngestStateSize              uint32          = 1024 * 1024      //size at which we start trimming the reporting-only config/metadata blocks
+	maxIngestStateStupidSize        uint32          = 16 * 1024 * 1024 //size at which a state block is so absurd we assume something is broken and cut the connection
 	CompressNone                    CompressionType = 0
 	CompressSnappy                  CompressionType = 0x10
 )
@@ -39,6 +40,7 @@ var (
 	ErrInvalidBuffer            = errors.New("invalid buffer")
 	ErrInvalidIngestStateHeader = errors.New("Invalid ingest state header")
 	ErrOversizedConfigBlock     = errors.New("configuration block too large")
+	ErrOversizedIngestState     = errors.New("ingester state block absurdly large")
 	ErrEmptyConfigBlock         = errors.New("configuration block empty")
 )
 
@@ -263,26 +265,40 @@ func (s *IngesterState) Write(wtr io.Writer) (err error) {
 func (s *IngesterState) Read(rdr io.Reader) (err error) {
 	// First read out the size (32-bit integer)
 	var bsz uint32
-	var n int
 	if err = binary.Read(rdr, binary.LittleEndian, &bsz); err != nil {
 		return
 	}
-	if bsz > maxIngestStateSize || bsz == 0 {
+	if bsz == 0 {
 		err = ErrInvalidIngestStateHeader
+		return
+	} else if bsz > maxIngestStateStupidSize {
+		// a state block this large is absurd, refuse it outright and let the
+		// caller tear down the connection
+		err = ErrOversizedIngestState
+		return
+	} else if bsz > maxIngestStateSize {
+		// downstream reporter is trying to send us a config block that is too large.
+		// we don't want to kick the connection but we don't want this config report either
+		// just read and discard the bytes without updating our internal config or metadata
+		// io.CopyN streams through a small fixed buffer so we never hold the whole block in memory
+		if _, err = io.CopyN(io.Discard, rdr, int64(bsz)); err != nil {
+			err = fmt.Errorf("failed to discard oversized ingest state %w", err)
+		}
 		return
 	}
 
+	// We are informed that the config block is within our tolerance to consume and report
 	// Now read that much data off the reader
 	buff := make([]byte, bsz)
-	if n, err = rdr.Read(buff); err != nil {
-		return
-	} else if n != len(buff) {
+	if _, err = io.ReadFull(rdr, buff); err != nil {
 		err = errors.New("Failed to read ingest state")
 		return
 	}
 
-	// Finally, decode the JSON
-	err = json.Unmarshal(buff, s)
+	// Decode the JSON
+	if err = json.Unmarshal(buff, s); err != nil {
+		return
+	}
 
 	return
 }

--- a/ingest/api.go
+++ b/ingest/api.go
@@ -291,7 +291,7 @@ func (s *IngesterState) Read(rdr io.Reader) (err error) {
 	// Now read that much data off the reader
 	buff := make([]byte, bsz)
 	if _, err = io.ReadFull(rdr, buff); err != nil {
-		err = errors.New("Failed to read ingest state")
+		err = fmt.Errorf("failed to read ingest state: %w", err)
 		return
 	}
 

--- a/ingest/api.go
+++ b/ingest/api.go
@@ -31,7 +31,7 @@ const (
 	configurationBlockSize          uint32          = 1
 	maxStreamConfigurationBlockSize uint32          = 1024 * 1024      //just a sanity check
 	maxIngestStateSize              uint32          = 1024 * 1024      //size at which we start trimming the reporting-only config/metadata blocks
-	maxIngestStateStupidSize        uint32          = 16 * 1024 * 1024 //size at which a state block is so absurd we assume something is broken and cut the connection
+	maxIngestStateStupidSize        uint32          = 64 * 1024 * 1024 //size at which a state block is so absurd we assume something is broken and cut the connection
 	CompressNone                    CompressionType = 0
 	CompressSnappy                  CompressionType = 0x10
 )

--- a/ingest/api_test.go
+++ b/ingest/api_test.go
@@ -11,7 +11,9 @@ package ingest
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -98,5 +100,75 @@ func TestIngestState(t *testing.T) {
 	}
 	if !reflect.DeepEqual(x, y) {
 		t.Fatalf("ReadWrite failure: %+v != %+v\n", x, y)
+	}
+}
+
+// writeRawIngesterState encodes an IngesterState onto the wire without the size
+// enforcement that IngesterState.Write applies, so we can exercise the read-side
+// handling of oversized blocks.
+func writeRawIngesterState(t *testing.T, s IngesterState) *bytes.Buffer {
+	t.Helper()
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bb := bytes.NewBuffer(nil)
+	if err := binary.Write(bb, binary.LittleEndian, uint32(len(data))); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := bb.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	return bb
+}
+
+// A state that is larger than maxIngestStateSize but not absurd should be read
+// off the wire and discarded (not reported), leaving the stream synchronized so
+// the connection survives.
+func TestOversizedIngestStateDiscarded(t *testing.T) {
+	bigCfg, err := json.Marshal(strings.Repeat("A", int(maxIngestStateSize)+1024))
+	if err != nil {
+		t.Fatal(err)
+	}
+	x := IngesterState{
+		Name:          "foobar",
+		Tags:          []string{"tag1", "tag2"},
+		Configuration: json.RawMessage(bigCfg),
+		Metadata:      json.RawMessage(bigCfg),
+		Children:      map[string]IngesterState{},
+	}
+	bb := writeRawIngesterState(t, x)
+	if uint32(bb.Len()) <= maxIngestStateSize {
+		t.Fatalf("test setup failure: expected an oversized block, got %d", bb.Len())
+	}
+	// tack on a trailing sentinel to prove Read consumed exactly the state bytes
+	// and left the stream synchronized
+	const sentinel = "SENTINEL"
+	bb.WriteString(sentinel)
+
+	var y IngesterState
+	if err := y.Read(bb); err != nil {
+		t.Fatalf("oversized-but-sane state should be discarded, not error: %v", err)
+	}
+	// the oversized report is dropped entirely, nothing populated
+	if !reflect.DeepEqual(y, IngesterState{}) {
+		t.Fatalf("expected oversized state to be discarded, got %+v", y)
+	}
+	// and the stream must be left exactly at the sentinel
+	if rest := bb.String(); rest != sentinel {
+		t.Fatalf("stream not left synchronized after discard: %q", rest)
+	}
+}
+
+// A state block claiming an absurd size must be rejected outright so the caller
+// can tear down the connection.
+func TestStupidSizedIngestStateRejected(t *testing.T) {
+	bb := bytes.NewBuffer(nil)
+	if err := binary.Write(bb, binary.LittleEndian, maxIngestStateStupidSize+1); err != nil {
+		t.Fatal(err)
+	}
+	var y IngesterState
+	if err := y.Read(bb); err != ErrOversizedIngestState {
+		t.Fatalf("expected ErrOversizedIngestState, got %v", err)
 	}
 }

--- a/ingest/entryReader.go
+++ b/ingest/entryReader.go
@@ -467,7 +467,7 @@ headerLoop:
 			if length == 0 {
 				return ErrInvalidIngestStateHeader
 			} else if length > maxIngestStateStupidSize {
-				// a state block this large is absurd (>16MB), we can't trust
+				// a state block this large is absurd (>64MB), we can't trust
 				// the stream anymore so cut the connection and bail
 				return ErrOversizedIngestState
 			} else if length > maxIngestStateSize {

--- a/ingest/entryReader.go
+++ b/ingest/entryReader.go
@@ -464,8 +464,22 @@ headerLoop:
 				return errFailedFullRead
 			}
 			length := binary.LittleEndian.Uint32(er.buff[0:4])
-			if length > maxIngestStateSize {
+			if length == 0 {
 				return ErrInvalidIngestStateHeader
+			} else if length > maxIngestStateStupidSize {
+				// a state block this large is absurd (>16MB), we can't trust
+				// the stream anymore so cut the connection and bail
+				return ErrOversizedIngestState
+			} else if length > maxIngestStateSize {
+				// the reporter is trying to send us a config block that is too large.
+				// we don't want to kick the connection but we don't want this config
+				// report either, so read and discard the bytes without holding the
+				// whole block in memory, then acknowledge and move on.
+				if _, err = io.CopyN(io.Discard, er.bIO, int64(length)); err != nil {
+					return err
+				}
+				er.ackChan <- ackCommand{cmd: CONFIRM_INGESTER_STATE_MAGIC}
+				continue
 			}
 			stateBuff := make([]byte, length)
 			n, err = io.ReadFull(er.bIO, stateBuff)

--- a/ingest/muxer.go
+++ b/ingest/muxer.go
@@ -697,31 +697,57 @@ func (im *IngestMuxer) stateReportRoutine() {
 
 func (im *IngestMuxer) getTrimmedState(lastPush time.Time, lastEntryCount uint64) (s IngesterState, shouldPush bool, err error) {
 	//check if we should push an ingester state out either due to max time duration or because it was updated
-	if s, shouldPush = im.getIngesterState(lastPush, lastEntryCount); shouldPush {
-		//SendIngesterState throws a full sync and then pushes a potentially very large
-		//configuration block. DO NOT HOLD THE LOCK on the entire muxer when this is happening
-		//or you will most likely starve the ingest muxer.
-		var sz uint32
-		if sz, err = s.EncodedSize(); err != nil {
-			return
-		} else if sz > maxIngestStateSize {
-			ogSize := sz
-			s.trimChildConfigs()
-			if sz, err = s.EncodedSize(); err != nil {
-				return
-			} else if sz > maxIngestStateSize {
-				s.trimChildren(64)
-				if sz, err = s.EncodedSize(); err != nil {
-					return
-				} else if sz > maxIngestStateSize {
-					//log an error stating that we could not make it work
-					im.Error("Failed to send ingester state, too large",
-						log.KV("original-size", ogSize), log.KV("post-trim-size", sz))
-					err = fmt.Errorf("failed to send ingester state, too large: post trim %d > %d", sz, maxIngestStateSize)
-				}
-			}
-		}
+	if s, shouldPush = im.getIngesterState(lastPush, lastEntryCount); !shouldPush {
+		return
 	}
+	//SendIngesterState throws a full sync and then pushes a potentially very large
+	//configuration block. DO NOT HOLD THE LOCK on the entire muxer when this is happening
+	//or you will most likely starve the ingest muxer.
+	var sz uint32
+	if sz, err = s.EncodedSize(); err != nil || sz <= maxIngestStateSize {
+		return //either an error, or it already fits, either way we are done
+	}
+	ogSize := sz
+
+	// The state is too large to ship.  The configuration and metadata blocks are
+	// only used for reporting, so progressively discard the least useful data
+	// until the state fits or we run out of things to trim.
+
+	// drop the configuration/metadata blocks carried by our children
+	s.trimChildConfigs()
+	if sz, err = s.EncodedSize(); err != nil || sz <= maxIngestStateSize {
+		return
+	}
+
+	// drop our own configuration and metadata blocks
+	s.Configuration = nil
+	s.Metadata = nil
+	if sz, err = s.EncodedSize(); err != nil || sz <= maxIngestStateSize {
+		return
+	}
+
+	// trim the number of children we report
+	s.trimChildren(64)
+	if sz, err = s.EncodedSize(); err != nil || sz <= maxIngestStateSize {
+		return
+	}
+
+	// trim them again
+	s.trimChildren(8)
+	if sz, err = s.EncodedSize(); err != nil || sz <= maxIngestStateSize {
+		return
+	}
+
+	// give up on reporting children entirely
+	s.Children = nil
+	if sz, err = s.EncodedSize(); err != nil || sz <= maxIngestStateSize {
+		return
+	}
+
+	//log an error stating that we could not make it work, this really shouldn't be possible but handle the error anyway
+	im.Error("Failed to send ingester state, too large",
+		log.KV("original-size", ogSize), log.KV("post-trim-size", sz))
+	err = fmt.Errorf("failed to send ingester state, too large: post trim %d > %d", sz, maxIngestStateSize)
 	return
 }
 

--- a/ingest/muxer_test.go
+++ b/ingest/muxer_test.go
@@ -137,7 +137,7 @@ func TestGetTrimmedStateStages(t *testing.T) {
 		assertFits(t, out)
 	})
 
-	// stage 3: trimChildren(64) - too many children, sized so 63 fit
+	// stage 3: trimChildren(64) - too many children, sized so 64 fit
 	t.Run("stage3-trim-children-64", func(t *testing.T) {
 		out, push, err := run(IngesterState{
 			Children: makeChildren(100, 12*1024, 0),
@@ -145,13 +145,13 @@ func TestGetTrimmedStateStages(t *testing.T) {
 		if err != nil || !push {
 			t.Fatalf("unexpected err=%v push=%v", err, push)
 		}
-		if len(out.Children) != 63 {
-			t.Fatalf("stage3: expected 63 children after trimChildren(64), got %d", len(out.Children))
+		if len(out.Children) != 64 {
+			t.Fatalf("stage3: expected 64 children after trimChildren(64), got %d", len(out.Children))
 		}
 		assertFits(t, out)
 	})
 
-	// stage 4: trimChildren(8) - 63 children still too big, 7 fit
+	// stage 4: trimChildren(8) - 64 children still too big, 8 fit
 	t.Run("stage4-trim-children-8", func(t *testing.T) {
 		out, push, err := run(IngesterState{
 			Children: makeChildren(100, 30*1024, 0),
@@ -159,8 +159,8 @@ func TestGetTrimmedStateStages(t *testing.T) {
 		if err != nil || !push {
 			t.Fatalf("unexpected err=%v push=%v", err, push)
 		}
-		if len(out.Children) != 7 {
-			t.Fatalf("stage4: expected 7 children after trimChildren(8), got %d", len(out.Children))
+		if len(out.Children) != 8 {
+			t.Fatalf("stage4: expected 8 children after trimChildren(8), got %d", len(out.Children))
 		}
 		assertFits(t, out)
 	})

--- a/ingest/muxer_test.go
+++ b/ingest/muxer_test.go
@@ -1,0 +1,194 @@
+/*************************************************************************
+ * Copyright 2017 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
+package ingest
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// rawStr builds a valid JSON string value of n filler bytes for use as a
+// Configuration/Metadata block.
+func rawStr(n int) json.RawMessage {
+	return json.RawMessage(`"` + strings.Repeat("C", n) + `"`)
+}
+
+// makeChildren builds n child states, each carrying a Name of nameBytes and,
+// when cfgBytes > 0, a Configuration block of cfgBytes.
+func makeChildren(n, nameBytes, cfgBytes int) map[string]IngesterState {
+	m := make(map[string]IngesterState, n)
+	name := strings.Repeat("A", nameBytes)
+	var cfg json.RawMessage
+	if cfgBytes > 0 {
+		cfg = rawStr(cfgBytes)
+	}
+	for i := 0; i < n; i++ {
+		key := fmt.Sprintf("child-%04d", i)
+		m[key] = IngesterState{
+			UUID:          key,
+			Name:          name,
+			Configuration: cfg,
+		}
+	}
+	return m
+}
+
+// muxerForState returns a bare muxer wired up with just enough state to exercise
+// getTrimmedState. No logger is set; im.Error is a no-op when lgr is nil.
+func muxerForState(s IngesterState) *IngestMuxer {
+	return &IngestMuxer{
+		mtx:           &sync.RWMutex{},
+		start:         time.Now(),
+		ingesterState: s,
+	}
+}
+
+func assertFits(t *testing.T, s IngesterState) {
+	t.Helper()
+	sz, err := s.EncodedSize()
+	if err != nil {
+		t.Fatalf("EncodedSize failed: %v", err)
+	}
+	if sz > maxIngestStateSize {
+		t.Fatalf("state does not fit after trimming: %d > %d", sz, maxIngestStateSize)
+	}
+}
+
+// TestGetTrimmedStateStages walks each stage of the progressive size reduction
+// in getTrimmedState.  Each subtest is built so that the state only drops below
+// maxIngestStateSize at the specific stage under test, proving every earlier
+// stage ran but was insufficient and that the target stage is what made it fit.
+func TestGetTrimmedStateStages(t *testing.T) {
+	const MB = int(maxIngestStateSize)
+
+	run := func(s IngesterState) (IngesterState, bool, error) {
+		return muxerForState(s).getTrimmedState(time.Time{}, 0)
+	}
+
+	// stage 0: already fits, nothing is trimmed
+	t.Run("fits-no-trim", func(t *testing.T) {
+		out, push, err := run(IngesterState{
+			Name:          "small",
+			Configuration: rawStr(1024),
+			Metadata:      rawStr(1024),
+			Children:      makeChildren(2, 512, 512),
+		})
+		if err != nil || !push {
+			t.Fatalf("unexpected err=%v push=%v", err, push)
+		}
+		if out.Configuration == nil || out.Metadata == nil {
+			t.Fatal("stage0: reporting blocks should be retained when the state already fits")
+		}
+		if len(out.Children) != 2 {
+			t.Fatalf("stage0: children should be untouched, got %d", len(out.Children))
+		}
+		assertFits(t, out)
+	})
+
+	// stage 1: child configuration/metadata blocks are what push us over
+	t.Run("stage1-child-configs", func(t *testing.T) {
+		out, push, err := run(IngesterState{
+			Configuration: rawStr(1024), // small own config that must survive
+			Children:      makeChildren(4, 256, 400*1024),
+		})
+		if err != nil || !push {
+			t.Fatalf("unexpected err=%v push=%v", err, push)
+		}
+		if len(out.Children) != 4 {
+			t.Fatalf("stage1: children should be retained, got %d", len(out.Children))
+		}
+		for k, c := range out.Children {
+			if c.Configuration != nil {
+				t.Fatalf("stage1: child %s config was not trimmed", k)
+			}
+		}
+		if out.Configuration == nil {
+			t.Fatal("stage1: own configuration should still be present")
+		}
+		assertFits(t, out)
+	})
+
+	// stage 2: our own configuration/metadata blocks dominate
+	t.Run("stage2-own-config", func(t *testing.T) {
+		out, push, err := run(IngesterState{
+			Configuration: rawStr(2 * MB),
+			Metadata:      rawStr(1024),
+			Children:      makeChildren(2, 256, 1024),
+		})
+		if err != nil || !push {
+			t.Fatalf("unexpected err=%v push=%v", err, push)
+		}
+		if out.Configuration != nil || out.Metadata != nil {
+			t.Fatal("stage2: own configuration/metadata should be dropped")
+		}
+		if len(out.Children) != 2 {
+			t.Fatalf("stage2: children should be retained, got %d", len(out.Children))
+		}
+		assertFits(t, out)
+	})
+
+	// stage 3: trimChildren(64) - too many children, sized so 63 fit
+	t.Run("stage3-trim-children-64", func(t *testing.T) {
+		out, push, err := run(IngesterState{
+			Children: makeChildren(100, 12*1024, 0),
+		})
+		if err != nil || !push {
+			t.Fatalf("unexpected err=%v push=%v", err, push)
+		}
+		if len(out.Children) != 63 {
+			t.Fatalf("stage3: expected 63 children after trimChildren(64), got %d", len(out.Children))
+		}
+		assertFits(t, out)
+	})
+
+	// stage 4: trimChildren(8) - 63 children still too big, 7 fit
+	t.Run("stage4-trim-children-8", func(t *testing.T) {
+		out, push, err := run(IngesterState{
+			Children: makeChildren(100, 30*1024, 0),
+		})
+		if err != nil || !push {
+			t.Fatalf("unexpected err=%v push=%v", err, push)
+		}
+		if len(out.Children) != 7 {
+			t.Fatalf("stage4: expected 7 children after trimChildren(8), got %d", len(out.Children))
+		}
+		assertFits(t, out)
+	})
+
+	// stage 5: even 7 children are too big, drop them entirely
+	t.Run("stage5-drop-children", func(t *testing.T) {
+		out, push, err := run(IngesterState{
+			Children: makeChildren(100, 200*1024, 0),
+		})
+		if err != nil || !push {
+			t.Fatalf("unexpected err=%v push=%v", err, push)
+		}
+		if len(out.Children) != 0 {
+			t.Fatalf("stage5: expected all children dropped, got %d", len(out.Children))
+		}
+		assertFits(t, out)
+	})
+
+	// stage 6: nothing trimmable can shrink it (Name is never trimmed) -> error
+	t.Run("stage6-unshrinkable-errors", func(t *testing.T) {
+		_, push, err := run(IngesterState{
+			Name: strings.Repeat("A", 2*MB),
+		})
+		if !push {
+			t.Fatal("stage6: expected shouldPush true")
+		}
+		if err == nil {
+			t.Fatal("stage6: expected an error when the state cannot be shrunk below the limit")
+		}
+	})
+}


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses an outside issue

## This PR proposes...

- Allow receivers to discard oversized blocks while also protecting against malicious authenticated ingesters

## PR Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e and/or unit tests included. If not, please provide an explanation.
- [ ] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
