### PR TITLE
refactor(search): pass in existing owner id instead of nil

### DIFF
--- a/client/searchCtrl.go
+++ b/client/searchCtrl.go
@@ -66,9 +66,14 @@ func (c *Client) BackgroundSearch(sid string) error {
 	return c.patchStaticURL(searchCtrlBackgroundUrl(sid), nil)
 }
 
-// SetAccess sets the Readers/Writers ACLs and optionally reassigns ownership (for admins only)
-// for an existing search. Pass a nil ownerID to leave ownership unchanged.
-func (c *Client) SetAccess(sid string, ownerID *int32, readers, writers types.ACL) error {
+// SetAccess sets the Readers/Writers ACLs and, for admins, reassigns ownership
+// for an existing search, in a single clobbering update. ownerID must always
+// be non-zero: non-admins must echo back the search's current owner (fetch
+// it first if you don't already have it) or the request is rejected, and
+// admins may pass a different owner to reassign it. There is no "leave
+// ownership unchanged" sentinel. As with Readers and Writers, the caller
+// is always responsible for resending the value they want to keep.
+func (c *Client) SetAccess(sid string, ownerID int32, readers, writers types.ACL) error {
 	request := types.SearchCtrlSetAccessRequest{
 		OwnerID: ownerID,
 		Readers: readers,

--- a/client/searchCtrl_test.go
+++ b/client/searchCtrl_test.go
@@ -10,8 +10,10 @@ package client_test
 
 import (
 	"encoding/json"
+	"io"
 	"net"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/gravwell/gravwell/v4/client"
@@ -32,14 +34,11 @@ func TestSetAccess(t *testing.T) {
 	}
 	t.Cleanup(func() { l.Close() })
 
-	type accessBody struct {
-		OwnerID *int32
-		Readers types.ACL
-		Writers types.ACL
-	}
+	type accessBody types.SearchCtrlSetAccessRequest
 
 	var gotMethod, gotPath string
 	var gotBody accessBody
+	var gotRawBody []byte
 	var failReq bool
 
 	mux := http.NewServeMux()
@@ -47,7 +46,10 @@ func TestSetAccess(t *testing.T) {
 		gotMethod = r.Method
 		gotPath = r.URL.Path
 		gotBody = accessBody{}
-		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+		var err error
+		if gotRawBody, err = io.ReadAll(r.Body); err != nil {
+			t.Errorf("failed to read request body: %v", err)
+		} else if err := json.Unmarshal(gotRawBody, &gotBody); err != nil {
 			t.Errorf("failed to decode request body: %v", err)
 		}
 		if failReq {
@@ -68,7 +70,7 @@ func TestSetAccess(t *testing.T) {
 		readers := types.ACL{GIDs: []int32{1, 2}}
 		writers := types.ACL{Global: true}
 
-		if err := c.SetAccess("search-123", &nid, readers, writers); err != nil {
+		if err := c.SetAccess("search-123", nid, readers, writers); err != nil {
 			t.Fatalf("SetAccess: %v", err)
 		}
 
@@ -78,7 +80,7 @@ func TestSetAccess(t *testing.T) {
 		if want := "/api/searchctrl/search-123/access"; gotPath != want {
 			t.Errorf("path = %q, want %q", gotPath, want)
 		}
-		if gotBody.OwnerID == nil || *gotBody.OwnerID != nid {
+		if gotBody.OwnerID != nid {
 			t.Errorf("OwnerID = %v, want %d", gotBody.OwnerID, nid)
 		}
 		if !equalACL(gotBody.Readers, readers) {
@@ -89,19 +91,31 @@ func TestSetAccess(t *testing.T) {
 		}
 	})
 
-	t.Run("nil ownerID round-trips as JSON null, not a zero uid", func(t *testing.T) {
-		if err := c.SetAccess("search-456", nil, types.ACL{}, types.ACL{}); err != nil {
-			t.Fatalf("SetAccess with nil ownerID: %v", err)
+	t.Run("ownerID of 0 rides the wire as a literal 0, not omitted or null", func(t *testing.T) {
+		// SetAccess/SearchCtrlSetAccessRequest have no "leave unchanged"
+		// sentinel for OwnerID anymore (it's a plain, always-present int32,
+		// not the old *int32) -- validating that 0 is invalid is the
+		// webserver's job (see TestSetSearchAccess/TestSearchCtrlSetAccessHandler
+		// in the backend repo), not this SDK's. This only proves the client
+		// doesn't do anything surprising with a zero value on the way out --
+		// e.g. dropping the field via an accidental `omitempty` tag on
+		// SearchCtrlSetAccessRequest.OwnerID, which would let a real bug there
+		// slip past unnoticed.
+		if err := c.SetAccess("search-789", 0, types.ACL{}, types.ACL{}); err != nil {
+			t.Fatalf("SetAccess with ownerID=0: %v", err)
 		}
-		if gotBody.OwnerID != nil {
-			t.Errorf("OwnerID = %v, want nil", *gotBody.OwnerID)
+		if gotBody.OwnerID != 0 {
+			t.Errorf("OwnerID = %d, want 0", gotBody.OwnerID)
+		}
+		if !strings.Contains(string(gotRawBody), `"OwnerID":0`) {
+			t.Errorf("expected the actual wire body to contain a literal OwnerID:0, got %s", gotRawBody)
 		}
 	})
 
 	t.Run("non-200 response surfaces as an error", func(t *testing.T) {
 		failReq = true
 		t.Cleanup(func() { failReq = false })
-		if err := c.SetAccess("search-123", nil, types.ACL{}, types.ACL{}); err == nil {
+		if err := c.SetAccess("search-123", 1, types.ACL{}, types.ACL{}); err == nil {
 			t.Fatal("expected error on 500 response, got nil")
 		}
 	})

--- a/client/types/search.go
+++ b/client/types/search.go
@@ -822,7 +822,7 @@ func (p SaveSearchPatch) MergeLaunchInfo(li *SearchLaunchInfo) (changed bool) {
 }
 
 type SearchCtrlSetAccessRequest struct {
-	OwnerID *int32
+	OwnerID int32
 	Readers ACL
 	Writers ACL
 }

--- a/gwcli/tree/queries/queries.go
+++ b/gwcli/tree/queries/queries.go
@@ -382,7 +382,7 @@ func setGroup() action.Pair {
 					results[i] = scaffold.Result{Success: false, Output: fmt.Sprintf("failed to fetch search: %s: %v", ID, err)}
 					continue
 				}
-				if err := connection.Client.SetAccess(ID, nil, types.ACL{GIDs: GIDs}, si.Writers); err != nil {
+				if err := connection.Client.SetAccess(ID, si.OwnerID, types.ACL{GIDs: GIDs}, si.Writers); err != nil {
 					results[i] = scaffold.Result{Success: false, Output: fmt.Sprintf("failed to set groups for search %s: %v", ID, err)}
 				} else if len(GIDs) < 1 {
 					results[i] = scaffold.Result{Success: true, Output: "cleared read groups from search " + ID}

--- a/gwcli/tree/queries/queries_test.go
+++ b/gwcli/tree/queries/queries_test.go
@@ -25,12 +25,14 @@ import (
 
 // TestSetGroupPreservesWriters is a regression test for gravwell/issues#2708:
 // setGroup() migrated from the Readers-only SetGroups endpoint to the
-// combined SetAccess endpoint, which replaces Writers wholesale on every
-// call. Without fetching the search's current Writers first, running
-// set-groups would silently wipe any existing write access on the search.
-// This drives the actual cobra command non-interactively against a mock
-// server and asserts the wire request it sends preserves Writers while only
-// updating Readers.
+// combined SetAccess endpoint, which replaces Writers and OwnerID wholesale
+// on every call (OwnerID has no "leave unchanged" sentinel -- it's a plain,
+// always-required int32, same as Writers). Without fetching the search's
+// current Writers and OwnerID first, running set-groups would silently wipe
+// any existing write access, or get rejected outright for sending an
+// unowned/zero OwnerID. This drives the actual cobra command
+// non-interactively against a mock server and asserts the wire request it
+// sends preserves Writers and OwnerID while only updating Readers.
 func TestSetGroupPreservesWriters(t *testing.T) {
 	l, err := net.Listen("tcp", "[::1]:0")
 	if err != nil {
@@ -39,9 +41,10 @@ func TestSetGroupPreservesWriters(t *testing.T) {
 	t.Cleanup(func() { l.Close() })
 
 	existingWriters := types.ACL{GIDs: []int32{99}}
+	const existingOwnerID = int32(42)
 
 	type accessBody struct {
-		OwnerID *int32
+		OwnerID int32
 		Readers types.ACL
 		Writers types.ACL
 	}
@@ -53,6 +56,7 @@ func TestSetGroupPreservesWriters(t *testing.T) {
 		switch {
 		case r.Method == http.MethodGet:
 			si := types.SearchInfo{}
+			si.OwnerID = existingOwnerID
 			si.Writers = existingWriters
 			if err := json.NewEncoder(w).Encode(si); err != nil {
 				t.Errorf("failed to encode mock GetSearch response: %v", err)
@@ -94,6 +98,9 @@ func TestSetGroupPreservesWriters(t *testing.T) {
 
 	if !sawAccessCall {
 		t.Fatal("expected a PUT .../access request, got none")
+	}
+	if gotAccess.OwnerID != existingOwnerID {
+		t.Errorf("OwnerID = %d, want unchanged %d", gotAccess.OwnerID, existingOwnerID)
 	}
 	if !slices.Equal(gotAccess.Writers.GIDs, existingWriters.GIDs) {
 		t.Errorf("Writers.GIDs = %v, want unchanged %v", gotAccess.Writers.GIDs, existingWriters.GIDs)


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses https://github.com/gravwell/issues/issues/2708

## This PR proposes...

- using `int32` instead of `*int32` for owner id as per discussion with Rory
  - allows callers to just echo the current owner id instead of explicitly passing in `nil` for non-admins

## PR Tasks

<!-- Add tasks to this list as needed -->

- [x] e2e and/or unit tests included. If not, please provide an explanation.
- [ ] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
