### PR TITLE
make the log escaping stuff actually fit the spec

### DIFF
--- a/ingest/log/logging.go
+++ b/ingest/log/logging.go
@@ -583,17 +583,22 @@ func renderMsgRaw(msg string, sds ...rfc5424.SDParam) string {
 	return sb.String()
 }
 
+// syslogReplacer scrubs characters RFC 5424 forbids in an SD-NAME ('=', SP,
+// ']', '"') plus '/'; it must only be applied to PARAM-NAMEs, never to
+// PARAM-VALUEs, which may legally contain all of these characters.
 var syslogReplacer = strings.NewReplacer(" ", "_", "=", "_", "/", "_", "]", "_", `"`, "_")
 
 // genRFCOutput returns the given data formatted raw and as syslog.
-// Invalid runes in SDParam Names and Values are destructively replaced with "_".
+// Invalid runes in SDParam Names are destructively replaced with "_".
 func (l *Logger) genRfcOutput(ts time.Time, pfx string, lvl Level, msg string, sds ...rfc5424.SDParam) (ln, rawmsg string) {
 	rawmsg = renderMsgRaw(msg, sds...)
 
 	// to prevent swallowing logs on errors, replace illegal characters in SDParam
+	// names and strip invalid UTF-8 from values; values are otherwise left intact
+	// because marshaling escapes '"', '\', and ']' per RFC 5424 6.3.3
 	for i := range sds {
 		sds[i].Name = syslogReplacer.Replace(sds[i].Name)
-		sds[i].Value = syslogReplacer.Replace(sds[i].Value)
+		sds[i].Value = strings.ToValidUTF8(sds[i].Value, "_")
 	}
 	if b, err := GenRFCMessage(ts, lvl.priority(), l.hostname, l.appname, pfx, msg, sds...); err == nil && len(b) > 0 {
 		ln = string(bytes.Trim(b, "\n\r\t"))

--- a/ingest/log/logging_test.go
+++ b/ingest/log/logging_test.go
@@ -391,39 +391,53 @@ func TestUdpLogger(t *testing.T) {
 
 }
 
-// TestGenRFCMessage checks that illegal characters do not return errors, given
+// Test_genRfcOutput checks that SDParams that would fail RFC 5424 marshaling
+// do not swallow the log line, that illegal characters in PARAM-NAMEs are
+// replaced, and that PARAM-VALUEs are preserved verbatim (spaces included)
+// with '"', '\', and ']' escaped per RFC 5424 6.3.3.
 func Test_genRfcOutput(t *testing.T) {
 	tests := []struct {
-		name string // description of this test case
-		// Named input parameters for target function.
-		ts       time.Time
-		prio     rfc5424.Priority
-		hostname string
-		appname  string
-		msgid    string
-		msg      string
-		sds      []rfc5424.SDParam
+		name   string // description of this test case
+		ts     time.Time
+		msg    string
+		sds    []rfc5424.SDParam
+		wantSD string // the expected structured data element
 	}{
 		{"single valid SDParam",
-			time.Now(),
-			rfc5424.Debug, "host", "app", "id", "base message",
+			time.Now(), "base message",
 			[]rfc5424.SDParam{{Name: "1Name", Value: "1Value"}},
+			`[gw@1 1Name="1Value"]`,
 		},
-		{"two SDParams with spaces",
-			time.Now(),
-			rfc5424.Debug, "host", "app", "id", "base message",
+		{"space in name replaced, space in value preserved",
+			time.Now(), "base message",
 			[]rfc5424.SDParam{
 				{Name: "1 Name", Value: "1Value"},
 				{Name: "2Name", Value: "2 Value"},
 			},
+			`[gw@1 1_Name="1Value" 2Name="2 Value"]`,
 		},
-		{"two SDParams with illegal characters",
-			time.Now(),
-			rfc5424.Debug, "host", "app", "id", "base message",
+		{"quoted string value with spaces preserved",
+			time.Now(), "base message",
+			[]rfc5424.SDParam{{Name: "msg", Value: "i am a teapot"}},
+			`[gw@1 msg="i am a teapot"]`,
+		},
+		{"illegal characters in names replaced, escapable characters in values escaped",
+			time.Now(), "base message",
 			[]rfc5424.SDParam{
 				{Name: "1=Name", Value: "1Value"},
 				{Name: `2Na'me"`, Value: "2/Value']"},
 			},
+			`[gw@1 1_Name="1Value" 2Na'me_="2/Value'\]"]`,
+		},
+		{"value with quotes and backslashes escaped",
+			time.Now(), "base message",
+			[]rfc5424.SDParam{{Name: "err", Value: `open "C:\tmp"`}},
+			`[gw@1 err="open \"C:\\tmp\""]`,
+		},
+		{"invalid UTF-8 in value replaced",
+			time.Now(), "base message",
+			[]rfc5424.SDParam{{Name: "bin", Value: "bad\xffbyte"}},
+			`[gw@1 bin="bad_byte"]`,
 		},
 	}
 	const prefix string = "pfx"
@@ -431,17 +445,17 @@ func Test_genRfcOutput(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			l := NewDiscardLogger()
 
-			// generate expected raw and sbRFC
-			var sbRFC, sbRaw strings.Builder
-			fmt.Fprintf(&sbRFC, "<14>1 %v %s %s - %s [gw@1 ",
-				tt.ts.Format("2006-01-02T15:04:05.999999Z07:00"), l.hostname, l.appname, prefix)
+			// generate expected raw and RFC outputs; the raw form is untouched
+			// by any sanitization
+			var sbRaw strings.Builder
 			fmt.Fprint(&sbRaw, tt.msg)
 			for _, sd := range tt.sds {
-				fmt.Fprintf(&sbRFC, "%s=\"%s\" ", syslogReplacer.Replace(sd.Name), syslogReplacer.Replace(sd.Value))
-				fmt.Fprintf(&sbRaw, " %s=\"%s\"", sd.Name, sd.Value)
+				fmt.Fprintf(&sbRaw, " %s=%q", sd.Name, sd.Value)
 			}
-			wantRFC := sbRFC.String()[:sbRFC.Len()-1] + "] " + tt.msg
 			wantRaw := sbRaw.String()
+			wantRFC := fmt.Sprintf("<14>1 %v %s %s - %s %s %s",
+				tt.ts.Format("2006-01-02T15:04:05.999999Z07:00"), l.hostname, l.appname,
+				prefix, tt.wantSD, tt.msg)
 
 			gotRFC, gotRaw := l.genRfcOutput(tt.ts, prefix, INFO, tt.msg, tt.sds...)
 			if string(gotRFC) != wantRFC {


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses https://github.com/gravwell/issues/issues/2769

## This PR proposes...

- adjust the escaping on our logging package so that we follow the spec
   -  we were calling an overly aggressive escape function

## Notes

ingest/log: stop mutating SDParam values, only names need scrubbing

RFC 5424 treats the two sides of an SD-PARAM very differently
(ABNF in Section 6: https://datatracker.ietf.org/doc/html/rfc5424#section-6):

```
  SD-PARAM    = PARAM-NAME "=" %d34 PARAM-VALUE %d34
  PARAM-NAME  = SD-NAME
  SD-NAME     = 1*32PRINTUSASCII  ; except '=', SP, ']', %d34 (")
  PARAM-VALUE = UTF-8-STRING      ; characters '"', '\' and ']'
                                  ; MUST be escaped
```

* PARAM-NAME may not contain '=', SP, ']', or '"'. we call syslogReplacer on these.
* PARAM-VALUE may contain ANY UTF-8, we do not call syslogReplacer and backslash escape  \" \\ \] per Section 6.3.3

## Example
`logging KV("msg", `i am a teapot`), KV("q", `a[0] = "b"`):`

  before:
```
    <14>1 2026-08-22T17:05:00.123456Z host app - main.go:212
    [gw@1 msg="i_am_a_teapot" q="a[0____b_"] scheduled search failed
```

  after (escaped, losslessly recoverable by any RFC 5424 parser):
```
    <14>1 2026-08-22T17:05:00.123456Z host app - main.go:212
    [gw@1 msg="i am a teapot" q="a[0\] = \"b\""] scheduled search failed
```

Test_genRfcOutput previously computed its expected strings by running
the same replacer as the implementation, so it asserted the bug; it now
checks explicit expected output, including space preservation, RFC
escaping, and invalid UTF-8 replacement.


## PR Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e and/or unit tests included. If not, please provide an explanation.
- [ ] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
