### PR TITLE
feat(jamf): GENERAL should always be populated in sections

### DIFF
--- a/hosted/plugins/jamf/config.go
+++ b/hosted/plugins/jamf/config.go
@@ -40,7 +40,7 @@ const sectionGeneral string = "GENERAL"
 
 // Sections lists the computers-inventory sections we'll request if the
 // config doesn't specify any explicitly.
-var defaultSections = []string{sectionGeneral, "DISK_ENCRYPTION", "STORAGE"}
+var defaultSections = []string{sectionGeneral}
 
 type Config struct {
 	hosted.BaseConfig

--- a/hosted/plugins/jamf/config.go
+++ b/hosted/plugins/jamf/config.go
@@ -14,6 +14,7 @@ package jamf
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/gravwell/gravwell/v3/hosted"
@@ -35,9 +36,11 @@ const (
 	pollBufferSeconds = 60
 )
 
+const sectionGeneral string = "GENERAL"
+
 // Sections lists the computers-inventory sections we'll request if the
 // config doesn't specify any explicitly.
-var defaultSections = []string{"GENERAL", "DISK_ENCRYPTION", "STORAGE"}
+var defaultSections = []string{sectionGeneral, "DISK_ENCRYPTION", "STORAGE"}
 
 type Config struct {
 	hosted.BaseConfig
@@ -74,8 +77,11 @@ func (c *Config) Verify() error {
 		return fmt.Errorf("Page-Size %d is too large, must be <= 1000", c.Page_Size)
 	}
 
+	// GENERAL should _always_ be in c.Sections.
 	if len(c.Sections) == 0 {
 		c.Sections = defaultSections
+	} else if !slices.Contains(c.Sections, sectionGeneral) {
+		c.Sections = append(c.Sections, sectionGeneral)
 	}
 
 	c.PollingConfig.ApplyDefaults(defaultLookback, defaultRequestsPerMinute, defaultInterval)

--- a/hosted/plugins/jamf/config_test.go
+++ b/hosted/plugins/jamf/config_test.go
@@ -8,7 +8,10 @@
 
 package jamf
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestConfig_Verify(t *testing.T) {
 	tests := []struct {
@@ -69,10 +72,72 @@ func TestConfig_Verify_Defaults(t *testing.T) {
 	if c.Page_Size != defaultPageSize {
 		t.Errorf("expected default page size %d, got %d", defaultPageSize, c.Page_Size)
 	}
-	if len(c.Sections) != len(defaultSections) {
-		t.Errorf("expected default sections, got %v", c.Sections)
+	if !slices.Equal(c.Sections, defaultSections) {
+		t.Errorf("expected default sections %v, got %v", defaultSections, c.Sections)
 	}
 	if got := c.Tags(); len(got) != 1 || got[0] != defaultTag {
 		t.Errorf("expected default tag %q, got %v", defaultTag, got)
+	}
+}
+
+func TestConfig_Verify_Sections(t *testing.T) {
+	tests := []struct {
+		name         string
+		sections     []string
+		wantSections []string
+	}{
+		{
+			name:         "nil sections get GENERAL defaults",
+			sections:     nil,
+			wantSections: []string{sectionGeneral, "DISK_ENCRYPTION", "STORAGE"},
+		},
+		{
+			name:         "empty sections get GENERAL defaults",
+			sections:     []string{},
+			wantSections: []string{sectionGeneral, "DISK_ENCRYPTION", "STORAGE"},
+		},
+		{
+			name:         "user sections without GENERAL get it appended",
+			sections:     []string{"STORAGE"},
+			wantSections: []string{"STORAGE", sectionGeneral},
+		},
+		{
+			name:         "user sections already containing GENERAL are unchanged",
+			sections:     []string{sectionGeneral, "STORAGE"},
+			wantSections: []string{sectionGeneral, "STORAGE"},
+		},
+		{
+			name:         "user sections with GENERAL not first are unchanged",
+			sections:     []string{"STORAGE", sectionGeneral, "DISK_ENCRYPTION"},
+			wantSections: []string{"STORAGE", sectionGeneral, "DISK_ENCRYPTION"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := Config{
+				Host: "https://jamf.example.com", Client_Id: "id", Client_Secret: "secret",
+				Sections: tt.sections,
+			}
+			if err := c.Verify(); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !slices.Equal(c.Sections, tt.wantSections) {
+				t.Errorf("Sections = %v, want %v", c.Sections, tt.wantSections)
+			}
+			if !slices.Contains(c.Sections, sectionGeneral) {
+				t.Errorf("Sections %v does not contain %q", c.Sections, sectionGeneral)
+			}
+			// Guard against GENERAL being duplicated by a broken slices.Contains check.
+			var generalCount int
+			for _, s := range c.Sections {
+				if s == sectionGeneral {
+					generalCount++
+				}
+			}
+			if generalCount != 1 {
+				t.Errorf("Sections %v contains %q %d times, want exactly 1", c.Sections, sectionGeneral, generalCount)
+			}
+		})
 	}
 }

--- a/hosted/plugins/jamf/config_test.go
+++ b/hosted/plugins/jamf/config_test.go
@@ -89,12 +89,12 @@ func TestConfig_Verify_Sections(t *testing.T) {
 		{
 			name:         "nil sections get GENERAL defaults",
 			sections:     nil,
-			wantSections: []string{sectionGeneral, "DISK_ENCRYPTION", "STORAGE"},
+			wantSections: defaultSections,
 		},
 		{
 			name:         "empty sections get GENERAL defaults",
 			sections:     []string{},
-			wantSections: []string{sectionGeneral, "DISK_ENCRYPTION", "STORAGE"},
+			wantSections: defaultSections,
 		},
 		{
 			name:         "user sections without GENERAL get it appended",


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses [ISSUE_LINK]

## This PR proposes...

- ensure the GENERAL section is provided. without it, we can't pull `reportDate` for timestamps
- if no sections are provided in config, provide sensible defaults
- tests

## PR Tasks

<!-- Add tasks to this list as needed -->

- [x] e2e and/or unit tests included. If not, please provide an explanation.
- [ ] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
