### PR TITLE
fix(#2729): marshal entry.Timestamp as UTC

### DIFF
--- a/ingest/entry/time.go
+++ b/ingest/entry/time.go
@@ -122,13 +122,13 @@ func (t Timestamp) MarshalBinary() ([]byte, error) {
 // MarshalJSON marshals the timestamp into the golang time.Time JSON format
 // this is a total hack, and we will write our own marshallers soon
 func (t Timestamp) MarshalJSON() ([]byte, error) {
-	return t.StandardTime().MarshalJSON()
+	return t.StandardTime().UTC().MarshalJSON()
 }
 
 // MarshalText marshals the timestamp into the golang time.Time text format
 // this is a total hack, and we will write our own marshallers soon
 func (t Timestamp) MarshalText() ([]byte, error) {
-	return t.StandardTime().MarshalJSON()
+	return t.StandardTime().UTC().MarshalJSON()
 }
 
 // UnmarshalBinary unmarshals a 12 byte encoding of a Timestamp


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR closes https://github.com/gravwell/gravwell/issues/2729

## This PR forces entry.Timestamp to marshal in UTC

Timestamp already does this in `.String()` and has no way of setting a TZ so MarshalJSON can never be consistent without this change

## PR Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e and/or unit tests included. If not, please provide an explanation.
- [ ] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
