### PR TITLE
llm_ingester: fix user mode logging of assistant replies. 

### DIFF
--- a/ingesters/llm_ingester/config.go
+++ b/ingesters/llm_ingester/config.go
@@ -70,7 +70,9 @@ type listener struct {
 	// the default tag when unset.
 	Tag_Name string
 	// Log_Mode controls how much of each request is ingested: "delta" (default,
-	// one entry per new logical event), "user" (latest user prompt only), or
+	// one entry per new logical event), "user" (user prompts only — never the
+	// model's replies; tool calls and results are still captured when
+	// Log_Tool_Calls is true, and the usage record when Log_Usage is true), or
 	// "full" (every message in the request body, every request).
 	Log_Mode string
 	// Log_Tool_Calls, when true, captures function-call / MCP tool invocations

--- a/ingesters/llm_ingester/gravwell_llm_ingester.conf
+++ b/ingesters/llm_ingester/gravwell_llm_ingester.conf
@@ -36,8 +36,9 @@
 	#   delta (default): one entry per logical new event — the latest user
 	#       turn, each assistant reply, each tool call, plus the usage
 	#       record. 
-	#   user: only ingest the latest user prompt (and the usage record
-	#       if Log-Usage is true).
+	#   user: only ingest the user prompts — never the model's replies.
+	#       Tool calls and results are still captured when Log-Tool-Calls
+	#       is true, and the usage record when Log-Usage is true.
 	#   full: ingest every message in the request body, every
 	#       request. 
 	Log-Mode = "delta"

--- a/ingesters/llm_ingester/ingest.go
+++ b/ingesters/llm_ingester/ingest.go
@@ -44,12 +44,31 @@ type emitCtx struct {
 func emitRequestEvents(ec *emitCtx, evs []protocol.Event) {
 	switch ec.logMode {
 	case logModeUserOnly:
-		// Only the most recent user message.
+		// The most recent user message, plus any tool results from the current
+		// turn when tool logging is on (so the response.tool_call entries have
+		// matching results). Assistant turns are never logged in this mode.
+		latest := -1
 		for i := len(evs) - 1; i >= 0; i-- {
 			if evs[i].Type == protocol.EventUserMessage {
-				writeEvent(ec, evs[i])
-				return
+				latest = i
+				break
 			}
+		}
+		tail := tailStart(evs)
+		for i, e := range evs {
+			switch e.Type {
+			case protocol.EventUserMessage:
+				if i != latest {
+					continue
+				}
+			case protocol.EventToolResult:
+				if !ec.logToolCalls || i < tail {
+					continue
+				}
+			default:
+				continue
+			}
+			writeEvent(ec, e)
 		}
 	case logModeFullConversation:
 		// Every message in the request body.
@@ -72,17 +91,10 @@ func emitRequestEvents(ec *emitCtx, evs []protocol.Event) {
 				}
 			}
 		}
-		// Walk from the end, collect user/tool_result turns until we hit an
-		// assistant turn (everything before that was already logged in a
-		// previous request).
-		var tail []protocol.Event
-		for i := len(evs) - 1; i >= 0; i-- {
-			if evs[i].Type == protocol.EventAssistantMessage {
-				break
-			}
-			tail = append([]protocol.Event{evs[i]}, tail...)
-		}
-		for _, e := range tail {
+		// Everything after the last assistant turn is new (the latest user
+		// message plus any tool_result tail); everything before it was already
+		// logged in a previous request.
+		for _, e := range evs[tailStart(evs):] {
 			if e.Type == protocol.EventToolResult && !ec.logToolCalls {
 				continue
 			}
@@ -91,11 +103,27 @@ func emitRequestEvents(ec *emitCtx, evs []protocol.Event) {
 	}
 }
 
+// tailStart returns the index of the first event after the last assistant
+// message — the events that arrived with this request and were not already
+// logged as part of a previous one.
+func tailStart(evs []protocol.Event) int {
+	for i := len(evs) - 1; i >= 0; i-- {
+		if evs[i].Type == protocol.EventAssistantMessage {
+			return i + 1
+		}
+	}
+	return 0
+}
+
 // emitResponseEvents writes the response-side events (assistant message,
 // tool calls, usage) honoring listener flags.
 func emitResponseEvents(ec *emitCtx, evs []protocol.Event) {
 	for _, e := range evs {
 		switch e.Type {
+		case protocol.EventAssistantMessage:
+			if ec.logMode == logModeUserOnly {
+				continue // user mode logs prompts, not replies
+			}
 		case protocol.EventToolCall:
 			if !ec.logToolCalls {
 				continue

--- a/ingesters/llm_ingester/ingest_test.go
+++ b/ingesters/llm_ingester/ingest_test.go
@@ -116,6 +116,44 @@ func TestEmitRequestEventsUserOnly(t *testing.T) {
 	}
 }
 
+func TestEmitRequestEventsUserOnlyToolResults(t *testing.T) {
+	// An agentic turn: a tool result from a prior turn, an assistant turn, then
+	// the current turn's tool result.
+	evs := []protocol.Event{
+		{Type: protocol.EventUserMessage, Role: "user", Content: []byte("u1")},
+		{Type: protocol.EventToolResult, Role: "tool", Content: []byte("old"), ToolCallID: "c0"},
+		{Type: protocol.EventAssistantMessage, Role: "assistant", Content: []byte("a1")},
+		{Type: protocol.EventToolResult, Role: "tool", Content: []byte("new"), ToolCallID: "c1"},
+	}
+
+	// tool logging on: latest user message + only the current turn's tool result
+	ec, c := newCapturingCtx(logModeUserOnly, true, true)
+	emitRequestEvents(ec, evs)
+	types := c.eventTypes(t)
+	if countType(types, protocol.EventUserMessage) != 1 {
+		t.Errorf("user-only should emit the latest user message, got %v", types)
+	}
+	if got := countType(types, protocol.EventToolResult); got != 1 {
+		t.Errorf("expected 1 tool_result from the current turn, got %d (%v)", got, types)
+	}
+	if countType(types, protocol.EventAssistantMessage) != 0 {
+		t.Errorf("user-only must not emit assistant turns, got %v", types)
+	}
+	for _, e := range c.ents {
+		if string(e.Data) == "old" {
+			t.Errorf("user-only emitted a tool_result from a prior turn")
+		}
+	}
+
+	// tool logging off: just the user message
+	ec2, c2 := newCapturingCtx(logModeUserOnly, false, true)
+	emitRequestEvents(ec2, evs)
+	types2 := c2.eventTypes(t)
+	if len(types2) != 1 || types2[0] != protocol.EventUserMessage {
+		t.Errorf("user-only with tool logging off should emit just the user message, got %v", types2)
+	}
+}
+
 func TestEmitRequestEventsFullConversation(t *testing.T) {
 	ec, c := newCapturingCtx(logModeFullConversation, true, true)
 	emitRequestEvents(ec, sampleConversation())
@@ -208,6 +246,37 @@ func TestEmitResponseEventsToggles(t *testing.T) {
 	}
 	if countType(types2, protocol.EventAssistantMessage) != 1 {
 		t.Errorf("assistant message should still be emitted, got %v", types2)
+	}
+}
+
+// gravwell/issues#2679: Log-Mode=user was still ingesting assistant replies
+// because emitResponseEvents ignored the log mode entirely.
+func TestEmitResponseEventsUserMode(t *testing.T) {
+	resp := []protocol.Event{
+		{Type: protocol.EventAssistantMessage, Role: "assistant", Content: []byte("reply")},
+		{Type: protocol.EventToolCall, Role: "assistant", ToolName: "f", ToolCallID: "c1"},
+		{Type: protocol.EventUsage, Usage: &protocol.TokenUsage{TotalTokens: 5}},
+	}
+
+	// tool calls and usage still honor their own toggles
+	ec, c := newCapturingCtx(logModeUserOnly, true, true)
+	emitResponseEvents(ec, resp)
+	types := c.eventTypes(t)
+	if countType(types, protocol.EventAssistantMessage) != 0 {
+		t.Errorf("user mode must not emit assistant messages, got %v", types)
+	}
+	if countType(types, protocol.EventToolCall) != 1 {
+		t.Errorf("user mode should still emit tool calls when enabled, got %v", types)
+	}
+	if countType(types, protocol.EventUsage) != 1 {
+		t.Errorf("user mode should still emit usage when enabled, got %v", types)
+	}
+
+	// with both toggles off, user mode emits nothing from the response
+	ec2, c2 := newCapturingCtx(logModeUserOnly, false, false)
+	emitResponseEvents(ec2, resp)
+	if types2 := c2.eventTypes(t); len(types2) != 0 {
+		t.Errorf("user mode with all toggles off should emit nothing, got %v", types2)
 	}
 }
 

--- a/ingesters/llm_ingester/proxy_test.go
+++ b/ingesters/llm_ingester/proxy_test.go
@@ -323,6 +323,63 @@ func TestProxyStreaming(t *testing.T) {
 	}
 }
 
+// gravwell/issues#2679: with Log-Mode=user the reporter still saw
+// response.assistant_message entries under tag=llm. Exercise the full proxy
+// path — buffered and streaming — the way the repro does.
+func TestProxyUserModeSuppressesAssistant(t *testing.T) {
+	userMode := func(l *listener) { l.Log_Mode = logModeUserOnly }
+
+	t.Run("buffered", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			io.WriteString(w, chatRespBody)
+		}))
+		defer srv.Close()
+
+		ph, c := newTestHandler(t, srv.URL, userMode)
+		if w := doChat(t, ph, chatReqBody, "Bearer sk-test"); w.Code != http.StatusOK {
+			t.Fatalf("status = %d", w.Code)
+		}
+		types := c.eventTypes(t)
+		if countType(types, protocol.EventAssistantMessage) != 0 {
+			t.Errorf("Log-Mode=user ingested an assistant message, got %v", types)
+		}
+		if countType(types, protocol.EventUserMessage) != 1 {
+			t.Errorf("expected the user prompt to be ingested, got %v", types)
+		}
+		if countType(types, protocol.EventUsage) != 1 {
+			t.Errorf("expected the usage record (Log-Usage=true), got %v", types)
+		}
+	})
+
+	t.Run("streaming", func(t *testing.T) {
+		sse := "data: {\"id\":\"s1\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\n" +
+			"data: [DONE]\n\n"
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			io.WriteString(w, sse)
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+		}))
+		defer srv.Close()
+
+		ph, c := newTestHandler(t, srv.URL, userMode)
+		w := doChat(t, ph, chatReqBody, "Bearer sk-test")
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d", w.Code)
+		}
+		// The client still gets the full stream; only ingest is filtered.
+		if w.Body.String() != sse {
+			t.Errorf("client stream body = %q, want raw SSE", w.Body.String())
+		}
+		if types := c.eventTypes(t); countType(types, protocol.EventAssistantMessage) != 0 {
+			t.Errorf("Log-Mode=user ingested a reassembled assistant message, got %v", types)
+		}
+	})
+}
+
 func TestProxyUpstreamError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
Fixes gravwell/issues#2679

## This PR proposes...

- Fixing an issue where assistant replies were logged while in user mode
- Forcing tool calls to log when the log tool calls flag is set while in user mode

