### PR TITLE
refactor(2768): Duration is now int64, not string

### DIFF
--- a/client/types/search.go
+++ b/client/types/search.go
@@ -711,38 +711,6 @@ func (l LaunchResponse) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (si SearchInfo) MarshalJSON() ([]byte, error) {
-	type alias SearchInfo
-	return json.Marshal(struct {
-		alias
-		Duration string `json:",omitempty"`
-	}{
-		alias:    alias(si),
-		Duration: si.Duration.String(),
-	})
-}
-
-func (si *SearchInfo) UnmarshalJSON(data []byte) error {
-	type aalias SearchInfo
-	type alias struct {
-		aalias
-		Duration string `json:",omitempty"`
-	}
-	var v alias
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	*si = SearchInfo(v.aalias)
-	if len(v.Duration) > 0 {
-		dur, err := time.ParseDuration(v.Duration)
-		if err != nil {
-			return err
-		}
-		si.Duration = dur
-	}
-	return nil
-}
-
 type emptyStatSet []StatSet
 
 func (ess emptyStatSet) MarshalJSON() ([]byte, error) {

--- a/client/types/search.go
+++ b/client/types/search.go
@@ -56,7 +56,7 @@ type Element struct {
 	Args        string `json:",omitempty"`
 	Name        string
 	Path        string
-	Value       interface{}
+	Value       any
 	SubElements []Element `json:",omitempty"`
 	Filters     []string
 }
@@ -753,7 +753,6 @@ func (ess emptyStatSet) MarshalJSON() ([]byte, error) {
 }
 
 func (ssr SearchStatsResponse) MarshalJSON() ([]byte, error) {
-	type alias SearchStatsResponse
 	return json.Marshal(&struct {
 		Size       int
 		Set        emptyStatSet
@@ -811,7 +810,7 @@ func (p SaveSearchPatch) MergeLaunchInfo(li *SearchLaunchInfo) (changed bool) {
 	// this marks the search as saved and sets an expiration.  A user gets the alert, clicks the search,
 	// sees that the results should be kept and clicks save; this action means the user wants to kill
 	// the timer, so we wipe the expiration.
-	changed = !li.Expires.Equal(p.Expires)
+	changed = changed || !li.Expires.Equal(p.Expires)
 	li.Expires = p.Expires
 
 	//Started is best effort, take whatever isn't zero if there is one

--- a/client/types/search_test.go
+++ b/client/types/search_test.go
@@ -478,16 +478,16 @@ func TestRenderSettingsErrors(t *testing.T) {
 	}
 }
 
-// TestSearchInfoDurationRoundTrip covers Duration surviving a decode. It is
-// carried on the wire as a string and parsed back in UnmarshalJSON, so it is
-// the one field that can be silently dropped by the order of assignments there.
+// TestSearchInfoDurationRoundTrip covers Duration surviving a decode as a
+// plain int64 nanoseconds value (the default encoding for a time.Duration field).
+// Per the registry API spec.
 func TestSearchInfoDurationRoundTrip(t *testing.T) {
 	in := SearchInfo{CommonFields: CommonFields{ID: "dur"}, ItemCount: 42, Duration: 90 * time.Second}
 	b, err := json.Marshal(in)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	if !strings.Contains(string(b), `"Duration":"1m30s"`) {
+	if !strings.Contains(string(b), `"Duration":90000000000`) {
 		t.Fatalf("Duration missing from the wire format: %s", b)
 	}
 	var out SearchInfo
@@ -499,11 +499,6 @@ func TestSearchInfoDurationRoundTrip(t *testing.T) {
 	}
 	if out.ItemCount != in.ItemCount {
 		t.Errorf("ItemCount = %d, want %d", out.ItemCount, in.ItemCount)
-	}
-
-	// An unparseable duration must still surface as an error.
-	if err := json.Unmarshal([]byte(`{"Duration":"notaduration"}`), &out); err == nil {
-		t.Error("expected an error for an invalid duration")
 	}
 }
 


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR **PARTIALLY** addresses https://github.com/gravwell/issues/issues/2768

## This PR proposes...

- removing the custom `MarshalJSON`/`UnmarshalJSON` methods on `SearchInfo` to allow `Duration` to just be an `int64`, not `string`
- clean up linter warnings in this file
- update test

## PR Tasks

<!-- Add tasks to this list as needed -->

- [x] e2e and/or unit tests included. If not, please provide an explanation.
- [ ] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
