### PR TITLE
update the stderrLogger to not create world readable stderr log files

### DIFF
--- a/ingest/log/stderrlog_darwin.go
+++ b/ingest/log/stderrlog_darwin.go
@@ -25,8 +25,8 @@ func newStderrLogger(fileOverride string, cb StderrCallback) (lgr *Logger, err e
 		clr.rfc = os.Stderr //this is getting redirected to a file
 		var oldstderr int
 		var fout *os.File
-		//get a handle on the output file
-		if fout, err = os.Create(fileOverride); err != nil {
+		//get a handle on the output file, truncate it and make sure its RW for user and group but not other
+		if fout, err = os.OpenFile(fileOverride, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0660); err != nil {
 			return
 		}
 		if cb != nil {

--- a/ingest/log/stderrlog_unix.go
+++ b/ingest/log/stderrlog_unix.go
@@ -25,8 +25,8 @@ func newStderrLogger(fileOverride string, cb StderrCallback) (lgr *Logger, err e
 		clr.rfc = os.Stderr //this is getting redirected to a file
 		var oldstderr int
 		var fout *os.File
-		//get a handle on the output file
-		if fout, err = os.Create(fileOverride); err != nil {
+		//get a handle on the output file, truncate it and make sure its RW for user and group but not other
+		if fout, err = os.OpenFile(fileOverride, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0660); err != nil {
 			return
 		}
 		if cb != nil {


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR updates https://github.com/gravwell/issues/issues/2770

## This PR proposes...

- do not create world readable files when doing stderr override files on ingesters

## PR Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e and/or unit tests included. If not, please provide an explanation.
- [ ] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
