### PR TITLE
fix(N/A): test annotations for all-children-disabled

### DIFF
--- a/gwcli/internal/annotations/annotations.go
+++ b/gwcli/internal/annotations/annotations.go
@@ -23,7 +23,7 @@ const (
 	keyDisabled          string = "disabled"
 )
 const requirementValue string = "1"
-const ReasonAllChildrenDisabled string = "your user lacks permissions to uses the commands"
+const ReasonAllChildrenDisabled string = "your user lacks permissions to use the commands"
 
 // Requirements define the requirements that must be satisfied for a command to be invoked.
 //

--- a/gwcli/internal/annotations/annotations.go
+++ b/gwcli/internal/annotations/annotations.go
@@ -23,6 +23,7 @@ const (
 	keyDisabled          string = "disabled"
 )
 const requirementValue string = "1"
+const ReasonAllChildrenDisabled string = "your user lacks permissions to uses the commands"
 
 // Requirements define the requirements that must be satisfied for a command to be invoked.
 //
@@ -245,7 +246,7 @@ func ConsolidateToDisabled(cmd *cobra.Command, CBACEnabled bool, userIsAdmin boo
 		if cmd.Annotations == nil {
 			cmd.Annotations = make(map[string]string)
 		}
-		cmd.Annotations[keyDisabled] = "your user lacks permissions to uses the commands" // all children disabled
+		cmd.Annotations[keyDisabled] = ReasonAllChildrenDisabled
 	}
 	return
 }

--- a/gwcli/internal/annotations/annotations_test.go
+++ b/gwcli/internal/annotations/annotations_test.go
@@ -208,13 +208,27 @@ func TestConsolidateToDisabled(t *testing.T) {
 
 }
 
-// checks that the given command's CheckRequirement result match their IsDisabled state, then recurs to each child.
+// checks that the given command's CheckRequirement result match their IsDisabled state (unless their IsDisabled state is because every child is disabled),
+// then recurs to each child.
 func checkIsDisabledRecursive(t *testing.T, cmd *cobra.Command, CBACEnabled bool, userIsAdmin bool, usersCapabilities []types.Capability) {
+	t.Helper()
 	// check self
 	err := annotations.CheckRequirements(cmd, CBACEnabled, userIsAdmin, uniques.SliceToSet(usersCapabilities))
 	// error state and IsDisabled state should match
 	reason := annotations.IsDisabled(cmd)
-	if err != nil {
+	// we need to check specifically for if a command was disabled due to all children being disabled, as CheckRequirements won't do that.
+	if reason == annotations.ReasonAllChildrenDisabled {
+		// this is the lowest priority disable; CheckRequirements shouldn't have found anything.
+		assert.Nil(t, err, "CheckRequirement returned an error, but cmd is disabled due to children")
+		// check every child (and that we actually have children. If we don't, a more specific error should have been used.)
+		assert.NotZero(t, len(cmd.Commands()), "'all children disabled' is only reasonable if this command has children")
+		for i, child := range cmd.Commands() {
+			if reason := annotations.IsDisabled(child); reason == "" {
+				t.Fatalf("parent is disabled due to children, but child %d is not disabled.\nChild's annotations: %v\nParent's annotations%v",
+					i, child.Annotations, cmd.Annotations)
+			}
+		}
+	} else if err != nil {
 		assert.Equal(t, err.Error(), reason, "child annotations: %v", cmd.Annotations)
 	} else {
 		assert.Empty(t, reason, "child annotations: %v", cmd.Annotations)


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses no issue.

## This PR fixes annotations_test.go:TestConsolidateToDisabled()

I recently introduced this test, but it is flaky. The test checks that annotation consolidate appropriately, but failed to take into account an extra check that only the consolidation subroutine performs. This PR fixes that. The test still relies on randomness, but should no longer be flaky.

## PR Tasks

<!-- Add tasks to this list as needed -->

- [x] e2e and/or unit tests included. If not, please provide an explanation.
- [ ] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
