### PR TITLE
TOY: Optional[T] with Patch types

### DIFF
--- a/client/macros.go
+++ b/client/macros.go
@@ -94,7 +94,7 @@ func (c *Client) PATCH[T types.PatchType, K any](url string, data T) (patched K,
 	body, err := json.Marshal(data, json.OmitZeroStructFields(true))
 	if err != nil {
 		return patched, err
-	} else if string(body) == "{}" { // if this marshaled to no data, throw away the request
+	} else if body == nil || string(body) == "{}" { // if this marshaled to no data, throw away the request
 		return patched, ErrEmptyPatch
 	}
 

--- a/client/macros.go
+++ b/client/macros.go
@@ -8,7 +8,15 @@
 
 package client
 
-import "github.com/gravwell/gravwell/v4/client/types"
+import (
+	"bytes"
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/gravwell/gravwell/v4/client/types"
+)
 
 // ListMacros returns all macros accessible to the current user.
 func (c *Client) ListMacros(opts *types.QueryOptions) (ret types.MacroListResponse, err error) {
@@ -64,9 +72,67 @@ func (c *Client) CreateMacro(m types.Macro) (result types.Macro, err error) {
 	return
 }
 
-// UpdateMacro modifies an existing macro.
-func (c *Client) UpdateMacro(m types.Macro) error {
-	return c.putStaticURL(macroUrl(m.ID), m)
+var (
+	ErrEmptyPatch  = errors.New("empty PATCHs are ineffectual")
+	ErrNilResponse = errors.New("nil response")
+	ErrNilID       = errors.New("ID must not be nil")
+)
+
+// UpdateMacro modifies an existing macro and returns complete, updated struct.
+func (c *Client) UpdateMacro(ID string, p types.MacroPatch) (updated types.Macro, _ error) {
+	if ID == "" {
+		return types.Macro{}, ErrNilID
+	}
+	return c.PATCH[types.MacroPatch, types.Macro](macroUrl(ID), p)
+}
+
+// PATCH marshals data to JSON and submits a PATCH request against the target URL.
+//
+// TODO we can probably consolidate a lot of the methodStaticPushURLs by taking a method param in
+// wrapper calls and converting this to a driver func
+func (c *Client) PATCH[T types.PatchType, K any](url string, data T) (patched K, _ error) {
+	body, err := json.Marshal(data, json.OmitZeroStructFields(true))
+	if err != nil {
+		return patched, err
+	} else if string(body) == "{}" { // if this marshaled to no data, throw away the request
+		return patched, ErrEmptyPatch
+	}
+
+	uri := fmt.Sprintf("%s://%s%s", c.httpScheme, c.server, url)
+	req, err := http.NewRequest(http.MethodPatch, uri, bytes.NewBuffer(body))
+	if err != nil {
+		return patched, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	c.hm.populateRequest(req.Header) // add in the headers
+
+	// add in any queries like ?admin=true
+	if req.URL.RawQuery, err = c.qm.appendEncode(req.URL.RawQuery); err != nil {
+		return patched, err
+	}
+
+	c.objLog.Log("WEB REQ "+http.MethodPatch, url, data)
+	resp, err := c.clnt.Do(req)
+	if err != nil {
+		c.objLog.Log("WEB "+http.MethodPatch+" Error "+err.Error(), url, nil)
+		return patched, err
+	}
+	if resp == nil {
+		return patched, ErrNilResponse
+	}
+	if resp.StatusCode != http.StatusOK {
+		c.objLog.Log("WEB "+http.MethodPatch, url+" "+resp.Status, nil)
+		return patched, aliasResponseError(c, resp)
+	}
+	defer drainResponse(resp)
+
+	if err := json.UnmarshalRead(resp.Body, &patched); err != nil {
+		return patched, err
+	}
+
+	c.objLog.Log("WEB RECV", url, patched)
+	return patched, nil
 }
 
 // CleanupMacros (admin-only) purges all deleted macros for all users.

--- a/client/types/commonfields.go
+++ b/client/types/commonfields.go
@@ -163,6 +163,17 @@ func (cf *CommonFields) AllGIDs() []int32 {
 	return gids
 }
 
+// CommonFieldsPatch is the base type used to request updates to existing assets.
+// It contains only fields that can be updated.
+type CommonFieldsPatch struct {
+	Description Optional[string]
+	Labels      Optional[[]string]
+	Name        Optional[string]
+	OwnerID     Optional[int32]
+	Readers     Optional[ACL]
+	Writers     Optional[ACL]
+}
+
 type ListAllResponse struct {
 	BaseListResponse
 	Results []CommonFields

--- a/client/types/marshalers_v2_test.go
+++ b/client/types/marshalers_v2_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTDD(t *testing.T) {
+func TestOptional(t *testing.T) {
 	tests := []struct {
 		name                  string
 		data                  any
@@ -151,5 +151,37 @@ func TestTDD(t *testing.T) {
 			require.Equal(t, `{"B":{}}`, string(b))
 		})
 
+	})
+
+	t.Run("marshal and unmarshal", func(t *testing.T) {
+		t.Run("empty patch", func(t *testing.T) {
+			mp := types.MacroPatch{}
+			b, err := json.Marshal(&mp, json.OmitZeroStructFields(true))
+			require.Nil(t, err, "failed to marshal %v", &mp)
+
+			out := types.MacroPatch{}
+			require.Nil(t, json.Unmarshal(b, &out))
+		})
+		t.Run("partial patch", func(t *testing.T) {
+			mp := types.MacroPatch{Expansion: types.NewOptional("exp")}
+			b, err := json.Marshal(&mp, json.OmitZeroStructFields(true))
+			require.Nil(t, err, "failed to marshal %v", &mp)
+
+			out := types.MacroPatch{}
+			require.Nil(t, json.Unmarshal(b, &out))
+			require.Equal(t, mp.Expansion.Value(), out.Expansion.Value())
+		})
+		t.Run("partial patch 2", func(t *testing.T) {
+			mp := types.MacroPatch{
+				Labels:    types.NewOptional([]string{"kuài"}),
+				OwnerID:   types.NewOptional[int32](0),
+				Expansion: types.NewOptional("exp")}
+			b, err := json.Marshal(&mp, json.OmitZeroStructFields(true))
+			require.Nil(t, err, "failed to marshal %v", &mp)
+
+			out := types.MacroPatch{}
+			require.Nil(t, json.Unmarshal(b, &out))
+			require.Equal(t, mp.Expansion.Value(), out.Expansion.Value())
+		})
 	})
 }

--- a/client/types/marshalers_v2_test.go
+++ b/client/types/marshalers_v2_test.go
@@ -1,0 +1,57 @@
+package types_test
+
+import (
+	"encoding/json/v2"
+	"testing"
+
+	"github.com/gravwell/gravwell/v4/client/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOptionalPatch(t *testing.T) {
+	t.Run("Optional is included if set", func(t *testing.T) {
+		st := struct {
+			S types.Optional[string]
+		}{S: types.NewOptional("foo")}
+		b, err := json.Marshal(&st)
+		require.Nil(t, err)
+		require.Equal(t, `{"S":"foo"}`, string(b))
+	})
+	t.Run("Optional is skipped if omitzero tag is included in field", func(t *testing.T) {
+		st := struct {
+			S types.Optional[string] `json:",omitzero"`
+		}{}
+		b, err := json.Marshal(&st)
+		require.Nil(t, err)
+		require.Equal(t, "{}", string(b))
+	})
+	t.Run("Optional is skipped if omitzero option is included in encoder", func(t *testing.T) {
+		st := struct {
+			S types.Optional[string]
+		}{}
+		b, err := json.Marshal(&st, json.OmitZeroStructFields(true))
+		require.Nil(t, err)
+		require.Equal(t, "{}", string(b))
+	})
+
+	t.Run("empty patch produces no values", func(t *testing.T) {
+		m := types.MacroPatch{}
+		//m.Expansion.Set("xp")
+		b, err := json.Marshal(&m, json.OmitZeroStructFields(true))
+		require.Nil(t, err)
+		require.Equal(t, "{}", string(b))
+	})
+	/*t.Run("an set field is included", func(t *testing.T) {
+		m := types.MacroPatch{Expansion: types.NewOptional("Venkmann")}
+		m.Expansion.Unset()
+		b, err := json.Marshal(&m)
+		require.Nil(t, err)
+		require.Empty(t, string(b))
+		t.Run("an unset field is absent", func(t *testing.T) {
+			m.Expansion.Unset()
+			b, err := json.Marshal(&m)
+			require.Nil(t, err)
+			require.Empty(t, string(b))
+		})
+	})*/
+}

--- a/client/types/marshalers_v2_test.go
+++ b/client/types/marshalers_v2_test.go
@@ -32,10 +32,10 @@ func TestTDD(t *testing.T) {
 			false,
 			`{}`,
 		},
-		{"Optional field is omitted if OmitZeroStructFields option is included",
+		{"Optional field is omitted if OmitZeroStructFields option is present",
 			struct{ S types.Optional[int32] }{S: types.NewOptional[int32](5)},
 			true,
-			`{}`,
+			`{"S":5}`,
 		},
 		{"Zero Patch results in emptyJSON",
 			types.CommonFieldsPatch{},
@@ -43,16 +43,25 @@ func TestTDD(t *testing.T) {
 			`{}`,
 		},
 		{"Partially populated Patch type results in only populated fields",
-			types.CommonFieldsPatch{}, // TODO
+			types.CommonFieldsPatch{
+				Description: types.NewOptional(""),
+				Writers:     types.NewOptional(types.ACL{GIDs: []int32{1, 2, 12}}),
+			},
 			true,
-			`{}`, // TODO
+			`{"Description":"","Writers":{"GIDs":[1,2,12],"Global":false}}`,
 		},
 		{"Fully populated Patch type results in full JSO",
-			types.CommonFieldsPatch{}, // TODO
+			types.CommonFieldsPatch{
+				Description: types.NewOptional("desc"),
+				Labels:      types.NewOptional([]string{"shí"}),
+				Name:        types.NewOptional("fully popped"),
+				OwnerID:     types.NewOptional[int32](1),
+				Readers:     types.NewOptional(types.ACL{GIDs: []int32{0, 5, 8, 0}}),
+				Writers:     types.NewOptional(types.ACL{}),
+			},
 			true,
-			`{}`, // TODO
+			`{"Description":"desc","Labels":["shí"],"Name":"fully popped","OwnerID":1,"Readers":{"GIDs":[0,5,8,0],"Global":false},"Writers":{"GIDs":[],"Global":false}}`,
 		},
-		// TODO
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -92,10 +101,9 @@ func TestTDD(t *testing.T) {
 			b, err = json.Marshal(&v, json.OmitZeroStructFields(true))
 			require.Nil(t, err, "failed to marshal %v", &v)
 			t.Logf("Marshaled %+v to %s", v, b)
-			// we unset the whole thing; there is nothing left to marshal so null is the only available option
-			// NOTE(rlandau): I don't expect this to come up at all, but it could technically require nil instead of the desired '[]',
-			// so we may need to come back later.
-			require.Equal(t, `null`, string(b))
+			// we unset the whole thing, so the zero value ([]struct{...}(nil)) is marshaled;
+			// JSON/v2 defaults nil slices to '[]' rather than null.
+			require.Equal(t, `[]`, string(b))
 		})
 		t.Run("Set -> Set -> Unset -> Set", func(t *testing.T) {
 			v := struct {

--- a/client/types/marshalers_v2_test.go
+++ b/client/types/marshalers_v2_test.go
@@ -8,50 +8,140 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOptionalPatch(t *testing.T) {
-	t.Run("Optional is included if set", func(t *testing.T) {
-		st := struct {
-			S types.Optional[string]
-		}{S: types.NewOptional("foo")}
-		b, err := json.Marshal(&st)
-		require.Nil(t, err)
-		require.Equal(t, `{"S":"foo"}`, string(b))
-	})
-	t.Run("Optional is skipped if omitzero tag is included in field", func(t *testing.T) {
-		st := struct {
-			S types.Optional[string] `json:",omitzero"`
-		}{}
-		b, err := json.Marshal(&st)
-		require.Nil(t, err)
-		require.Equal(t, "{}", string(b))
-	})
-	t.Run("Optional is skipped if omitzero option is included in encoder", func(t *testing.T) {
-		st := struct {
-			S types.Optional[string]
-		}{}
-		b, err := json.Marshal(&st, json.OmitZeroStructFields(true))
-		require.Nil(t, err)
-		require.Equal(t, "{}", string(b))
-	})
-
-	t.Run("empty patch produces no values", func(t *testing.T) {
-		m := types.MacroPatch{}
-		//m.Expansion.Set("xp")
-		b, err := json.Marshal(&m, json.OmitZeroStructFields(true))
-		require.Nil(t, err)
-		require.Equal(t, "{}", string(b))
-	})
-	/*t.Run("an set field is included", func(t *testing.T) {
-		m := types.MacroPatch{Expansion: types.NewOptional("Venkmann")}
-		m.Expansion.Unset()
-		b, err := json.Marshal(&m)
-		require.Nil(t, err)
-		require.Empty(t, string(b))
-		t.Run("an unset field is absent", func(t *testing.T) {
-			m.Expansion.Unset()
-			b, err := json.Marshal(&m)
-			require.Nil(t, err)
-			require.Empty(t, string(b))
+func TestTDD(t *testing.T) {
+	tests := []struct {
+		name                  string
+		data                  any
+		includeOmitZeroOption bool // include the json.OmitZeroStructFields option when marshaling
+		expected              string
+	}{
+		{"Optional field is included if set",
+			struct{ S types.Optional[string] }{S: types.NewOptional("foo")},
+			false,
+			`{"S":"foo"}`,
+		},
+		{"Optional field with zero value is included",
+			struct{ S types.Optional[int32] }{S: types.NewOptional[int32](5)},
+			true,
+			`{"S":5}`,
+		},
+		{"Optional field is omitted if omitzero tag is present",
+			struct {
+				S types.Optional[string] `json:",omitzero"`
+			}{},
+			false,
+			`{}`,
+		},
+		{"Optional field is omitted if OmitZeroStructFields option is included",
+			struct{ S types.Optional[int32] }{S: types.NewOptional[int32](5)},
+			true,
+			`{}`,
+		},
+		{"Zero Patch results in emptyJSON",
+			types.CommonFieldsPatch{},
+			true,
+			`{}`,
+		},
+		{"Partially populated Patch type results in only populated fields",
+			types.CommonFieldsPatch{}, // TODO
+			true,
+			`{}`, // TODO
+		},
+		{"Fully populated Patch type results in full JSO",
+			types.CommonFieldsPatch{}, // TODO
+			true,
+			`{}`, // TODO
+		},
+		// TODO
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var opts []json.Options
+			if tt.includeOmitZeroOption {
+				opts = append(opts, json.OmitZeroStructFields(true))
+			}
+			b, err := json.Marshal(&tt.data, opts...)
+			require.Nil(t, err, "failed to marshal %v", &tt.data)
+			t.Logf("Marshaled %+v to %s", tt.data, b)
+			require.Equal(t, tt.expected, string(b))
 		})
-	})*/
+	}
+
+	t.Run("Complex Optional scenarios", func(t *testing.T) {
+		t.Run("Nested T", func(t *testing.T) {
+			// very messy, but a good way to ensure we capture all fields
+			v := types.NewOptional([]struct {
+				A int32
+				B struct{ Yī, èr string }
+			}{struct {
+				A int32
+				B struct {
+					Yī string
+					èr string
+				}
+			}{A: 5, B: struct {
+				Yī string
+				èr string
+			}{"one", "two"}}})
+			b, err := json.Marshal(&v, json.OmitZeroStructFields(true))
+			require.Nil(t, err, "failed to marshal %v", &v)
+			t.Logf("Marshaled %+v to %s", v, b)
+			require.Equal(t, `[{"A":5,"B":{"Yī":"one"}}]`, string(b))
+
+			v.Unset()
+			b, err = json.Marshal(&v, json.OmitZeroStructFields(true))
+			require.Nil(t, err, "failed to marshal %v", &v)
+			t.Logf("Marshaled %+v to %s", v, b)
+			// we unset the whole thing; there is nothing left to marshal so null is the only available option
+			// NOTE(rlandau): I don't expect this to come up at all, but it could technically require nil instead of the desired '[]',
+			// so we may need to come back later.
+			require.Equal(t, `null`, string(b))
+		})
+		t.Run("Set -> Set -> Unset -> Set", func(t *testing.T) {
+			v := struct {
+				A types.Optional[int32]
+				B struct{ One, two types.Optional[string] }
+				C types.Optional[struct {
+					three bool
+					Four  float32
+				}]
+			}{
+				A: types.NewOptional[int32](0),
+				B: struct {
+					One types.Optional[string]
+					two types.Optional[string]
+				}{types.NewOptional("Yī"), types.NewOptional("èr")},
+				C: types.NewOptional(struct {
+					three bool
+					Four  float32
+				}{true, 4.4}),
+			}
+			// everything should be included
+			b, err := json.Marshal(&v, json.OmitZeroStructFields(true))
+			require.Nil(t, err, "failed to marshal %v", &v)
+			t.Logf("Marshaled %+v to %s", v, b)
+			require.Equal(t, `{"A":0,"B":{"One":"Yī"},"C":{"Four":4.4}}`, string(b))
+
+			// set a couple new values
+			v.B.One.Set("ein")
+			v.B.two.Set("swei")
+			// everything should be included
+			b, err = json.Marshal(&v, json.OmitZeroStructFields(true))
+			require.Nil(t, err, "failed to marshal %v", &v)
+			t.Logf("Marshaled %+v to %s", v, b)
+			require.Equal(t, `{"A":0,"B":{"One":"ein"},"C":{"Four":4.4}}`, string(b))
+
+			// unset everything
+			v.A.Unset()
+			v.B.One.Unset()
+			v.C.Unset()
+			b, err = json.Marshal(&v, json.OmitZeroStructFields(true))
+			require.Nil(t, err, "failed to marshal %v", &v)
+			t.Logf("Marshaled %+v to %s", v, b)
+			// B is a concrete struct, so it will always be included.
+			// This is intentional.
+			require.Equal(t, `{"B":{}}`, string(b))
+		})
+
+	})
 }

--- a/client/types/marshallers_test.go
+++ b/client/types/marshallers_test.go
@@ -6,7 +6,7 @@
  * BSD 2-clause license. See the LICENSE file for details.
  **************************************************************************/
 
-package types
+package types_test
 
 import (
 	"bytes"
@@ -15,12 +15,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gravwell/gravwell/v4/client/types"
 	"github.com/gravwell/gravwell/v4/ingest/entry"
 )
 
 func TestTimeRangeEncodeDecode(t *testing.T) {
 	ts := entry.Now()
-	tr := TimeRange{
+	tr := types.TimeRange{
 		StartTS: ts,
 		EndTS:   ts.Add(time.Hour),
 	}
@@ -28,7 +29,7 @@ func TestTimeRangeEncodeDecode(t *testing.T) {
 	if err := json.NewEncoder(bb).Encode(tr); err != nil {
 		t.Fatal(err)
 	}
-	var ttr TimeRange
+	var ttr types.TimeRange
 	if err := json.NewDecoder(bb).Decode(&ttr); err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +44,7 @@ func TestTimeRangeEncodeDecode(t *testing.T) {
 
 func TestEmptyTimeRangeEncodeDecode(t *testing.T) {
 	bb := bytes.NewBuffer(nil)
-	var ttr TimeRange
+	var ttr types.TimeRange
 	if err := ttr.DecodeJSON(bb); err != nil {
 		t.Fatal(err)
 	}
@@ -55,13 +56,13 @@ func TestEmptyTimeRangeEncodeDecode(t *testing.T) {
 func TestSearchEntryEncodeDecode(t *testing.T) {
 	bb := bytes.NewBuffer(nil)
 	//test without any enumerated values
-	s := SearchEntry{
+	s := types.SearchEntry{
 		TS:   entry.FromStandard(time.Now()),
 		Tag:  0x1337,
 		SRC:  net.ParseIP(`DEAD::BEEF`),
 		Data: []byte("this is my data, there are many like it, but this is mine"),
 	}
-	var d SearchEntry
+	var d types.SearchEntry
 	if err := json.NewEncoder(bb).Encode(s); err != nil {
 		t.Fatal(err)
 	} else if err = json.NewDecoder(bb).Decode(&d); err != nil {
@@ -74,17 +75,17 @@ func TestSearchEntryEncodeDecode(t *testing.T) {
 func TestSearchEntryEncodeDecodeEnum(t *testing.T) {
 	bb := bytes.NewBuffer(nil)
 	//test without any enumerated values
-	s := SearchEntry{
+	s := types.SearchEntry{
 		TS:   entry.FromStandard(time.Now()),
 		Tag:  0x1337,
 		SRC:  net.ParseIP(`DEAD::BEEF`),
 		Data: []byte("this is my data, there are many like it, but this is mine"),
-		Enumerated: []EnumeratedPair{
-			EnumeratedPair{Name: `foo`, Value: `bar`, RawValue: RawEnumeratedValue{Type: 1, Data: []byte("stuff")}},
-			EnumeratedPair{Name: `bar`, Value: `baz`},
+		Enumerated: []types.EnumeratedPair{
+			{Name: `foo`, Value: `bar`, RawValue: types.RawEnumeratedValue{Type: 1, Data: []byte("stuff")}},
+			{Name: `bar`, Value: `baz`},
 		},
 	}
-	var d SearchEntry
+	var d types.SearchEntry
 	if err := json.NewEncoder(bb).Encode(s); err != nil {
 		t.Fatal(err)
 	} else if err = json.NewDecoder(bb).Decode(&d); err != nil {
@@ -101,7 +102,7 @@ func TestSearchEntryEncodeDecodeRaw(t *testing.T) {
 		t.Fatal(err)
 	}
 	//test without any enumerated values
-	s := SearchEntry{
+	s := types.SearchEntry{
 		TS:   entry.FromStandard(ts),
 		Tag:  0x1337,
 		SRC:  net.ParseIP(`DEAD::BEEF`),
@@ -109,7 +110,7 @@ func TestSearchEntryEncodeDecodeRaw(t *testing.T) {
 	}
 	raw := `{"TS": "2020-12-23T16:04:17.417437Z", "Tag": 4919, "SRC": "DEAD::BEEF", "Data": "dGVzdGRhdGE="}`
 	bb.WriteString(raw)
-	var d SearchEntry
+	var d types.SearchEntry
 	if err = json.NewDecoder(bb).Decode(&d); err != nil {
 		t.Fatal(err)
 	} else if !s.Equal(d) {
@@ -118,8 +119,8 @@ func TestSearchEntryEncodeDecodeRaw(t *testing.T) {
 }
 
 func TestBaseResponseEncode(t *testing.T) {
-	br := BaseResponse{
-		Messages: []Message{
+	br := types.BaseResponse{
+		Messages: []types.Message{
 			{
 				ID: 1,
 			},
@@ -130,7 +131,7 @@ func TestBaseResponseEncode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var x BaseResponse
+	var x types.BaseResponse
 
 	if err := json.NewDecoder(bb).Decode(&x); err != nil {
 		t.Fatal(err)
@@ -142,15 +143,13 @@ func TestBaseResponseEncode(t *testing.T) {
 }
 
 func TestChartResponseEncode(t *testing.T) {
-	br := ChartResponse{
-		BaseResponse: BaseResponse{
-			Messages: []Message{
-				{
-					ID: 1,
-				},
+	br := types.ChartResponse{
+		Messages: []types.Message{
+			{
+				ID: 1,
 			},
 		},
-		Entries: ChartableValueSet{
+		Entries: types.ChartableValueSet{
 			Names: []string{"test"},
 		},
 	}
@@ -159,7 +158,7 @@ func TestChartResponseEncode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var x ChartResponse
+	var x types.ChartResponse
 
 	if err := json.NewDecoder(bb).Decode(&x); err != nil {
 		t.Fatal(err)
@@ -174,15 +173,13 @@ func TestChartResponseEncode(t *testing.T) {
 }
 
 func TestFDGResponseEncode(t *testing.T) {
-	br := FdgResponse{
-		BaseResponse: BaseResponse{
-			Messages: []Message{
-				{
-					ID: 1,
-				},
+	br := types.FdgResponse{
+		Messages: []types.Message{
+			{
+				ID: 1,
 			},
 		},
-		Entries: FdgSet{
+		Entries: types.FdgSet{
 			Groups: []string{"test"},
 		},
 	}
@@ -191,7 +188,7 @@ func TestFDGResponseEncode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var x FdgResponse
+	var x types.FdgResponse
 
 	if err := json.NewDecoder(bb).Decode(&x); err != nil {
 		t.Fatal(err)
@@ -206,17 +203,17 @@ func TestFDGResponseEncode(t *testing.T) {
 }
 
 func TestPointmapResponseEncode(t *testing.T) {
-	br := PointmapResponse{
-		BaseResponse: BaseResponse{
-			Messages: []Message{
+	br := types.PointmapResponse{
+		BaseResponse: types.BaseResponse{
+			Messages: []types.Message{
 				{
 					ID: 1,
 				},
 			},
 		},
-		Entries: []PointmapValue{
+		Entries: []types.PointmapValue{
 			{
-				Loc: Location{
+				Loc: types.Location{
 					Lat:  1,
 					Long: 1,
 				},
@@ -228,7 +225,7 @@ func TestPointmapResponseEncode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var x PointmapResponse
+	var x types.PointmapResponse
 
 	if err := json.NewDecoder(bb).Decode(&x); err != nil {
 		t.Fatal(err)
@@ -243,15 +240,15 @@ func TestPointmapResponseEncode(t *testing.T) {
 }
 
 func TestHeatmapResponseEncode(t *testing.T) {
-	br := HeatmapResponse{
-		BaseResponse: BaseResponse{
-			Messages: []Message{
+	br := types.HeatmapResponse{
+		BaseResponse: types.BaseResponse{
+			Messages: []types.Message{
 				{
 					ID: 1,
 				},
 			},
 		},
-		Entries: []HeatmapValue{
+		Entries: []types.HeatmapValue{
 			{
 				Magnitude: 1,
 			},
@@ -262,7 +259,7 @@ func TestHeatmapResponseEncode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var x HeatmapResponse
+	var x types.HeatmapResponse
 
 	if err := json.NewDecoder(bb).Decode(&x); err != nil {
 		t.Fatal(err)
@@ -277,15 +274,15 @@ func TestHeatmapResponseEncode(t *testing.T) {
 }
 
 func TestP2PResponseEncode(t *testing.T) {
-	br := P2PResponse{
-		BaseResponse: BaseResponse{
-			Messages: []Message{
+	br := types.P2PResponse{
+		BaseResponse: types.BaseResponse{
+			Messages: []types.Message{
 				{
 					ID: 1,
 				},
 			},
 		},
-		Entries: []P2PValue{
+		Entries: []types.P2PValue{
 			{
 				Magnitude: 1,
 			},
@@ -296,7 +293,7 @@ func TestP2PResponseEncode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var x P2PResponse
+	var x types.P2PResponse
 
 	if err := json.NewDecoder(bb).Decode(&x); err != nil {
 		t.Fatal(err)
@@ -311,15 +308,15 @@ func TestP2PResponseEncode(t *testing.T) {
 }
 
 func TestStackgraphResponseEncode(t *testing.T) {
-	br := StackGraphResponse{
-		BaseResponse: BaseResponse{
-			Messages: []Message{
+	br := types.StackGraphResponse{
+		BaseResponse: types.BaseResponse{
+			Messages: []types.Message{
 				{
 					ID: 1,
 				},
 			},
 		},
-		Entries: []StackGraphSet{
+		Entries: []types.StackGraphSet{
 			{
 				Key: "test",
 			},
@@ -330,7 +327,7 @@ func TestStackgraphResponseEncode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var x StackGraphResponse
+	var x types.StackGraphResponse
 
 	if err := json.NewDecoder(bb).Decode(&x); err != nil {
 		t.Fatal(err)
@@ -345,15 +342,15 @@ func TestStackgraphResponseEncode(t *testing.T) {
 }
 
 func TestTableResponseEncode(t *testing.T) {
-	br := TableResponse{
-		BaseResponse: BaseResponse{
-			Messages: []Message{
+	br := types.TableResponse{
+		BaseResponse: types.BaseResponse{
+			Messages: []types.Message{
 				{
 					ID: 1,
 				},
 			},
 		},
-		Entries: TableValueSet{
+		Entries: types.TableValueSet{
 			Columns: []string{"test"},
 		},
 	}
@@ -362,7 +359,7 @@ func TestTableResponseEncode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var x TableResponse
+	var x types.TableResponse
 
 	if err := json.NewDecoder(bb).Decode(&x); err != nil {
 		t.Fatal(err)
@@ -377,15 +374,15 @@ func TestTableResponseEncode(t *testing.T) {
 }
 
 func TestGaugeResponseEncode(t *testing.T) {
-	br := GaugeResponse{
-		BaseResponse: BaseResponse{
-			Messages: []Message{
+	br := types.GaugeResponse{
+		BaseResponse: types.BaseResponse{
+			Messages: []types.Message{
 				{
 					ID: 1,
 				},
 			},
 		},
-		Entries: []GaugeValue{
+		Entries: []types.GaugeValue{
 			{
 				Name: "test",
 			},
@@ -396,7 +393,7 @@ func TestGaugeResponseEncode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var x GaugeResponse
+	var x types.GaugeResponse
 
 	if err := json.NewDecoder(bb).Decode(&x); err != nil {
 		t.Fatal(err)
@@ -411,15 +408,15 @@ func TestGaugeResponseEncode(t *testing.T) {
 }
 
 func TestWordcloudResponseEncode(t *testing.T) {
-	br := WordcloudResponse{
-		BaseResponse: BaseResponse{
-			Messages: []Message{
+	br := types.WordcloudResponse{
+		BaseResponse: types.BaseResponse{
+			Messages: []types.Message{
 				{
 					ID: 1,
 				},
 			},
 		},
-		Entries: []WordcloudValue{
+		Entries: []types.WordcloudValue{
 			{
 				Name: "test",
 			},
@@ -430,7 +427,7 @@ func TestWordcloudResponseEncode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var x WordcloudResponse
+	var x types.WordcloudResponse
 
 	if err := json.NewDecoder(bb).Decode(&x); err != nil {
 		t.Fatal(err)
@@ -445,15 +442,15 @@ func TestWordcloudResponseEncode(t *testing.T) {
 }
 
 func TestTextResponseEncode(t *testing.T) {
-	br := TextResponse{
-		BaseResponse: BaseResponse{
-			Messages: []Message{
+	br := types.TextResponse{
+		BaseResponse: types.BaseResponse{
+			Messages: []types.Message{
 				{
 					ID: 1,
 				},
 			},
 		},
-		Entries: []SearchEntry{
+		Entries: []types.SearchEntry{
 			{
 				Data: []byte("foo"),
 			},
@@ -464,7 +461,7 @@ func TestTextResponseEncode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var x TextResponse
+	var x types.TextResponse
 
 	if err := json.NewDecoder(bb).Decode(&x); err != nil {
 		t.Fatal(err)
@@ -479,15 +476,15 @@ func TestTextResponseEncode(t *testing.T) {
 }
 
 func TestRawResponseEncode(t *testing.T) {
-	br := RawResponse{
-		BaseResponse: BaseResponse{
-			Messages: []Message{
+	br := types.RawResponse{
+		BaseResponse: types.BaseResponse{
+			Messages: []types.Message{
 				{
 					ID: 1,
 				},
 			},
 		},
-		Entries: []SearchEntry{
+		Entries: []types.SearchEntry{
 			{
 				Data: []byte("foo"),
 			},
@@ -498,7 +495,7 @@ func TestRawResponseEncode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var x RawResponse
+	var x types.RawResponse
 
 	if err := json.NewDecoder(bb).Decode(&x); err != nil {
 		t.Fatal(err)

--- a/client/types/optional.go
+++ b/client/types/optional.go
@@ -1,6 +1,12 @@
 package types
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
+
+type PatchType interface {
+	MacroPatch
+}
 
 // An Optional type represents a field which may be unset during an update, preserving its prior value.
 // If !Optional.IsSet(), this field will be omitted from a JSON marshal of the type.
@@ -15,7 +21,7 @@ func NewOptional[T any](v T) Optional[T] {
 }
 
 // Set installs the given value and marks it as valid to include when marshaling.
-func (o Optional[T]) Set(v T) {
+func (o *Optional[T]) Set(v T) {
 	o.value = v
 	o.set = true
 }
@@ -37,13 +43,22 @@ func (o Optional[T]) IsSet() bool {
 }
 
 // Unset marks this field s.t. it will be skipped when marshaling.
-func (o Optional[T]) Unset() {
+func (o *Optional[T]) Unset() {
 	o.set = false
 }
 
+func (o Optional[T]) IsZero() bool {
+	return !o.IsSet()
+}
+
+// MarshalJSON causes optional to print the set value or the zero value.
+//
+// NOTE(rlandau): as of go1.27.0, a field cannot skip itself with MarshalJSON.
+// Instead, we use IsZero and the OmitZeroStructFields option.
 func (o Optional[T]) MarshalJSON() ([]byte, error) {
 	if !o.IsSet() {
-		return nil, nil
+		var zero T
+		return json.Marshal(zero)
 	}
 	return json.Marshal(o.value)
 }

--- a/client/types/optional.go
+++ b/client/types/optional.go
@@ -47,11 +47,16 @@ func (o *Optional[T]) Unset() {
 	o.set = false
 }
 
+// IsZero returns true iff !o.Set.
+//
+// This allows marshalers to omit unset values while still including zero values
+// (assuming json.OmitZeroStructFields(true) or `json:",omitzero"` is set).
 func (o Optional[T]) IsZero() bool {
 	return !o.IsSet()
 }
 
-// MarshalJSON causes optional to print the set value or the zero value.
+// MarshalJSON causes optional to always marshal to a safe value.
+// If !o.IsSet(), T zero will be used.
 //
 // NOTE(rlandau): as of go1.27.0, a field cannot skip itself with MarshalJSON.
 // Instead, we use IsZero and the OmitZeroStructFields option.

--- a/client/types/optional.go
+++ b/client/types/optional.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	"encoding/json"
+	"encoding/json/v2"
 )
 
 type PatchType interface {

--- a/client/types/optional.go
+++ b/client/types/optional.go
@@ -67,3 +67,12 @@ func (o Optional[T]) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(o.value)
 }
+
+// UnmarshalJSON decodes the given data into o's value and marks it as set.
+func (o *Optional[T]) UnmarshalJSON(data []byte) error {
+	if err := json.Unmarshal(data, &o.value); err != nil {
+		return err
+	}
+	o.set = true
+	return nil
+}

--- a/client/types/optional.go
+++ b/client/types/optional.go
@@ -1,0 +1,49 @@
+package types
+
+import "encoding/json"
+
+// An Optional type represents a field which may be unset during an update, preserving its prior value.
+// If !Optional.IsSet(), this field will be omitted from a JSON marshal of the type.
+type Optional[T any] struct {
+	value T
+	set   bool
+}
+
+// NewOptional returns a set field with value v.
+func NewOptional[T any](v T) Optional[T] {
+	return Optional[T]{value: v, set: true}
+}
+
+// Set installs the given value and marks it as valid to include when marshaling.
+func (o Optional[T]) Set(v T) {
+	o.value = v
+	o.set = true
+}
+
+// Value fetches the value contained within the Optional.
+// It is intended to prevent nil-derefs and is always safe to call.
+// If !o.IsSet(), T's zero value will be returned
+func (o Optional[T]) Value() T {
+	if !o.IsSet() {
+		var zero T
+		return zero
+	}
+	return o.value
+}
+
+// IsSet states if this field has a value and thus will be included in the JSON representation.
+func (o Optional[T]) IsSet() bool {
+	return o.set
+}
+
+// Unset marks this field s.t. it will be skipped when marshaling.
+func (o Optional[T]) Unset() {
+	o.set = false
+}
+
+func (o Optional[T]) MarshalJSON() ([]byte, error) {
+	if !o.IsSet() {
+		return nil, nil
+	}
+	return json.Marshal(o.value)
+}

--- a/client/types/search.go
+++ b/client/types/search.go
@@ -679,6 +679,13 @@ func (si SearchInfo) StorageSize() int64 {
 
 const AllowedMacroChars = "ABCDCEFGHIJKLMNOPQRSTUVWXYZ1234567890_-"
 
+// MacroPatch is the type used to request an update to an existing Macro.
+type MacroPatch struct {
+	CommonFieldsPatch
+	Expansion Optional[string]
+}
+
+// Macro is the type used to Get and Create Macros.
 type Macro struct {
 	CommonFields
 	Expansion string

--- a/client/types/users.go
+++ b/client/types/users.go
@@ -11,7 +11,7 @@ package types
 import (
 	"bytes"
 	"encoding/gob"
-	"encoding/json"
+	"encoding/json/v2"
 	"net"
 	"time"
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravwell/gravwell/v4
 
-go 1.26.6
+go 1.27.0
 
 tool github.com/gravwell/gravwell/v4/tools/repo
 
@@ -69,7 +69,7 @@ require (
 	github.com/shirou/gopsutil v2.20.9+incompatible
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9
-	github.com/stretchr/testify v1.11.1
+	github.com/stretchr/testify v1.12.1
 	github.com/tealeg/xlsx v1.0.5
 	github.com/turnage/graw v0.0.0-20191104042329-405cc3092119
 	github.com/xdg-go/scram v1.1.2
@@ -165,7 +165,6 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sahilm/fuzzy v0.1.1 // indirect
@@ -181,6 +180,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect
 	go.opentelemetry.io/otel/trace v1.45.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/crypto v0.55.0 // indirect
 	golang.org/x/mod v0.40.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
@@ -190,5 +190,4 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260817212433-ac3dfec99bb1 // indirect
 	gopkg.in/gcfg.v1 v1.2.3 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -383,8 +383,6 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
-github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
 github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -426,8 +424,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
-github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=
+github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
 github.com/tealeg/xlsx v1.0.5 h1:+f8oFmvY8Gw1iUXzPk+kz+4GpbDZPK1FhPiQRd+ypgE=
 github.com/tealeg/xlsx v1.0.5/go.mod h1:btRS8dz54TDnvKNosuAqxrM1QgN1udgk9O34bDCnORM=
 github.com/turnage/graw v0.0.0-20191104042329-405cc3092119 h1:WpxPyCI7eEFG4Ix5m/UhTkrFZxSI6YAASpQswMn08b0=
@@ -470,6 +468,8 @@ go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXd
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
+go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -622,7 +622,6 @@ gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR prototypes https://github.com/gravwell/issues/issues/1467.

>[!IMPORTANT]
>This PR is NOT intended to be merged; it breaks nearly all update functionality! It is to serve as a toy other backenders can experiment with before we proceed with a full rollout. Assuming it is satisfactory, I will kill this PR and create a new one when the rollout is complete.

Sister PR: https://github.com/gravwell/backend/pull/4455

I did not create a sister api-docs prototype.

## This PR implements PATCH semantics for Macros

**The code, especially the backend code, is messy. Evaluate the syntax and ergonomics; I already have plans to clean up, optimize, and consolidate the hell out of these changes/files if we move forward.**


- Introduces Optional[T] type. This is the crux of this implementation; Patch/updates fields are wrapped in `Optional[T]` such that they inherit the properties required to patch their parent type's fields.
  - You can see it in action in `gravwell/client/types/marshalers_v2_test.go` and end-to-end at `backend/test/env/single_node/tests/patch.go`
- Introduces MacroPatch and CFPatch, each of which only contains fields a user is allowed to update.
- Updates Client.UpdateMacro() to send as PATCH.
  - Introduces a new func `Client.PATCH()` that would serve as the driver function for PATCH calls.

This PR is built on JSON/v2 and the toy assumes v2 across the board.

### Patching private types

The toy patches the pubtypes.*Patch directly onto the private type. It felt silly to convert the existing private type to a public type, patch the public type, and then convert back.

## Open Question: slice and map patching

Over all, the design we landed on feels great. Clean, easy to grok, easy to maintain, relatively ergonomic, and closer to API docs than what we were doing before.

However, there is still one open question: how do we handle maps/slices? 

- Do patches still clobber them (if Set)?
- Do we need to introduce Add/Clobber fields to Patch types (ex: instead of `CFP.Labels`, we have `CFP.LabelsAppend` and `CFP.LabelsReplace`)? 
- Do they need their own version of `Optional[T]` that includes an enum for how to handle it (ex: `OptionalBox[T]` has `.value`, `.set`, and `.behavior` where behavior is an enumerated `append`, `remove`, and `replace`)?

This tangentially relates to nested structs too. How deep do we place `Optional[T]`? `Optional[pubtypes.ACL]`? `pubtypes.ACL{GIDs Optional[[]int32], Global Optional[bool]}`?

## PR Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e and/or unit tests included. If not, please provide an explanation.
  - I have included some unit tests to ensure proper behavior, but am not planning to make this toy pass tests.

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
