### PR TITLE
fix: user put using base user instead of update user

### DIFF
--- a/client/types/users.go
+++ b/client/types/users.go
@@ -427,6 +427,21 @@ type UserWithCBAC struct {
 	CBAC CBACExpandedRules
 }
 
+func (u *User) ForUpdate() UpdateUser {
+	sg := make([]int32, len(u.DefaultSearchGroups))
+	for i := range u.DefaultSearchGroups {
+		sg[i] = u.DefaultSearchGroups[i].ID
+	}
+	return UpdateUser{
+		Username:            u.Username,
+		Name:                u.Name,
+		Email:               u.Email,
+		Admin:               u.Admin,
+		Locked:              u.Locked,
+		DefaultSearchGroups: sg,
+	}
+}
+
 // IsGroupMember returns true if the user is a member of group with
 // the specified ID.
 func (u *User) IsGroupMember(gid int32) bool {

--- a/client/users.go
+++ b/client/users.go
@@ -75,7 +75,7 @@ func (c *Client) CreateUser(m types.AddUser) (result types.User, err error) {
 
 // UpdateUser (admin-only) modifies an existing user.
 func (c *Client) UpdateUser(m types.User) error {
-	return c.putStaticURL(usersInfoUrl(m.ID), m)
+	return c.putStaticURL(usersInfoUrl(m.ID), m.ForUpdate())
 }
 
 // UpdateUserInfo changes basic information about the specified user.


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses no issue, but done as part of https://github.com/gravwell/issues/issues/2647 as I was using these types for the e2e tests. 

## This PR proposes...

When updating a user we were sending the base User, instead of UpdateUser. This is mostly an issue when working with the DefaultSearchGroups as they use different structure (an array of Groups vs a array of gids)

## PR Tasks

<!-- Add tasks to this list as needed -->

- [x] e2e and/or unit tests included. If not, please provide an explanation.
- [x] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
