### PR TITLE
Hosted ingester dynamic reload

### DIFF
--- a/e2e/hosted/reload_test.go
+++ b/e2e/hosted/reload_test.go
@@ -1,0 +1,417 @@
+package hosted
+
+import (
+	"bufio"
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"text/template"
+	"time"
+
+	"gravwell/e2e"
+
+	"github.com/gravwell/gravwell/v3/client"
+	"github.com/gravwell/gravwell/v3/ingest/config"
+	tc "github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+const (
+	runnerConfPath = "/opt/gravwell/etc/hosted_runner.conf"
+	runnerLogPath  = "/opt/gravwell/log/hosted_runner.log"
+
+	// log messages the runner emits while servicing a SIGHUP, these are the contract
+	// the reload tests assert against
+	reloadComplete    = "configuration reload complete"
+	reloadFailed      = "failed to reload" // covers both the config load and the ingester swap
+	ingesterAdded     = "created new ingester on reload"
+	ingesterRemoved   = "shutdown ingester on reload"
+	ingesterRestarted = "restarted ingester on reload"
+
+	// settle is how long we let entries accumulate after a reload before searching, long
+	// enough that a still running ingester on a 1s interval will certainly have written.
+	settle = 15 * time.Second
+
+	// shutdownGuard is skipped at the front of a post removal search window, see assertSilent
+	shutdownGuard = 5 * time.Second
+)
+
+// tester and okta stanzas rendered into testdata/reload.conf
+type testerPlugin struct {
+	Name     string
+	UUID     string
+	Interval string
+	Tag      string
+}
+
+type oktaPlugin struct {
+	Name   string
+	UUID   string
+	Domain string
+	Token  string
+}
+
+// reloadConfig is the template data for testdata/reload.conf. The embedded IngestConfig
+// supplies the Global section the same way e2e.DefaultConfig does for the other tests.
+type reloadConfig struct {
+	config.IngestConfig
+	Testers []testerPlugin
+	Oktas   []oktaPlugin
+}
+
+func newReloadConfig(testers ...testerPlugin) reloadConfig {
+	return reloadConfig{IngestConfig: e2e.DefaultConfig, Testers: testers}
+}
+
+// TestHostedReload covers the SIGHUP driven config reload. Every case runs several
+// ingesters and only touches one of them, so each case also proves the runner left the
+// bystanders alone rather than cycling everything on every reload.
+func TestHostedReload(t *testing.T) {
+	t.Run("Added Ingester", testReloadAdd)
+	t.Run("Removed Ingester", testReloadRemove)
+	t.Run("Changed Ingester", testReloadChange)
+	t.Run("Renamed Ingester", testReloadRename)
+	t.Run("Reused UUID", testReloadReusedUUID)
+}
+
+// a wholly new ingester shows up in the config and gets started, the existing two are untouched
+func testReloadAdd(t *testing.T) {
+	alpha := testerPlugin{"add-alpha", "1a7a3e04-2e3c-4f6f-9f5a-2a1b6a19d001", "1s", "reload-add-alpha"}
+	beta := testerPlugin{"add-beta", "1a7a3e04-2e3c-4f6f-9f5a-2a1b6a19d002", "1s", "reload-add-beta"}
+	gamma := testerPlugin{"add-gamma", "1a7a3e04-2e3c-4f6f-9f5a-2a1b6a19d003", "1s", "reload-add-gamma"}
+
+	con := startRunner(t, "hosted-reload-add", newReloadConfig(alpha, beta))
+	c := e2e.GetClient(t)
+	assertEmitting(t, c, time.Time{}, alpha.Tag, beta.Tag)
+
+	at := reload(t, con, newReloadConfig(alpha, beta, gamma))
+
+	assertAction(t, con, gamma.Name, ingesterAdded)
+	assertUntouched(t, con, alpha.Name, beta.Name)
+
+	waitOutWindow(t, at)
+	assertEmitting(t, c, at, gamma.Tag, alpha.Tag, beta.Tag)
+}
+
+// an ingester disappears from the config, it gets shut down and stops writing while the rest keep going
+func testReloadRemove(t *testing.T) {
+	alpha := testerPlugin{"rm-alpha", "2a7a3e04-2e3c-4f6f-9f5a-2a1b6a19d001", "1s", "reload-rm-alpha"}
+	beta := testerPlugin{"rm-beta", "2a7a3e04-2e3c-4f6f-9f5a-2a1b6a19d002", "1s", "reload-rm-beta"}
+	gamma := testerPlugin{"rm-gamma", "2a7a3e04-2e3c-4f6f-9f5a-2a1b6a19d003", "1s", "reload-rm-gamma"}
+
+	con := startRunner(t, "hosted-reload-remove", newReloadConfig(alpha, beta, gamma))
+	c := e2e.GetClient(t)
+	assertEmitting(t, c, time.Time{}, alpha.Tag, beta.Tag, gamma.Tag)
+
+	at := reload(t, con, newReloadConfig(alpha, beta))
+
+	assertAction(t, con, gamma.Name, ingesterRemoved)
+	assertUntouched(t, con, alpha.Name, beta.Name)
+
+	waitOutWindow(t, at)
+	assertSilent(t, c, at, gamma.Tag)
+	assertEmitting(t, c, at, alpha.Tag, beta.Tag)
+}
+
+// a trivial but real config change (the poll interval) restarts just that one ingester
+func testReloadChange(t *testing.T) {
+	alpha := testerPlugin{"chg-alpha", "3a7a3e04-2e3c-4f6f-9f5a-2a1b6a19d001", "1s", "reload-chg-alpha"}
+	beta := testerPlugin{"chg-beta", "3a7a3e04-2e3c-4f6f-9f5a-2a1b6a19d002", "1s", "reload-chg-beta"}
+	gamma := testerPlugin{"chg-gamma", "3a7a3e04-2e3c-4f6f-9f5a-2a1b6a19d003", "1s", "reload-chg-gamma"}
+
+	con := startRunner(t, "hosted-reload-change", newReloadConfig(alpha, beta, gamma))
+	c := e2e.GetClient(t)
+	assertEmitting(t, c, time.Time{}, alpha.Tag, beta.Tag, gamma.Tag)
+
+	// re-render the config with nothing changed at all, the runner must not cycle anything
+	reload(t, con, newReloadConfig(alpha, beta, gamma))
+	assertUntouched(t, con, alpha.Name, beta.Name, gamma.Name)
+
+	changed := gamma
+	changed.Interval = "2s"
+	at := reload(t, con, newReloadConfig(alpha, beta, changed))
+
+	assertAction(t, con, gamma.Name, ingesterRestarted)
+	assertUntouched(t, con, alpha.Name, beta.Name)
+
+	waitOutWindow(t, at)
+	assertEmitting(t, c, at, gamma.Tag, alpha.Tag, beta.Tag)
+}
+
+// the ingester UUID stays put but the name changes, that alone is a complete change and
+// the ingester is torn down and rebuilt under the new name
+func testReloadRename(t *testing.T) {
+	alpha := testerPlugin{"rn-alpha", "4a7a3e04-2e3c-4f6f-9f5a-2a1b6a19d001", "1s", "reload-rn-alpha"}
+	beta := testerPlugin{"rn-beta", "4a7a3e04-2e3c-4f6f-9f5a-2a1b6a19d002", "1s", "reload-rn-beta"}
+	gamma := testerPlugin{"rn-gamma", "4a7a3e04-2e3c-4f6f-9f5a-2a1b6a19d003", "1s", "reload-rn-gamma"}
+
+	con := startRunner(t, "hosted-reload-rename", newReloadConfig(alpha, beta, gamma))
+	c := e2e.GetClient(t)
+	assertEmitting(t, c, time.Time{}, alpha.Tag, beta.Tag, gamma.Tag)
+
+	// only the stanza name moves, same UUID, same interval, same tag
+	renamed := gamma
+	renamed.Name = "rn-delta"
+	at := reload(t, con, newReloadConfig(alpha, beta, renamed))
+
+	assertAction(t, con, renamed.Name, ingesterRestarted)
+	assertUntouched(t, con, gamma.Name, alpha.Name, beta.Name)
+
+	waitOutWindow(t, at)
+	assertEmitting(t, c, at, renamed.Tag, alpha.Tag, beta.Tag)
+}
+
+// an ingester UUID that belonged to one plugin is handed to a different plugin, the old
+// plugin has to come down and the new one has to come up in its place
+func testReloadReusedUUID(t *testing.T) {
+	const sharedUUID = "5a7a3e04-2e3c-4f6f-9f5a-2a1b6a19d003"
+	alpha := testerPlugin{"uuid-alpha", "5a7a3e04-2e3c-4f6f-9f5a-2a1b6a19d001", "1s", "reload-uuid-alpha"}
+	beta := testerPlugin{"uuid-beta", "5a7a3e04-2e3c-4f6f-9f5a-2a1b6a19d002", "1s", "reload-uuid-beta"}
+	// the okta plugin never reaches a real okta tenant, we only care that it holds the UUID
+	swapped := oktaPlugin{"uuid-swap", sharedUUID, "e2e-reload.okta.com", "not-a-real-token"}
+	tester := testerPlugin{swapped.Name, sharedUUID, "1s", "reload-uuid-swap"}
+
+	initial := newReloadConfig(alpha, beta)
+	initial.Oktas = []oktaPlugin{swapped}
+	con := startRunner(t, "hosted-reload-reused-uuid", initial)
+	c := e2e.GetClient(t)
+	assertEmitting(t, c, time.Time{}, alpha.Tag, beta.Tag)
+
+	// same name, same UUID, different plugin entirely
+	at := reload(t, con, newReloadConfig(alpha, beta, tester))
+
+	assertAction(t, con, tester.Name, ingesterRestarted)
+	assertUntouched(t, con, alpha.Name, beta.Name)
+	if line := findAction(t, con, tester.Name)[0]; !strings.Contains(line, `kind="tester"`) {
+		e2e.Fatalf(t, "UUID %s was not handed to the tester plugin: %s", sharedUUID, line)
+	}
+
+	// the tester now owning the UUID is running, which it could not be if the okta
+	// plugin still held the slot
+	waitOutWindow(t, at)
+	assertEmitting(t, c, at, tester.Tag, alpha.Tag, beta.Tag)
+}
+
+// startRunner brings up a hosted runner container with the given plugin set.
+func startRunner(t *testing.T, name string, cfg reloadConfig) *tc.DockerContainer {
+	t.Helper()
+	con, err := tc.Run(t.Context(), "gravwell/hosted:e2e",
+		e2e.WithDefaults(t, name,
+			tc.WithWaitStrategyAndDeadline(
+				35*time.Second,
+				wait.ForLog("Successfully connected to ingesters").WithPollInterval(time.Second),
+			),
+			tc.WithFiles(tc.ContainerFile{
+				Reader:            bytes.NewReader(renderConfig(t, "initial.conf", cfg)),
+				ContainerFilePath: runnerConfPath,
+				FileMode:          0o644,
+			}),
+		)...,
+	)
+	t.Cleanup(func() {
+		e2e.SaveTestFiles(t, con, e2e.Log, []string{runnerLogPath})
+		e2e.Terminate(t, con)
+	})
+	if err != nil {
+		e2e.Fatal(t, err)
+	}
+	return con
+}
+
+// reload swaps the config out from under the running runner and SIGHUPs it, returning the
+// instant the runner reported the reload finished. It blocks on that report so callers are
+// never racing the signal handler when they go assert on what happened.
+func reload(t *testing.T, con *tc.DockerContainer, cfg reloadConfig) time.Time {
+	t.Helper()
+	// the completion marker from any earlier reload is still sitting in the log, so count
+	// what is already there and wait for one more rather than matching a stale line
+	done := countLog(t, con, reloadComplete) + 1
+
+	if err := con.CopyToContainer(t.Context(), renderConfig(t, "reloaded.conf", cfg), runnerConfPath, 0o644); err != nil {
+		e2e.Fatalf(t, "failed to replace the running config: %v", err)
+	}
+	// the image starts the binary from a shell CMD, so signal it by name instead of assuming PID 1
+	code, out, err := con.Exec(t.Context(), []string{"sh", "-c", "kill -HUP $(pidof runner)"})
+	if err != nil {
+		e2e.Fatalf(t, "failed to send SIGHUP: %v", err)
+	} else if code != 0 {
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(out)
+		e2e.Fatalf(t, "SIGHUP exited %d: %s", code, buf.String())
+	}
+	waitForReload(t, con, done, 30*time.Second)
+	return time.Now()
+}
+
+// renderConfig renders testdata/reload.conf and saves the result as a test artifact.
+func renderConfig(t *testing.T, artifact string, cfg reloadConfig) []byte {
+	t.Helper()
+	path := filepath.Clean("testdata/reload.conf")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read config template %s: %v", path, err)
+	}
+	tmpl, err := template.New(filepath.Base(path)).Parse(string(body))
+	if err != nil {
+		t.Fatalf("failed to parse config template %s: %v", path, err)
+	}
+	var buf bytes.Buffer
+	if err = tmpl.Execute(&buf, cfg); err != nil {
+		t.Fatalf("failed to render config template %s: %v", path, err)
+	}
+	e2e.WriteArtifact(t, e2e.Conf, artifact, buf.Bytes())
+	return buf.Bytes()
+}
+
+// runnerLog pulls the current contents of the runner log out of the container.
+func runnerLog(t *testing.T, con *tc.DockerContainer) []string {
+	t.Helper()
+	r, err := con.CopyFileFromContainer(t.Context(), runnerLogPath)
+	if err != nil {
+		e2e.Fatalf(t, "failed to read %s: %v", runnerLogPath, err)
+	}
+	defer r.Close()
+	var lines []string
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err = scanner.Err(); err != nil {
+		e2e.Fatalf(t, "failed to scan %s: %v", runnerLogPath, err)
+	}
+	return lines
+}
+
+func countLog(t *testing.T, con *tc.DockerContainer, msg string) (n int) {
+	t.Helper()
+	for _, line := range runnerLog(t, con) {
+		if strings.Contains(line, msg) {
+			n++
+		}
+	}
+	return
+}
+
+// waitForReload blocks until the runner has logged want reload completions, or fails the
+// test. A reload that blew up never logs its completion, so surface that error instead of
+// sitting here until the timeout with nothing useful to say.
+func waitForReload(t *testing.T, con *tc.DockerContainer, want int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		var done int
+		for _, line := range runnerLog(t, con) {
+			if strings.Contains(line, reloadComplete) {
+				done++
+			} else if strings.Contains(line, reloadFailed) {
+				e2e.Fatalf(t, "reload failed: %s", line)
+			}
+		}
+		if done >= want {
+			return
+		}
+		if time.Now().After(deadline) {
+			e2e.Fatalf(t, "timed out after %v waiting for reload %d to complete", timeout, want)
+		}
+		time.Sleep(time.Second)
+	}
+}
+
+// findAction returns every reload action the runner logged against the named ingester.
+// Only reloads log these messages, startup does not, so anything here came from a SIGHUP.
+func findAction(t *testing.T, con *tc.DockerContainer, name string) []string {
+	t.Helper()
+	var r []string
+	for _, line := range runnerLog(t, con) {
+		if !strings.Contains(line, `name="`+name+`"`) {
+			continue
+		}
+		for _, action := range []string{ingesterAdded, ingesterRemoved, ingesterRestarted} {
+			if strings.Contains(line, action) {
+				r = append(r, line)
+				break
+			}
+		}
+	}
+	return r
+}
+
+// assertAction requires that the named ingester saw exactly one reload action, and that it
+// was the expected one. More than one means the reload cycled it more than it needed to.
+func assertAction(t *testing.T, con *tc.DockerContainer, name, want string) {
+	t.Helper()
+	actions := findAction(t, con, name)
+	if len(actions) == 0 {
+		e2e.Fatalf(t, "ingester %q was not %q on reload", name, want)
+	} else if len(actions) > 1 {
+		e2e.Fatalf(t, "ingester %q saw %d reload actions, want 1: %s", name, len(actions), strings.Join(actions, " | "))
+	} else if !strings.Contains(actions[0], want) {
+		e2e.Fatalf(t, "ingester %q got the wrong reload action, want %q: %s", name, want, actions[0])
+	}
+}
+
+// assertUntouched requires that the reload did not add, remove, or restart any of the named
+// ingesters, they were not the target of the change and must have been left running.
+func assertUntouched(t *testing.T, con *tc.DockerContainer, names ...string) {
+	t.Helper()
+	for _, name := range names {
+		if actions := findAction(t, con, name); len(actions) > 0 {
+			e2e.Fatalf(t, "ingester %q should not have been touched by the reload: %s", name, strings.Join(actions, " | "))
+		}
+	}
+}
+
+// searchWindow returns how far back to search. Anchoring on the reload instant means the
+// range starts exactly when the reload finished, no matter how long the log assertions in
+// between took. A fixed width window can slide back past the reload and turn entries the
+// old ingester legitimately wrote before it was stopped into a failure. Pass the zero time
+// before any reload has happened, when there is nothing to anchor to.
+func searchWindow(since time.Time) time.Duration {
+	if since.IsZero() {
+		return settle
+	}
+	return time.Since(since)
+}
+
+// assertEmitting requires fresh entries on each tag, which only a running ingester produces.
+func assertEmitting(t *testing.T, c *client.Client, since time.Time, tags ...string) {
+	t.Helper()
+	for _, tag := range tags {
+		if ents := e2e.WaitForEntries(t, c, "tag="+tag, searchWindow(since), 1, 45*time.Second); len(ents) == 0 {
+			e2e.Fatalf(t, "no entries on tag %s, its ingester is not running", tag)
+		}
+	}
+}
+
+// assertSilent requires that the tag stopped producing. The window starts a few seconds
+// after the reload rather than at it: a tester on a one second interval can land a single
+// entry right around the moment it is torn down, and that straggler says nothing about
+// whether the ingester is still running. An ingester that really is still up writes once a
+// second, so it cannot hide in the rest of the window. Call this only after waitOutWindow,
+// so there is enough window left to be meaningful.
+func assertSilent(t *testing.T, c *client.Client, since time.Time, tag string) {
+	t.Helper()
+	d := time.Since(since.Add(shutdownGuard))
+	if d < time.Second {
+		e2e.Fatalf(t, "assertSilent called %v after the reload, too soon to prove anything", time.Since(since))
+	}
+	if ents := e2e.RunSearch(t, c, "tag="+tag, d); len(ents) > 0 {
+		stamps := make([]string, 0, len(ents))
+		for _, ent := range ents {
+			stamps = append(stamps, ent.TS.Format(time.RFC3339Nano))
+		}
+		e2e.Fatalf(t, "got %d entries on tag %s after its ingester was shut down at %s: %s",
+			len(ents), tag, since.Format(time.RFC3339Nano), strings.Join(stamps, ", "))
+	}
+}
+
+// waitOutWindow gives the reloaded config long enough to produce entries before anything
+// searches for them, so an empty result means stopped rather than just not started yet.
+func waitOutWindow(t *testing.T, since time.Time) {
+	t.Helper()
+	if d := settle - time.Since(since); d > 0 {
+		time.Sleep(d)
+	}
+}

--- a/e2e/hosted/testdata/reload.conf
+++ b/e2e/hosted/testdata/reload.conf
@@ -1,0 +1,28 @@
+[Global]
+	Ingest-Secret = "{{ .Ingest_Secret }}"
+	Connection-Timeout = "{{ .Connection_Timeout }}"
+	Insecure-Skip-TLS-Verify=false
+
+	Cleartext-Backend-Target={{ index .Cleartext_Backend_Target 0 }}
+
+	# log levels and output files
+	# DEBUG is required, the "Successfully connected to ingesters" line the container
+	# wait strategy keys on is logged at debug level
+	Log-Level=DEBUG
+	Log-File=/opt/gravwell/log/hosted_runner.log
+
+# configure the state file for hosted ingesters
+[State]
+	Path="/opt/gravwell/etc/hosted_runner.state"
+	Sync=false #do NOT flush to disk on every sync (sync=true mode can be expensive if disks are slow)
+{{ range .Testers }}
+[Tester "{{ .Name }}"]
+	Ingester-UUID={{ .UUID }}
+	Interval={{ .Interval }}
+	Tag-Name={{ .Tag }}
+{{ end }}{{ range .Oktas }}
+[Okta "{{ .Name }}"]
+	Ingester-UUID={{ .UUID }}
+	Domain={{ .Domain }}
+	Token={{ .Token }}
+{{ end }}

--- a/hosted/configtest/configtest.go
+++ b/hosted/configtest/configtest.go
@@ -1,0 +1,144 @@
+/*************************************************************************
+ * Copyright 2026 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
+// Package configtest provides test helpers for plugin config types that implement
+// the hosted.Config interface.
+//
+// Equal implementations are hand written field by field, which means a field added
+// to a config later can quietly go unchecked and the runner will then refuse to
+// restart an ingester whose config really did change. CheckEqual walks the config
+// with reflection and fails if any exported field is ignored by Equal.
+package configtest
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/gravwell/gravwell/v3/hosted"
+)
+
+// CheckEqual validates that *T implements hosted.Config correctly.
+// It checks the basic contract (a config equals itself in both value and pointer
+// form, and never equals nil or a foreign type) and then mutates each exported
+// field in turn, requiring Equal to report a difference for every one of them.
+//
+// Unexported fields cannot be set through reflection and are not covered, so
+// derived state such as parsed override maps still needs a hand written test.
+func CheckEqual[T any](t *testing.T, base T) {
+	t.Helper()
+	cfg, ok := any(&base).(hosted.Config)
+	if !ok {
+		t.Fatalf("%T does not implement hosted.Config", &base)
+	}
+
+	// the basic contract, this also catches an Equal that just always returns false
+	self := base
+	if !cfg.Equal(&self) {
+		t.Fatal("Equal returned false for an identical config pointer")
+	}
+	if !cfg.Equal(self) {
+		t.Fatal("Equal returned false for an identical config value")
+	}
+	if cfg.Equal(nil) {
+		t.Error("Equal returned true for a nil any")
+	}
+	if cfg.Equal((*T)(nil)) {
+		t.Error("Equal returned true for a nil config pointer")
+	}
+	if cfg.Equal(struct{ Nonsense int }{}) {
+		t.Error("Equal returned true for a foreign type")
+	}
+
+	typ := reflect.TypeOf(base)
+	if typ.Kind() != reflect.Struct {
+		t.Fatalf("config type %s is not a struct", typ)
+	}
+
+	for _, f := range leaves(t, typ, nil, "") {
+		mutated := base
+		v := reflect.ValueOf(&mutated).Elem().FieldByIndex(f.index)
+		if err := mutate(v); err != nil {
+			t.Fatalf("cannot mutate field %s: %v", f.name, err)
+		}
+		if cfg.Equal(&mutated) {
+			t.Errorf("Equal ignores field %s, it must be added to the comparison", f.name)
+		}
+	}
+}
+
+type leaf struct {
+	index []int
+	name  string
+}
+
+// leaves collects every exported non-struct field, descending through nested and
+// embedded structs so that each individual value gets its own mutation.
+func leaves(t *testing.T, typ reflect.Type, prefix []int, path string) (r []leaf) {
+	t.Helper()
+	var exported int
+	for i := range typ.NumField() {
+		sf := typ.Field(i)
+		if sf.PkgPath != `` {
+			continue // unexported, reflection cannot set it
+		}
+		exported++
+		index := append(append([]int{}, prefix...), i)
+		name := sf.Name
+		if path != `` {
+			name = path + "." + name
+		}
+		if sf.Type.Kind() == reflect.Struct {
+			r = append(r, leaves(t, sf.Type, index, name)...)
+			continue
+		}
+		r = append(r, leaf{index: index, name: name})
+	}
+	if exported == 0 {
+		t.Fatalf("struct %s at %q has no exported fields, CheckEqual cannot cover it", typ, path)
+	}
+	return
+}
+
+// mutate sets v to a value that differs from the one it currently holds.
+func mutate(v reflect.Value) error {
+	switch v.Kind() {
+	case reflect.Bool:
+		v.SetBool(!v.Bool())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v.SetInt(v.Int() + 1)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		v.SetUint(v.Uint() + 1)
+	case reflect.Float32, reflect.Float64:
+		v.SetFloat(v.Float() + 1)
+	case reflect.String:
+		v.SetString(v.String() + "-configtest")
+	case reflect.Slice:
+		// build a fresh backing array so we never scribble on the original
+		nv := reflect.MakeSlice(v.Type(), v.Len(), v.Len()+1)
+		reflect.Copy(nv, v)
+		v.Set(reflect.Append(nv, reflect.New(v.Type().Elem()).Elem()))
+	case reflect.Map:
+		nv := reflect.MakeMapWithSize(v.Type(), v.Len()+1)
+		iter := v.MapRange()
+		for iter.Next() {
+			nv.SetMapIndex(iter.Key(), iter.Value())
+		}
+		key := reflect.New(v.Type().Key()).Elem()
+		for nv.MapIndex(key).IsValid() { // walk until we land on a key that is not in use
+			if err := mutate(key); err != nil {
+				return err
+			}
+		}
+		nv.SetMapIndex(key, reflect.New(v.Type().Elem()).Elem())
+		v.Set(nv)
+	default:
+		return fmt.Errorf("unsupported kind %s, extend configtest.mutate", v.Kind())
+	}
+	return nil
+}

--- a/hosted/interface.go
+++ b/hosted/interface.go
@@ -31,7 +31,9 @@ type Runner interface {
 	Running() bool
 	ID() string
 	Name() string
+	Version() string // keeping this as a string because some engines may not have good canonical versions
 	UUID() uuid.UUID
+	Config() any
 }
 
 // Runtime is the interface provided to a hosted ingester which enables it to
@@ -79,4 +81,27 @@ type Logger interface {
 	Warn(msg string, sds ...rfc5424.SDParam)
 	Error(msg string, sds ...rfc5424.SDParam)
 	Critical(msg string, sds ...rfc5424.SDParam)
+}
+
+// Config is the interface that ingester configuration types must implement so we can detect config changes
+type Config interface {
+	Equal(any) bool
+}
+
+// EqualTarget normalizes the value handed to a Config.Equal implementation down to a *T.
+// Equal takes an any so that configs of differing types can be compared, which means every
+// implementation has to deal with being handed a value, a pointer, a nil, or something else
+// entirely. Callers get back a usable pointer and true only when the value really is a T,
+// everything else is not equal by definition.
+func EqualTarget[T any](v any) (*T, bool) {
+	if p, ok := v.(*T); ok {
+		if p == nil {
+			return nil, false
+		}
+		return p, true
+	}
+	if val, ok := v.(T); ok {
+		return &val, true
+	}
+	return nil, false
 }

--- a/hosted/native.go
+++ b/hosted/native.go
@@ -90,10 +90,34 @@ func NewNativeRunner(id, name, verstr string, ingesterUUID uuid.UUID, cfg any, i
 		version:      ver,
 		Ingester:     ig,
 		ingesterUUID: ingesterUUID,
-		rt:           rt,
 		cfg:          cfg,
 	}
 	r.ctx, r.cf = context.WithCancel(rt.Context())
+	r.rt = &scopedRuntime{Runtime: rt, ctx: r.ctx}
+	return
+}
+
+// scopedRuntime narrows a Runtime down to a single runner's lifetime.
+// The runtime handed to NewNativeRunner is shared by every ingester in the process, so its
+// context only ends when the whole process is going down. An ingester that waits on that
+// context can never be stopped on its own, which means Close blocks forever and a config
+// reload can't cycle just one ingester. Scoping Context and Sleep to the runner's own
+// context is what makes an individual stop actually work.
+type scopedRuntime struct {
+	Runtime
+	ctx context.Context
+}
+
+func (sr *scopedRuntime) Context() context.Context { return sr.ctx }
+
+func (sr *scopedRuntime) Sleep(d time.Duration) (r bool) {
+	tmr := time.NewTimer(d)
+	defer tmr.Stop()
+	select {
+	case <-tmr.C:
+	case <-sr.ctx.Done():
+		r = true
+	}
 	return
 }
 

--- a/hosted/native.go
+++ b/hosted/native.go
@@ -51,6 +51,7 @@ type NativeRunner struct {
 	version      version.Canonical
 	ingesterUUID uuid.UUID
 	rt           Runtime
+	cfg          any // the native config for the ingester
 	ctx          context.Context
 	cf           context.CancelFunc
 	running      bool  // is the ingester currently running
@@ -58,7 +59,7 @@ type NativeRunner struct {
 }
 
 // NewNativeRunner creates a new NativeRunner that has validated some basic parameters and is ready to Run
-func NewNativeRunner(id, name, verstr string, ingesterUUID uuid.UUID, ig Ingester, rt Runtime) (r *NativeRunner, err error) {
+func NewNativeRunner(id, name, verstr string, ingesterUUID uuid.UUID, cfg any, ig Ingester, rt Runtime) (r *NativeRunner, err error) {
 	var ver version.Canonical
 	if id == `` {
 		err = errors.New("missing ingester ID")
@@ -74,6 +75,9 @@ func NewNativeRunner(id, name, verstr string, ingesterUUID uuid.UUID, ig Ingeste
 		return
 	} else if ver, err = version.Parse(verstr); err != nil {
 		return
+	} else if cfg == nil {
+		err = errors.New("nil config")
+		return
 	}
 	if ingesterUUID == uuid.Nil {
 		ingesterUUID = uuid.New()
@@ -87,6 +91,7 @@ func NewNativeRunner(id, name, verstr string, ingesterUUID uuid.UUID, ig Ingeste
 		Ingester:     ig,
 		ingesterUUID: ingesterUUID,
 		rt:           rt,
+		cfg:          cfg,
 	}
 	r.ctx, r.cf = context.WithCancel(rt.Context())
 	return
@@ -147,6 +152,20 @@ func (nr *NativeRunner) Name() (name string) {
 func (nr *NativeRunner) UUID() (r uuid.UUID) {
 	if nr != nil {
 		r = nr.ingesterUUID
+	}
+	return
+}
+
+func (nr *NativeRunner) Version() (r string) {
+	if nr != nil {
+		r = nr.version.String()
+	}
+	return
+}
+
+func (nr *NativeRunner) Config() (r any) {
+	if nr != nil {
+		r = nr.cfg
 	}
 	return
 }

--- a/hosted/native_test.go
+++ b/hosted/native_test.go
@@ -1,0 +1,69 @@
+package hosted
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// TestNativeRunnerCloseStopsOneIngester covers stopping a single ingester while the runtime
+// it was handed stays alive, which is exactly what a config reload does. The process wide
+// runtime context is never cancelled here, so a runner that waits on the runtime instead of
+// its own context hangs in Close and the reload never finishes.
+func TestNativeRunnerCloseStopsOneIngester(t *testing.T) {
+	// this context stands in for the runtime shared by every ingester in the process
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	rt := newTestRuntime(ctx, cancel)
+
+	// an ingester that only ever waits on the runtime, the way the job adapter does
+	var once sync.Once
+	started := make(chan struct{})
+	ig := ingesterFunc(func(_ context.Context, rt Runtime) error {
+		for {
+			once.Do(func() { close(started) })
+			if rt.Sleep(10 * time.Millisecond) {
+				return nil
+			}
+		}
+	})
+
+	nr, err := NewNativeRunner("test.ingesters.gravwell.io", "test", "1.0.0", uuid.New(), &struct{}{}, ig, rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = nr.Start(); err != nil {
+		t.Fatal(err)
+	}
+	// closing before the ingester is actually up would exit on the run loop guard and
+	// prove nothing, wait until it is really in its poll loop
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ingester never started")
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- nr.Close() }()
+	select {
+	case err = <-done:
+		if err != nil {
+			t.Fatalf("close returned %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("close did not return, the ingester cannot be stopped on its own")
+	}
+	if nr.Running() {
+		t.Error("runner still reports running after close")
+	}
+	if ctx.Err() != nil {
+		t.Error("closing one runner cancelled the shared runtime context")
+	}
+}
+
+type ingesterFunc func(context.Context, Runtime) error
+
+func (f ingesterFunc) Run(ctx context.Context, rt Runtime) error { return f(ctx, rt) }

--- a/hosted/plugins/builder.go
+++ b/hosted/plugins/builder.go
@@ -11,11 +11,11 @@ package plugins
 import (
 	"github.com/google/uuid"
 	"github.com/gravwell/gravwell/v3/hosted"
+	"github.com/gravwell/gravwell/v3/hosted/plugins/jamf"
 	"github.com/gravwell/gravwell/v3/hosted/plugins/mimecast"
 	"github.com/gravwell/gravwell/v3/hosted/plugins/msgraph"
 	"github.com/gravwell/gravwell/v3/hosted/plugins/okta"
 	"github.com/gravwell/gravwell/v3/hosted/plugins/tester"
-	"github.com/gravwell/gravwell/v3/hosted/plugins/jamf"
 	"github.com/gravwell/gravwell/v3/hosted/plugins/wiz"
 )
 
@@ -147,7 +147,7 @@ func NewWizBuilder(config *wiz.Config, kind, id, version string) *WizBuilder {
 	return &WizBuilder{
 		Builder[*wiz.Config]{
 			config:  config,
-      		kind:    kind,
+			kind:    kind,
 			id:      id,
 			version: version,
 		},

--- a/hosted/plugins/config.go
+++ b/hosted/plugins/config.go
@@ -18,11 +18,11 @@ import (
 	"github.com/gravwell/gravwell/v3/hosted"
 
 	// include all the native hosted ingesters
+	"github.com/gravwell/gravwell/v3/hosted/plugins/jamf"
 	"github.com/gravwell/gravwell/v3/hosted/plugins/mimecast"
 	"github.com/gravwell/gravwell/v3/hosted/plugins/msgraph"
 	"github.com/gravwell/gravwell/v3/hosted/plugins/okta"
 	"github.com/gravwell/gravwell/v3/hosted/plugins/tester"
-	"github.com/gravwell/gravwell/v3/hosted/plugins/jamf"
 	"github.com/gravwell/gravwell/v3/hosted/plugins/wiz"
 )
 
@@ -115,8 +115,8 @@ func (c Configs) Tags() (tags []string, err error) {
 		tags = append(tags, v.Tags()...)
 	}
 	for _, v := range c.Wiz {
-    	tags = append(tags, v.Tags()...)
-  	}
+		tags = append(tags, v.Tags()...)
+	}
 	for _, v := range c.MSGraph {
 		tags = append(tags, v.Tags()...)
 	}
@@ -165,9 +165,9 @@ func (c Configs) Builders() iter.Seq2[string, IngesterBuilder] {
 		}
 		for name, config := range c.Wiz {
 			if !yield(name, NewWizBuilder(config, wiz.Name, wiz.ID, wiz.Version)) {
-        		return
-      		}
-    	}
+				return
+			}
+		}
 		for name, config := range c.MSGraph {
 			if !yield(name, NewMSGraphBuilder(config, msgraph.Name, msgraph.ID, msgraph.Version)) {
 				return

--- a/hosted/plugins/jamf/config.go
+++ b/hosted/plugins/jamf/config.go
@@ -56,6 +56,26 @@ type Config struct {
 	Insecure_Skip_TLS_Verify bool
 }
 
+var _ hosted.Config = (*Config)(nil) // compile time interface check
+
+// Equal implements hosted.Config so the runner can decide whether a config reload
+// actually changed anything for this ingester.
+func (c *Config) Equal(ncp any) bool {
+	nc, ok := hosted.EqualTarget[Config](ncp)
+	if c == nil || !ok {
+		return false
+	}
+	return c.BaseConfig == nc.BaseConfig &&
+		c.SingleTagConfig == nc.SingleTagConfig &&
+		c.PollingConfig == nc.PollingConfig &&
+		c.Host == nc.Host &&
+		c.Client_Id == nc.Client_Id &&
+		c.Client_Secret == nc.Client_Secret &&
+		c.Page_Size == nc.Page_Size &&
+		c.Insecure_Skip_TLS_Verify == nc.Insecure_Skip_TLS_Verify &&
+		slices.Equal(c.Sections, nc.Sections)
+}
+
 func (c *Config) Verify() error {
 	c.ApplyDefaultIngesterUUID(defaultIngesterUUIDStr)
 

--- a/hosted/plugins/jamf/config_test.go
+++ b/hosted/plugins/jamf/config_test.go
@@ -11,6 +11,9 @@ package jamf
 import (
 	"slices"
 	"testing"
+
+	"github.com/gravwell/gravwell/v3/hosted"
+	"github.com/gravwell/gravwell/v3/hosted/configtest"
 )
 
 func TestConfig_Verify(t *testing.T) {
@@ -140,4 +143,22 @@ func TestConfig_Verify_Sections(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConfigEqual(t *testing.T) {
+	configtest.CheckEqual(t, Config{
+		BaseConfig:      hosted.BaseConfig{Ingester_UUID: defaultIngesterUUIDStr},
+		SingleTagConfig: hosted.SingleTagConfig{Tag_Name: defaultTag},
+		PollingConfig: hosted.PollingConfig{
+			Lookback:            defaultLookback,
+			Requests_Per_Minute: defaultRequestsPerMinute,
+			Request_Interval:    defaultInterval,
+		},
+		Host:                     "https://example.jamfcloud.com",
+		Client_Id:                "id",
+		Client_Secret:            "secret",
+		Page_Size:                defaultPageSize,
+		Sections:                 defaultSections,
+		Insecure_Skip_TLS_Verify: true,
+	})
 }

--- a/hosted/plugins/jamf/jamf.go
+++ b/hosted/plugins/jamf/jamf.go
@@ -51,7 +51,7 @@ func (j *Jamf) initClient(ctx context.Context) {
 // whose general.reportDate falls in (lastEnd, now-buffer], paginating until
 // the API reports no more results, then schedules the next run.
 func (j *Jamf) Handle(ctx context.Context, rt hosted.Runtime) (*hosted.Continuation, error) {
-	j.initClient(rt.Context())
+	j.initClient(ctx)
 
 	tag, err := rt.NegotiateTag(j.conf.Tags()[0])
 	if err != nil {

--- a/hosted/plugins/mimecast/config.go
+++ b/hosted/plugins/mimecast/config.go
@@ -11,6 +11,7 @@ package mimecast
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/gravwell/gravwell/v3/hosted"
 )
@@ -32,6 +33,25 @@ type Config struct {
 	Api           []Api
 	Host          string
 	Preprocessor  []string
+}
+
+var _ hosted.Config = (*Config)(nil) // compile time interface check
+
+// Equal implements hosted.Config so the runner can decide whether a config reload
+// actually changed anything for this ingester.
+func (c *Config) Equal(ncp any) bool {
+	nc, ok := hosted.EqualTarget[Config](ncp)
+	if c == nil || !ok {
+		return false
+	}
+	return c.BaseConfig == nc.BaseConfig &&
+		c.MultiTagConfig == nc.MultiTagConfig &&
+		c.PollingConfig == nc.PollingConfig &&
+		c.Client_Id == nc.Client_Id &&
+		c.Client_Secret == nc.Client_Secret &&
+		c.Host == nc.Host &&
+		slices.Equal(c.Api, nc.Api) &&
+		slices.Equal(c.Preprocessor, nc.Preprocessor)
 }
 
 func (c *Config) Verify() error {

--- a/hosted/plugins/mimecast/config_test.go
+++ b/hosted/plugins/mimecast/config_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gravwell/gravwell/v3/hosted"
+	"github.com/gravwell/gravwell/v3/hosted/configtest"
 )
 
 func TestConfig_Verify(t *testing.T) {
@@ -205,4 +206,21 @@ func TestConfig_Verify_PrefersExistingValues(t *testing.T) {
 	if cfg.Host != "https://custom.com" {
 		t.Errorf("Host = %q, want https://custom.com", cfg.Host)
 	}
+}
+
+func TestConfigEqual(t *testing.T) {
+	configtest.CheckEqual(t, Config{
+		BaseConfig:     hosted.BaseConfig{Ingester_UUID: defaultIngesterUUIDStr},
+		MultiTagConfig: hosted.MultiTagConfig{Tag_Prefix: "mimecast"},
+		PollingConfig: hosted.PollingConfig{
+			Lookback:            defaultLookback,
+			Requests_Per_Minute: defaultRequestsPerMinute,
+			Request_Interval:    defaultInterval,
+		},
+		Client_Id:     "id",
+		Client_Secret: "secret",
+		Api:           []Api{AuditApi},
+		Host:          defaultHost,
+		Preprocessor:  []string{"pp"},
+	})
 }

--- a/hosted/plugins/mimecast/events.go
+++ b/hosted/plugins/mimecast/events.go
@@ -75,12 +75,12 @@ type SIEMBatchEventResponse struct {
 
 type SIEMBatchEvent struct {
 	URL    string    `json:"url"`
-	Expiry time.Time `json:"expiry,omitempty"`
+	Expiry time.Time `json:"expiry"`
 	Size   int       `json:"size"`
 }
 
 type SIEMErrorResponse struct {
-	Error Error `json:"error,omitempty"`
+	Error Error `json:"error"`
 }
 
 type Error struct {

--- a/hosted/plugins/mimecast/mimecast.go
+++ b/hosted/plugins/mimecast/mimecast.go
@@ -108,7 +108,7 @@ func (m *Mimecast) get(rt hosted.Runtime, api Api, defaultTs time.Time) (cursor 
 
 func (m *Mimecast) Handle(ctx context.Context, rt hosted.Runtime) (*hosted.Continuation,
 	error) {
-	m.initClient(rt.Context())
+	m.initClient(ctx)
 
 	eg, egCtx := errgroup.WithContext(ctx)
 

--- a/hosted/plugins/msgraph/config.go
+++ b/hosted/plugins/msgraph/config.go
@@ -12,6 +12,7 @@ import (
 	"cmp"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/gravwell/gravwell/v3/hosted"
 )
@@ -51,6 +52,29 @@ type Config struct {
 	Request_Interval    int // In seconds between poll cycles.
 	Graph_Host          string
 	Auth_Host           string
+}
+
+var _ hosted.Config = (*Config)(nil) // compile time interface check
+
+// Equal implements hosted.Config so the runner can decide whether a config reload
+// actually changed anything for this ingester.
+func (c *Config) Equal(ncp any) bool {
+	nc, ok := hosted.EqualTarget[Config](ncp)
+	if c == nil || !ok {
+		return false
+	}
+	return c.BaseConfig == nc.BaseConfig &&
+		c.Tenant_ID == nc.Tenant_ID &&
+		c.Client_ID == nc.Client_ID &&
+		c.Client_Secret == nc.Client_Secret &&
+		c.Tag_Name == nc.Tag_Name &&
+		c.Tag_Prefix == nc.Tag_Prefix &&
+		c.Lookback == nc.Lookback &&
+		c.Requests_Per_Minute == nc.Requests_Per_Minute &&
+		c.Request_Interval == nc.Request_Interval &&
+		c.Graph_Host == nc.Graph_Host &&
+		c.Auth_Host == nc.Auth_Host &&
+		slices.Equal(c.Content_Type, nc.Content_Type)
 }
 
 // Verify validates the configuration has correct values set. It also sets defaults for values that can be defaulted.

--- a/hosted/plugins/msgraph/config_test.go
+++ b/hosted/plugins/msgraph/config_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gravwell/gravwell/v3/hosted"
+	"github.com/gravwell/gravwell/v3/hosted/configtest"
 )
 
 func TestConfig_Verify_IngesterUUID(t *testing.T) {
@@ -72,4 +73,20 @@ func TestConfig_Verify_AggregatesErrors(t *testing.T) {
 	if cfg.Ingester_UUID != "not-a-uuid" {
 		t.Error("Ingester-UUID should not change on error")
 	}
+}
+
+func TestConfigEqual(t *testing.T) {
+	configtest.CheckEqual(t, Config{
+		BaseConfig:          hosted.BaseConfig{Ingester_UUID: defaultIngesterUUIDStr},
+		Tenant_ID:           "tenant",
+		Client_ID:           "id",
+		Client_Secret:       "secret",
+		Content_Type:        []ContentType{ContentAlerts},
+		Tag_Prefix:          "msgraph",
+		Lookback:            defaultLookbackHours,
+		Requests_Per_Minute: defaultRequestsPerMin,
+		Request_Interval:    defaultRequestIntervalSeconds,
+		Graph_Host:          defaultGraphHost,
+		Auth_Host:           defaultAuthHost,
+	})
 }

--- a/hosted/plugins/okta/config.go
+++ b/hosted/plugins/okta/config.go
@@ -44,6 +44,23 @@ type Config struct {
 	Token              string `json:"-"` // authentication token - DO NOT send this when marshalling
 }
 
+var _ hosted.Config = (*Config)(nil) // compile time interface check
+
+// Equal implements hosted.Config so the runner can decide whether a config reload
+// actually changed anything for this ingester.
+func (c *Config) Equal(ncp any) bool {
+	nc, ok := hosted.EqualTarget[Config](ncp)
+	if c == nil || !ok {
+		return false
+	}
+	return c.BaseConfig == nc.BaseConfig &&
+		c.Request_Batch_Size == nc.Request_Batch_Size &&
+		c.Request_Per_Minute == nc.Request_Per_Minute &&
+		c.Request_Burst == nc.Request_Burst &&
+		c.Domain == nc.Domain &&
+		c.Token == nc.Token
+}
+
 func (c *Config) Verify() (err error) {
 	c.ApplyDefaultIngesterUUID(defaultIngesterUUIDStr)
 

--- a/hosted/plugins/okta/config_test.go
+++ b/hosted/plugins/okta/config_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gravwell/gravwell/v3/hosted"
+	"github.com/gravwell/gravwell/v3/hosted/configtest"
 )
 
 func TestConfig_Verify(t *testing.T) {
@@ -172,4 +173,15 @@ func TestConfig_Verify_DomainContainsOkta(t *testing.T) {
 	if !strings.HasSuffix(cfg.Domain, "okta.com") {
 		t.Error("domain should end with okta.com")
 	}
+}
+
+func TestConfigEqual(t *testing.T) {
+	configtest.CheckEqual(t, Config{
+		BaseConfig:         hosted.BaseConfig{Ingester_UUID: defaultIngesterUUIDStr},
+		Request_Batch_Size: defaultPageSize,
+		Request_Per_Minute: defaultRequestPerMinute,
+		Request_Burst:      defaultRequestBurst,
+		Domain:             "example.okta.com",
+		Token:              "token",
+	})
 }

--- a/hosted/plugins/okta/okta.go
+++ b/hosted/plugins/okta/okta.go
@@ -156,7 +156,7 @@ func (o *OktaIngester) userLogRoutine(ctx context.Context, rt hosted.Runtime) {
 			}
 			//just look for changes over the last boundary
 			rt.Debug("requesting users", log.KV("start", start.Format(timeFormat)), log.KV("end", end.Format(timeFormat)))
-			if err := o.getUserLogs(start, end, rt); err != nil {
+			if err := o.getUserLogs(ctx, start, end, rt); err != nil {
 				rt.Error("failed to get users", log.KV("error", err))
 			} else {
 				//success, update last ts run
@@ -171,7 +171,7 @@ func (o *OktaIngester) systemLogRoutine(ctx context.Context, rt hosted.Runtime) 
 		log.KV("start-ts", o.latestTS.Format(time.RFC3339)),
 		log.KV("next-url", o.systemLogsNext != nil))
 	for {
-		if err := o.getSystemLogs(rt); err != nil {
+		if err := o.getSystemLogs(ctx, rt); err != nil {
 			rt.Error("system log error", log.KV("error", err))
 		}
 		if rt.Sleep(time.Minute) { // this sleep will quit if the context cancels
@@ -180,10 +180,10 @@ func (o *OktaIngester) systemLogRoutine(ctx context.Context, rt hosted.Runtime) 
 	}
 }
 
-func (o *OktaIngester) getSystemLogs(rt hosted.Runtime) error {
+func (o *OktaIngester) getSystemLogs(ctx context.Context, rt hosted.Runtime) error {
 	var req *http.Request
 
-	req, err := http.NewRequestWithContext(rt.Context(), http.MethodGet, fmt.Sprintf("https://%s", o.cfg.Domain), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://%s", o.cfg.Domain), nil)
 	if err != nil {
 		return fmt.Errorf("failed to build request %w", err)
 	}
@@ -204,7 +204,7 @@ func (o *OktaIngester) getSystemLogs(rt hosted.Runtime) error {
 	req.Header.Set(`Authorization`, fmt.Sprintf(`SSWS %s`, o.cfg.Token))
 
 	var quit bool
-	for !quit && rt.Context().Err() == nil {
+	for !quit && ctx.Err() == nil {
 		if !rt.Alive() {
 			// okta can back off and wait if the runtime isn't healthy, just loop and wait again
 			quit = rt.Sleep(emptySleepDur)
@@ -355,8 +355,8 @@ func lastUpdatedFilter(start, end time.Time) (r string) {
 	return
 }
 
-func (o *OktaIngester) getUserLogs(start, end time.Time, rt hosted.Runtime) error {
-	req, err := http.NewRequestWithContext(rt.Context(), http.MethodGet, fmt.Sprintf("https://%s", o.cfg.Domain), nil)
+func (o *OktaIngester) getUserLogs(ctx context.Context, start, end time.Time, rt hosted.Runtime) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://%s", o.cfg.Domain), nil)
 	if err != nil {
 		return err
 	}

--- a/hosted/plugins/okta/okta.go
+++ b/hosted/plugins/okta/okta.go
@@ -123,17 +123,13 @@ func (o *OktaIngester) Run(ctx context.Context, rt hosted.Runtime) (err error) {
 	o.c = utils.NewRetryHttpClient(rl, httpTimeout, httpBackoff, ctx, httpRetryCodes)
 
 	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		o.userLogRoutine(ctx, rt)
-	}()
+	})
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		o.systemLogRoutine(ctx, rt)
-	}()
+	})
 
 	wg.Wait()
 	return

--- a/hosted/plugins/tester/tester.go
+++ b/hosted/plugins/tester/tester.go
@@ -32,6 +32,8 @@ type Config struct {
 	Test_Errors bool
 }
 
+var _ hosted.Config = (*Config)(nil) // compile time interface check
+
 func (c *Config) Verify() (err error) {
 	c.ApplyDefaultIngesterUUID(defaultIngesterUUIDStr)
 
@@ -53,6 +55,17 @@ func (c *Config) interval() time.Duration {
 		return defaultInterval
 	}
 	return dur
+}
+
+// Equal implements hosted.Config so the runner can decide whether a config reload
+// actually changed anything for this ingester.
+func (c *Config) Equal(ncp any) bool {
+	nc, ok := hosted.EqualTarget[Config](ncp)
+	if c == nil || !ok {
+		return false
+	}
+	return c.BaseConfig == nc.BaseConfig && c.SingleTagConfig == nc.SingleTagConfig &&
+		c.Interval == nc.Interval && c.Silent == nc.Silent && c.Test_Errors == nc.Test_Errors
 }
 
 type TesterIngester struct {

--- a/hosted/plugins/tester/tester_test.go
+++ b/hosted/plugins/tester/tester_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gravwell/gravwell/v3/hosted"
+	"github.com/gravwell/gravwell/v3/hosted/configtest"
 )
 
 func TestConfig_Verify(t *testing.T) {
@@ -207,5 +208,15 @@ func TestTesterIngester_Handle(t *testing.T) {
 		if res.Delay != defaultInterval {
 			t.Fatalf("TesterIngester.Handle() returned wrong delay")
 		}
+	})
+}
+
+func TestConfigEqual(t *testing.T) {
+	configtest.CheckEqual(t, Config{
+		BaseConfig:      hosted.BaseConfig{Ingester_UUID: defaultIngesterUUIDStr},
+		SingleTagConfig: hosted.SingleTagConfig{Tag_Name: Tag},
+		Interval:        "10s",
+		Silent:          true,
+		Test_Errors:     true,
 	})
 }

--- a/hosted/plugins/wiz/client.go
+++ b/hosted/plugins/wiz/client.go
@@ -176,7 +176,7 @@ func (c *Client) Query(ctx context.Context, query string, vars map[string]any, o
 
 	// attempt 0 uses the cached token; attempt 1 forces a refresh after an
 	// unauthenticated response.
-	for attempt := 0; attempt < 2; attempt++ {
+	for attempt := range 2 {
 		if err = c.authenticate(ctx, attempt == 1); err != nil {
 			return err
 		}

--- a/hosted/plugins/wiz/config.go
+++ b/hosted/plugins/wiz/config.go
@@ -11,8 +11,10 @@ package wiz
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/gravwell/gravwell/v3/hosted"
@@ -55,6 +57,33 @@ type Config struct {
 
 	tags    map[string]string // parsed Tag_Override
 	queries map[string]string // parsed Query_Override, source -> query document
+}
+
+var _ hosted.Config = (*Config)(nil) // compile time interface check
+
+// Equal implements hosted.Config so the runner can decide whether a config reload
+// actually changed anything for this ingester.
+// The parsed tags and queries are compared as well, that catches an edited query
+// override file, whose contents change without the config file itself changing.
+func (c *Config) Equal(ncp any) bool {
+	nc, ok := hosted.EqualTarget[Config](ncp)
+	if c == nil || !ok {
+		return false
+	}
+	return c.BaseConfig == nc.BaseConfig &&
+		c.PollingConfig == nc.PollingConfig &&
+		c.Client_Id == nc.Client_Id &&
+		c.Client_Secret == nc.Client_Secret &&
+		c.Endpoint == nc.Endpoint &&
+		c.Auth_URL == nc.Auth_URL &&
+		c.Audience == nc.Audience &&
+		c.Page_Size == nc.Page_Size &&
+		c.Max_Pages_Per_Type == nc.Max_Pages_Per_Type &&
+		c.Tag_Name == nc.Tag_Name &&
+		slices.Equal(c.Tag_Override, nc.Tag_Override) &&
+		slices.Equal(c.Query_Override, nc.Query_Override) &&
+		maps.Equal(c.tags, nc.tags) &&
+		maps.Equal(c.queries, nc.queries)
 }
 
 func (c *Config) Verify() error {

--- a/hosted/plugins/wiz/config_test.go
+++ b/hosted/plugins/wiz/config_test.go
@@ -12,6 +12,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/gravwell/gravwell/v3/hosted"
+	"github.com/gravwell/gravwell/v3/hosted/configtest"
 )
 
 func baseConfig() *Config {
@@ -145,4 +148,56 @@ func TestConfigQueryOverride(t *testing.T) {
 			t.Fatal("expected error for missing file")
 		}
 	})
+}
+
+func equalConfig() Config {
+	return Config{
+		BaseConfig: hosted.BaseConfig{Ingester_UUID: defaultIngesterUUIDStr},
+		PollingConfig: hosted.PollingConfig{
+			Lookback:            defaultLookback,
+			Requests_Per_Minute: defaultRequestsPerMinute,
+			Request_Interval:    defaultInterval,
+		},
+		Client_Id:          "id",
+		Client_Secret:      "secret",
+		Endpoint:           "https://api.us1.app.wiz.io/graphql",
+		Auth_URL:           defaultAuthURL,
+		Audience:           defaultAudience,
+		Page_Size:          defaultPageSize,
+		Max_Pages_Per_Type: defaultMaxPagesPerType,
+		Tag_Name:           "wiz",
+		Tag_Override:       []string{sourceAudit + ":wiz-audit"},
+		tags:               map[string]string{sourceAudit: "wiz-audit"},
+		queries:            map[string]string{sourceAudit: "query{}"},
+	}
+}
+
+func TestConfigEqual(t *testing.T) {
+	configtest.CheckEqual(t, equalConfig())
+}
+
+// the parsed override maps are unexported so configtest can't reach them, cover them by hand.
+// The query documents matter because an edited override file changes the query without
+// changing a single byte of the config file.
+func TestConfigEqualParsedOverrides(t *testing.T) {
+	base := equalConfig()
+	tests := []struct {
+		name   string
+		mutate func(*Config)
+	}{
+		{`tags added`, func(c *Config) { c.tags[sourceIssue] = "wiz-issue" }},
+		{`tags changed`, func(c *Config) { c.tags[sourceAudit] = "wiz-other" }},
+		{`tags dropped`, func(c *Config) { c.tags = nil }},
+		{`queries changed`, func(c *Config) { c.queries[sourceAudit] = "query{different}" }},
+		{`queries dropped`, func(c *Config) { c.queries = nil }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nc := equalConfig()
+			tt.mutate(&nc)
+			if base.Equal(&nc) {
+				t.Errorf("Equal ignored %s", tt.name)
+			}
+		})
+	}
 }

--- a/hosted/plugins/wiz/wiz.go
+++ b/hosted/plugins/wiz/wiz.go
@@ -132,7 +132,7 @@ func (w *Wiz) tag(rt hosted.Runtime, sourceName string) (entry.EntryTag, error) 
 }
 
 func (w *Wiz) Handle(ctx context.Context, rt hosted.Runtime) (*hosted.Continuation, error) {
-	w.initClient(rt.Context())
+	w.initClient(ctx)
 
 	pending := false
 	for _, s := range w.sources {

--- a/hosted/runner/main.go
+++ b/hosted/runner/main.go
@@ -107,6 +107,7 @@ func main() {
 
 	//listen for signals so we can close gracefully
 	sig := utils.GetQuitChannel()
+	hup := utils.GetSighupChannel()
 	tckr := time.NewTicker(time.Minute)
 	defer tckr.Stop()
 
@@ -116,6 +117,15 @@ exitLoop:
 		case <-sig:
 			lg.Info("ingester shutting down")
 			break exitLoop
+		case <-hup:
+			var newCfg *cfgType
+			if err = ib.ReloadConfig(&newCfg); err != nil {
+				lg.Error("failed to reload config", log.KVErr(err))
+			} else {
+				//hand the config into the run manager and tell it to reload
+				rm.reloadIngesters(newCfg)
+			}
+			// try to reload the config
 		case <-tckr.C:
 			// go check on all ingesters and see if we should try to restart one that has died
 			rm.startIngesters()

--- a/hosted/runner/main.go
+++ b/hosted/runner/main.go
@@ -118,14 +118,17 @@ exitLoop:
 			lg.Info("ingester shutting down")
 			break exitLoop
 		case <-hup:
+			// try to reload the config
+			lg.Info("reloading configuration")
 			var newCfg *cfgType
 			if err = ib.ReloadConfig(&newCfg); err != nil {
 				lg.Error("failed to reload config", log.KVErr(err))
-			} else {
+			} else if err = rm.reloadIngesters(newCfg); err != nil {
 				//hand the config into the run manager and tell it to reload
-				rm.reloadIngesters(newCfg)
+				lg.Error("failed to reload ingesters", log.KVErr(err))
+			} else {
+				lg.Info("configuration reload complete")
 			}
-			// try to reload the config
 		case <-tckr.C:
 			// go check on all ingesters and see if we should try to restart one that has died
 			rm.startIngesters()

--- a/hosted/runner/manager.go
+++ b/hosted/runner/manager.go
@@ -78,7 +78,7 @@ func (rm *runtimeManager) createRunners(c *cfgType, ib base.IngesterBase) (err e
 	}
 	for name, builder := range c.Builders() {
 		if err = rm.createRunner(name, builder); err != nil {
-			if err == errExists {
+			if errors.Is(err, errExists) {
 				continue // just skip it
 			}
 			return // this is an actual error
@@ -158,7 +158,11 @@ func (rm *runtimeManager) startIngesters() (err error) {
 	return
 }
 
-// TODO FIXME
+// reloadIngesters will walk the incoming config and compare it against the running config to determine an action
+// to take on each plugin/ingester.  Actions can be:
+//  1. start a whole new ingester
+//  2. stop/remove an ingester that is no longer configured
+//  3. detect a config change on an existing ingester and restart it
 func (rm *runtimeManager) reloadIngesters(nc *cfgType) (err error) {
 	if nc == nil {
 		return errors.New("new config is empty")
@@ -183,13 +187,12 @@ func (rm *runtimeManager) reloadIngesters(nc *cfgType) (err error) {
 				)
 				// just continue
 				continue
-			} else {
-				rm.lgr.Info("created new ingester on reload",
-					log.KV("kind", builder.Kind()),
-					log.KV("name", name),
-					log.KV("uuid", guid),
-				)
 			}
+			rm.lgr.Info("created new ingester on reload",
+				log.KV("kind", builder.Kind()),
+				log.KV("name", name),
+				log.KV("uuid", guid),
+			)
 		} else if existing.configChanged(name, builder) {
 			if lerr := existing.Close(); lerr != nil {
 				rm.lgr.Error("failed to stop ingester on reload",
@@ -234,18 +237,18 @@ func (rm *runtimeManager) reloadIngesters(nc *cfgType) (err error) {
 					log.KVErr(lerr),
 				)
 				// not much to do here other than complain about it... :/
-			} else {
-				rm.lgr.Info("shutdown ingester on reload",
-					log.KV("id", id),
-					log.KV("name", name),
-					log.KV("uuid", guid),
-				)
+				continue
 			}
-			delete(rm.mp, guid)
+			delete(rm.mp, guid) // ingester is closed
+			rm.lgr.Info("shutdown ingester on reload",
+				log.KV("id", id),
+				log.KV("name", name),
+				log.KV("uuid", guid),
+			)
 		}
 	}
 
-	// last step is to fire up all the ingesters
+	// last step is to fire up all the ingesters that might be down
 	return rm.startIngesters()
 }
 

--- a/hosted/runner/manager.go
+++ b/hosted/runner/manager.go
@@ -188,7 +188,6 @@ func (rm *runtimeManager) reloadIngesters(nc *cfgType) (err error) {
 					log.KV("kind", builder.Kind()),
 					log.KV("name", name),
 					log.KV("uuid", guid),
-					log.KVErr(err),
 				)
 			}
 		} else if existing.configChanged(name, builder) {
@@ -201,13 +200,6 @@ func (rm *runtimeManager) reloadIngesters(nc *cfgType) (err error) {
 				)
 				// does not restart, we don't want to corrupt the state
 				continue
-			} else {
-				rm.lgr.Info("restarted ingester on reload",
-					log.KV("kind", builder.Kind()),
-					log.KV("name", name),
-					log.KV("uuid", guid),
-					log.KVErr(err),
-				)
 			}
 			// ok fire the new one up
 			delete(rm.mp, guid)
@@ -218,7 +210,13 @@ func (rm *runtimeManager) reloadIngesters(nc *cfgType) (err error) {
 					log.KV("uuid", guid),
 					log.KVErr(lerr),
 				)
+				continue
 			}
+			rm.lgr.Info("restarted ingester on reload",
+				log.KV("kind", builder.Kind()),
+				log.KV("name", name),
+				log.KV("uuid", guid),
+			)
 		}
 	}
 
@@ -236,6 +234,12 @@ func (rm *runtimeManager) reloadIngesters(nc *cfgType) (err error) {
 					log.KVErr(lerr),
 				)
 				// not much to do here other than complain about it... :/
+			} else {
+				rm.lgr.Info("shutdown ingester on reload",
+					log.KV("id", id),
+					log.KV("name", name),
+					log.KV("uuid", guid),
+				)
 			}
 			delete(rm.mp, guid)
 		}

--- a/hosted/runner/manager.go
+++ b/hosted/runner/manager.go
@@ -10,11 +10,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/gravwell/gravwell/v3/hosted"
+	"github.com/gravwell/gravwell/v3/hosted/plugins"
 	"github.com/gravwell/gravwell/v3/hosted/storage"
 	"github.com/gravwell/gravwell/v3/ingest"
 	"github.com/gravwell/gravwell/v3/ingest/log"
@@ -75,28 +77,41 @@ func (rm *runtimeManager) createRunners(c *cfgType, ib base.IngesterBase) (err e
 		return fmt.Errorf("nil config, can't create runners")
 	}
 	for name, builder := range c.Builders() {
-		rt, bw, err := rm.createNativeRuntime(builder.Kind(), name, builder.UUID())
-		if err != nil {
-			return fmt.Errorf("failed to create runtime for %s plugin %s: %w", builder.Kind(), name, err)
+		if err = rm.createRunner(name, builder); err != nil {
+			if err == errExists {
+				continue // just skip it
+			}
+			return // this is an actual error
 		}
-		var ig hosted.Ingester
-		if ig, err = builder.Build(rm.igst, bw.Sync); err != nil {
-			return fmt.Errorf("failed to build %s plugin %s: %w", builder.Kind(), name, err)
-		}
-		runner, err := hosted.NewNativeRunner(builder.ID(), name, builder.Version(), builder.UUID(), ig, rt)
-		if err != nil {
-			return fmt.Errorf("failed to create runner for %s plugin %s: %w", builder.Kind(), name, err)
-		}
-		if existing, exists := rm.mp[builder.UUID()]; exists {
-			ib.Logger.Error("hosted runner UUID collision",
-				log.KV("existing-uuid", existing.UUID()),
-				log.KV("colliding-type", existing.ID()),
-				log.KV("colliding-name", name),
-				log.KV("colliding-uuid", builder.UUID()))
-			continue // just skip it
-		}
-		rm.mp[builder.UUID()] = wrappedRunner{Runner: runner}
 	}
+	return nil
+}
+
+var errExists = errors.New("hosted runner UUID already exists")
+
+func (rm *runtimeManager) createRunner(name string, builder plugins.IngesterBuilder) error {
+	rt, bw, err := rm.createNativeRuntime(builder.Kind(), name, builder.UUID())
+	if err != nil {
+		return fmt.Errorf("failed to create runtime for %s plugin %s: %w", builder.Kind(), name, err)
+	}
+	var ig hosted.Ingester
+	if ig, err = builder.Build(rm.igst, bw.Sync); err != nil {
+		return fmt.Errorf("failed to build %s plugin %s: %w", builder.Kind(), name, err)
+	}
+	runner, err := hosted.NewNativeRunner(builder.ID(), name, builder.Version(), builder.UUID(), builder.Config(), ig, rt)
+	if err != nil {
+		return fmt.Errorf("failed to create runner for %s plugin %s: %w", builder.Kind(), name, err)
+	}
+	if existing, exists := rm.mp[builder.UUID()]; exists {
+		rm.lgr.Error("hosted runner UUID collision",
+			log.KV("existing-uuid", existing.UUID()),
+			log.KV("colliding-type", existing.ID()),
+			log.KV("colliding-name", name),
+			log.KV("colliding-uuid", builder.UUID()),
+		)
+		return errExists
+	}
+	rm.mp[builder.UUID()] = wrappedRunner{Runner: runner}
 	return nil
 }
 
@@ -141,4 +156,107 @@ func (rm *runtimeManager) startIngesters() (err error) {
 		}
 	}
 	return
+}
+
+// TODO FIXME
+func (rm *runtimeManager) reloadIngesters(nc *cfgType) (err error) {
+	if nc == nil {
+		return errors.New("new config is empty")
+	}
+
+	newSet := map[string]struct{}{} // just a membership struct
+	var es struct{}                 // empt value to assign into the membership struct
+
+	// step 1 is check if there are any new ingesters that we can easily just start or restart
+	for name, builder := range nc.Builders() {
+		guid := builder.UUID()
+		newSet[guid.String()] = es
+
+		if existing, ok := rm.mp[guid]; !ok {
+			// just fire it up
+			if err = rm.createRunner(name, builder); err != nil {
+				rm.lgr.Error("failed to create new ingester on reload",
+					log.KV("kind", builder.Kind()),
+					log.KV("name", name),
+					log.KV("uuid", guid),
+					log.KVErr(err),
+				)
+				// just continue
+				continue
+			} else {
+				rm.lgr.Info("created new ingester on reload",
+					log.KV("kind", builder.Kind()),
+					log.KV("name", name),
+					log.KV("uuid", guid),
+					log.KVErr(err),
+				)
+			}
+		} else if existing.configChanged(name, builder) {
+			if lerr := existing.Close(); lerr != nil {
+				rm.lgr.Error("failed to stop ingester on reload",
+					log.KV("kind", builder.Kind()),
+					log.KV("name", name),
+					log.KV("uuid", guid),
+					log.KVErr(lerr),
+				)
+				// does not restart, we don't want to corrupt the state
+				continue
+			} else {
+				rm.lgr.Info("restarted ingester on reload",
+					log.KV("kind", builder.Kind()),
+					log.KV("name", name),
+					log.KV("uuid", guid),
+					log.KVErr(err),
+				)
+			}
+			// ok fire the new one up
+			delete(rm.mp, guid)
+			if lerr := rm.createRunner(name, builder); lerr != nil {
+				rm.lgr.Error("failed to create ingester on config change",
+					log.KV("kind", builder.Kind()),
+					log.KV("name", name),
+					log.KV("uuid", guid),
+					log.KVErr(lerr),
+				)
+			}
+		}
+	}
+
+	// step 2 is check if any ingesters have been removed and shut them down
+	for guid, wr := range rm.mp {
+		if _, ok := newSet[guid.String()]; !ok {
+			// ingester was removed, just kill it and delete it
+			//grab the name and ID before we attempt to close it, just in case
+			id, name := wr.ID(), wr.Name()
+			if lerr := wr.Close(); lerr != nil {
+				rm.lgr.Error("failed to shutdown ingester on reload",
+					log.KV("id", id),
+					log.KV("name", name),
+					log.KV("uuid", guid),
+					log.KVErr(lerr),
+				)
+				// not much to do here other than complain about it... :/
+			}
+			delete(rm.mp, guid)
+		}
+	}
+
+	// last step is to fire up all the ingesters
+	return rm.startIngesters()
+}
+
+func (wr wrappedRunner) configChanged(name string, builder plugins.IngesterBuilder) bool {
+	// if the name, UUID, kind (id), or version  changed, return true
+	if wr.Name() != name || wr.UUID() != builder.UUID() {
+		return true
+	} else if wr.ID() != builder.ID() || wr.Version() != builder.Version() {
+		return true
+	}
+	// now shunt off into the runner to see if it thinks its config changed
+	if internalConfig := wr.Config(); internalConfig != nil {
+		if compareConfig, ok := internalConfig.(hosted.Config); ok {
+			return !compareConfig.Equal(builder.Config())
+		}
+	}
+	return true // we can't compare so this gets restarted
 }

--- a/hosted/storage/bolt.go
+++ b/hosted/storage/bolt.go
@@ -268,7 +268,7 @@ func (bw *BucketWriter) GetInt64(key string) (value int64, err error) {
 
 // PutInt64 puts a native int64 into the storage
 func (bw *BucketWriter) PutInt64(key string, value int64) (err error) {
-	err = bw.Put(key, []byte(fmt.Sprintf("%d", value)))
+	err = bw.Put(key, fmt.Appendf(nil, "%d", value))
 	return
 }
 


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses https://github.com/gravwell/gravwell/issues/2658

## This PR proposes...

- adding a SIGHUP to dynamically reload the config
- Tweak interfaces so that plugins can compare their configs and declare if a config changed
- Tweak the context on plugins so that they use their own context and can be shutdown individually
- Added logic to reload a configs and then restart ingesters that need to be restarted
  -  Or shutdown deleted ones
  - or start new ones
- added E2E tests for everything

## PR Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e and/or unit tests included. If not, please provide an explanation.
- [ ] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
