### PR TITLE
feat(search): update gwcli to allow match set access endpoint

### DIFF
--- a/gwcli/tree/queries/queries.go
+++ b/gwcli/tree/queries/queries.go
@@ -57,7 +57,7 @@ func NewNav() *cobra.Command {
 			save(),
 			background(),
 			delete(),
-			setGroup(),
+			setAccess(),
 		},
 		treeutils.NodeOptions{CommandAliases: []string{"queries"}},
 	)
@@ -365,41 +365,60 @@ func delete() action.Pair {
 		})
 }
 
-// TODO this should be converted to a scaffoldcreate with two MSL fields after the scaffoldcreate/edit merge.
-func setGroup() action.Pair {
-	var GIDs []int32 // managed in validate args
-	return scaffoldselect.NewSelectAction("set or wipe the group read permissions of a search",
-		"Modify with groups can read a set of searches. Omitting --groups removes all groups from the selected searches.",
-		"group ID",
-		func(addtlFlags *pflag.FlagSet) ([]multiselectlist.SelectableItem[string], error) {
+// TODO: this should be converted to a scaffoldcreate with MSL fields after the scaffoldcreate/edit merge.
+func setAccess() action.Pair {
+	var (
+		readerGroups, writerGroups       []int32
+		readerGroupsSet, writerGroupsSet bool
+		readerGlobal, writerGlobal       bool
+		readerGlobalSet, writerGlobalSet bool
+	)
+
+	return scaffoldselect.NewSelectAction("set the read/write access of a search",
+		`Modify which groups can read or write a set of searches, and/or whether they are globally readable/writable by any user. Only flags you explicitly pass are changed. Anything you omit is left as-is. Only admins may set --reader-global or --writer-global to true, the server will reject this action otherwise`, "search ID", func(addtlFlags *pflag.FlagSet) ([]multiselectlist.SelectableItem[string], error) {
 			return fetchActiveSearchesForMSL(false)
-		},
-		func(IDs []string, _ *pflag.FlagSet) (results []scaffold.Result, _ error) {
-			results = make([]scaffold.Result, len(IDs))
-			for i, ID := range IDs {
-				si, err := connection.Client.GetSearch(ID)
+		}, func(ids []string, _ *pflag.FlagSet) (results []scaffold.Result, _ error) {
+			results = make([]scaffold.Result, len(ids))
+			for i, id := range ids {
+				si, err := connection.Client.GetSearch(id)
 				if err != nil {
-					results[i] = scaffold.Result{Success: false, Output: fmt.Sprintf("failed to fetch search: %s: %v", ID, err)}
+					results[i] = scaffold.Result{Success: false, Output: fmt.Sprintf("failed to fetch search: %s: %v", id, err)}
 					continue
 				}
-				if err := connection.Client.SetAccess(ID, si.OwnerID, types.ACL{GIDs: GIDs}, si.Writers); err != nil {
-					results[i] = scaffold.Result{Success: false, Output: fmt.Sprintf("failed to set groups for search %s: %v", ID, err)}
-				} else if len(GIDs) < 1 {
-					results[i] = scaffold.Result{Success: true, Output: "cleared read groups from search " + ID}
-				} else {
-					results[i] = scaffold.Result{Success: true, Output: fmt.Sprintf("assigned read access for GIDs %v to search %s", GIDs, ID)}
+
+				readers, writers := si.Readers, si.Writers
+				if readerGroupsSet {
+					readers.GIDs = readerGroups
 				}
+				if readerGlobalSet {
+					readers.Global = readerGlobal
+				}
+				if writerGroupsSet {
+					writers.GIDs = writerGroups
+				}
+				if writerGlobalSet {
+					writers.Global = writerGlobal
+				}
+
+				if err := connection.Client.SetAccess(id, si.OwnerID, readers, writers); err != nil {
+					results[i] = scaffold.Result{Success: false, Output: fmt.Sprintf("failed to set access for search %s: %v", id, err)}
+					continue
+				}
+
+				results[i] = scaffold.Result{Success: true, Output: "updated access for search " + id}
 			}
+
 			return results, nil
-		},
-		scaffoldselect.Options{
+		}, scaffoldselect.Options{
 			CommonOptions: scaffold.CommonOptions{
-				Use:     "set-groups",
-				Aliases: []string{"set-group"},
+				Use:     "set-access",
+				Aliases: []string{"set-groups", "set-group"},
 				AddtlFlags: func() *pflag.FlagSet {
 					fs := &pflag.FlagSet{}
-					fs.Int32Slice("groups", nil, "Groups to grant read access to the search. You must have access to the group."+
-						"If you omit this flag, all groups will be removed from the selected searches.")
+					fs.Int32Slice("reader-groups", nil, "Groups allowed to read the search. Omit to leave unchanged; pass an empty list to clear.")
+					fs.Int32Slice("writer-groups", nil, "Groups allowed to write the search. Omit to leave unchanged; pass an empty list to clear.")
+					fs.Bool("reader-global", false, "Whether the search is globally readable by any user. Omit to leave unchanged. Requires admin to set true.")
+					fs.Bool("writer-global", false, "Whether the search is globally writable by any user. Omit to leave unchanged. Requires admin to set true.")
 					return fs
 				},
 				Requirements: annotations.Requirements{
@@ -408,12 +427,24 @@ func setGroup() action.Pair {
 				},
 			},
 			ValidateArgs: func(fs *pflag.FlagSet) (invalid string, err error) {
-				// check they we have at least one search and at least one group
-				GIDs, err = fs.GetInt32Slice("groups")
-				clilog.GetFlag(err)
+				if readerGroupsSet = fs.Changed("reader-groups"); readerGroupsSet {
+					readerGroups, err = fs.GetInt32Slice("reader-groups")
+					clilog.GetFlag(err)
+				}
+				if writerGroupsSet = fs.Changed("writer-groups"); writerGroupsSet {
+					writerGroups, err = fs.GetInt32Slice("writer-groups")
+					clilog.GetFlag(err)
+				}
+				if readerGlobalSet = fs.Changed("reader-global"); readerGlobalSet {
+					readerGlobal, err = fs.GetBool("reader-global")
+					clilog.GetFlag(err)
+				}
+				if writerGlobalSet = fs.Changed("writer-global"); writerGlobalSet {
+					writerGlobal, err = fs.GetBool("writer-global")
+					clilog.GetFlag(err)
+				}
 
 				return "", nil
 			},
-		},
-	)
+		})
 }

--- a/gwcli/tree/queries/queries.go
+++ b/gwcli/tree/queries/queries.go
@@ -375,7 +375,7 @@ func setAccess() action.Pair {
 	)
 
 	return scaffoldselect.NewSelectAction("set the read/write access of a search",
-		`Modify which groups can read or write a set of searches, and/or whether they are globally readable/writable by any user. Only flags you explicitly pass are changed. Anything you omit is left as-is. Only admins may set --reader-global or --writer-global to true, the server will reject this action otherwise`, "search ID", func(addtlFlags *pflag.FlagSet) ([]multiselectlist.SelectableItem[string], error) {
+		`Modify which groups can read or write a set of searches, and/or whether they are globally readable/writable by any user. Only flags you explicitly pass are changed. Anything you omit is left as-is. Only admins may set --reader-global or --writer-global to true, the server will reject this action otherwise. At least one of --reader-groups, --writer-groups, --reader-global, or --writer-global must be given`, "search ID", func(addtlFlags *pflag.FlagSet) ([]multiselectlist.SelectableItem[string], error) {
 			return fetchActiveSearchesForMSL(false)
 		}, func(ids []string, _ *pflag.FlagSet) (results []scaffold.Result, _ error) {
 			results = make([]scaffold.Result, len(ids))
@@ -442,6 +442,10 @@ func setAccess() action.Pair {
 				if writerGlobalSet = fs.Changed("writer-global"); writerGlobalSet {
 					writerGlobal, err = fs.GetBool("writer-global")
 					clilog.GetFlag(err)
+				}
+
+				if !readerGroupsSet && !writerGroupsSet && !readerGlobalSet && !writerGlobalSet {
+					return "you must specify at least one of --reader-groups, --writer-groups, --reader-global, or --writer-global", nil
 				}
 
 				return "", nil

--- a/gwcli/tree/queries/queries_test.go
+++ b/gwcli/tree/queries/queries_test.go
@@ -21,49 +21,45 @@ import (
 	"github.com/gravwell/gravwell/v4/client"
 	"github.com/gravwell/gravwell/v4/client/types"
 	"github.com/gravwell/gravwell/v4/gwcli/connection"
+	"github.com/gravwell/gravwell/v4/gwcli/group"
+	"github.com/spf13/cobra"
 )
 
-// TestSetGroupPreservesWriters is a regression test for gravwell/issues#2708:
-// setGroup() migrated from the Readers-only SetGroups endpoint to the
-// combined SetAccess endpoint, which replaces Writers and OwnerID wholesale
-// on every call (OwnerID has no "leave unchanged" sentinel -- it's a plain,
-// always-required int32, same as Writers). Without fetching the search's
-// current Writers and OwnerID first, running set-groups would silently wipe
-// any existing write access, or get rejected outright for sending an
-// unowned/zero OwnerID. This drives the actual cobra command
-// non-interactively against a mock server and asserts the wire request it
-// sends preserves Writers and OwnerID while only updating Readers.
-func TestSetGroupPreservesWriters(t *testing.T) {
+// accessBody mirrors the wire shape of a PUT .../access request.
+type accessBody struct {
+	OwnerID int32
+	Readers types.ACL
+	Writers types.ACL
+}
+
+// newAccessMockServer spins up a mock searchctrl server that returns existing
+// as the search's current state on GET and captures the body of the PUT
+// .../access call into the returned *accessBody. It wires connection.Client
+// to point at the mock server and registers cleanup with t.
+//
+// *sawAccessCall is set true iff a PUT .../access request was received.
+func newAccessMockServer(t *testing.T, existing types.SearchInfo) (got *accessBody, sawAccessCall *bool) {
+	t.Helper()
+
 	l, err := net.Listen("tcp", "[::1]:0")
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { l.Close() })
 
-	existingWriters := types.ACL{GIDs: []int32{99}}
-	const existingOwnerID = int32(42)
-
-	type accessBody struct {
-		OwnerID int32
-		Readers types.ACL
-		Writers types.ACL
-	}
-	var gotAccess accessBody
-	var sawAccessCall bool
+	got = &accessBody{}
+	sawAccessCall = new(bool)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/searchctrl/", func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet:
-			si := types.SearchInfo{}
-			si.OwnerID = existingOwnerID
-			si.Writers = existingWriters
-			if err := json.NewEncoder(w).Encode(si); err != nil {
+			if err := json.NewEncoder(w).Encode(existing); err != nil {
 				t.Errorf("failed to encode mock GetSearch response: %v", err)
 			}
 		case r.Method == http.MethodPut && strings.HasSuffix(r.URL.Path, "/access"):
-			sawAccessCall = true
-			if err := json.NewDecoder(r.Body).Decode(&gotAccess); err != nil {
+			*sawAccessCall = true
+			if err := json.NewDecoder(r.Body).Decode(got); err != nil {
 				t.Errorf("failed to decode access request body: %v", err)
 			}
 		default:
@@ -87,25 +83,175 @@ func TestSetGroupPreservesWriters(t *testing.T) {
 	connection.Client = c
 	t.Cleanup(func() { connection.Client = nil })
 
+	return got, sawAccessCall
+}
+
+// execute runs cmd non-interactively with args and fails the test if it errors.
+func execute(t *testing.T, cmd *cobra.Command, args []string) {
+	t.Helper()
 	var stderr bytes.Buffer
-	pair := setGroup()
-	pair.Action.SetOut(io.Discard)
-	pair.Action.SetErr(&stderr)
-	pair.Action.SetArgs([]string{"--groups=1,2", "search-123"})
-	if err := pair.Action.Execute(); err != nil {
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs(args)
+	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v (stderr: %s)", err, stderr.String())
 	}
+}
 
-	if !sawAccessCall {
+// TestSetAccessPreservesUnspecifiedFields is a regression test for
+// gravwell/issues#2680: setAccess() (formerly setGroup()) must only mutate
+// the fields explicitly named by flags. The SetAccess endpoint clobbers
+// OwnerID/Readers/Writers wholesale on every call, and setGroup() used to
+// build a fresh types.ACL{GIDs: GIDs} for Readers -- which silently zeroed
+// Readers.Global (and, per gravwell/issues#2708, would have zeroed
+// OwnerID/Writers too without the earlier fix). This drives the actual
+// cobra command non-interactively against a mock server and asserts the
+// wire request preserves everything except the one field actually targeted.
+func TestSetAccessPreservesUnspecifiedFields(t *testing.T) {
+	existing := types.SearchInfo{}
+	existing.OwnerID = 42
+	existing.Readers = types.ACL{GIDs: []int32{7}, Global: true}
+	existing.Writers = types.ACL{GIDs: []int32{99}, Global: true}
+
+	got, sawAccessCall := newAccessMockServer(t, existing)
+
+	execute(t, setAccess().Action, []string{"--reader-groups=1,2", "search-123"})
+
+	if !*sawAccessCall {
 		t.Fatal("expected a PUT .../access request, got none")
 	}
-	if gotAccess.OwnerID != existingOwnerID {
-		t.Errorf("OwnerID = %d, want unchanged %d", gotAccess.OwnerID, existingOwnerID)
+	if got.OwnerID != existing.OwnerID {
+		t.Errorf("OwnerID = %d, want unchanged %d", got.OwnerID, existing.OwnerID)
 	}
-	if !slices.Equal(gotAccess.Writers.GIDs, existingWriters.GIDs) {
-		t.Errorf("Writers.GIDs = %v, want unchanged %v", gotAccess.Writers.GIDs, existingWriters.GIDs)
+	if want := []int32{1, 2}; !slices.Equal(got.Readers.GIDs, want) {
+		t.Errorf("Readers.GIDs = %v, want %v", got.Readers.GIDs, want)
 	}
-	if want := []int32{1, 2}; !slices.Equal(gotAccess.Readers.GIDs, want) {
-		t.Errorf("Readers.GIDs = %v, want %v", gotAccess.Readers.GIDs, want)
+	if got.Readers.Global != existing.Readers.Global {
+		t.Errorf("Readers.Global = %v, want unchanged %v", got.Readers.Global, existing.Readers.Global)
+	}
+	if !slices.Equal(got.Writers.GIDs, existing.Writers.GIDs) {
+		t.Errorf("Writers.GIDs = %v, want unchanged %v", got.Writers.GIDs, existing.Writers.GIDs)
+	}
+	if got.Writers.Global != existing.Writers.Global {
+		t.Errorf("Writers.Global = %v, want unchanged %v", got.Writers.Global, existing.Writers.Global)
+	}
+}
+
+// TestSetAccessFlagsIndependently checks that each of set-access's four
+// flags mutates only its own field, leaving the other three (fetched from
+// the search's current state) untouched.
+func TestSetAccessFlagsIndependently(t *testing.T) {
+	base := func() types.SearchInfo {
+		si := types.SearchInfo{}
+		si.OwnerID = 10
+		si.Readers = types.ACL{GIDs: []int32{1}, Global: false}
+		si.Writers = types.ACL{GIDs: []int32{2}, Global: false}
+		return si
+	}
+
+	tests := []struct {
+		name string
+		arg  string
+		want accessBody
+	}{
+		{
+			name: "writer-groups",
+			arg:  "--writer-groups=5,6",
+			want: accessBody{OwnerID: 10, Readers: types.ACL{GIDs: []int32{1}}, Writers: types.ACL{GIDs: []int32{5, 6}}},
+		},
+		{
+			name: "reader-global",
+			arg:  "--reader-global",
+			want: accessBody{OwnerID: 10, Readers: types.ACL{GIDs: []int32{1}, Global: true}, Writers: types.ACL{GIDs: []int32{2}}},
+		},
+		{
+			name: "writer-global",
+			arg:  "--writer-global",
+			want: accessBody{OwnerID: 10, Readers: types.ACL{GIDs: []int32{1}}, Writers: types.ACL{GIDs: []int32{2}, Global: true}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, sawAccessCall := newAccessMockServer(t, base())
+
+			execute(t, setAccess().Action, []string{tt.arg, "search-123"})
+
+			if !*sawAccessCall {
+				t.Fatal("expected a PUT .../access request, got none")
+			}
+			if got.OwnerID != tt.want.OwnerID {
+				t.Errorf("OwnerID = %d, want %d", got.OwnerID, tt.want.OwnerID)
+			}
+			if !slices.Equal(got.Readers.GIDs, tt.want.Readers.GIDs) {
+				t.Errorf("Readers.GIDs = %v, want %v", got.Readers.GIDs, tt.want.Readers.GIDs)
+			}
+			if got.Readers.Global != tt.want.Readers.Global {
+				t.Errorf("Readers.Global = %v, want %v", got.Readers.Global, tt.want.Readers.Global)
+			}
+			if !slices.Equal(got.Writers.GIDs, tt.want.Writers.GIDs) {
+				t.Errorf("Writers.GIDs = %v, want %v", got.Writers.GIDs, tt.want.Writers.GIDs)
+			}
+			if got.Writers.Global != tt.want.Writers.Global {
+				t.Errorf("Writers.Global = %v, want %v", got.Writers.Global, tt.want.Writers.Global)
+			}
+		})
+	}
+}
+
+// TestSetAccessNoFlagsIsANoop confirms that calling set-access with no
+// access flags at all round-trips the search's existing state unchanged
+// (rather than, say, defaulting any field to its zero value).
+func TestSetAccessNoFlagsIsANoop(t *testing.T) {
+	existing := types.SearchInfo{}
+	existing.OwnerID = 7
+	existing.Readers = types.ACL{GIDs: []int32{1, 2}, Global: true}
+	existing.Writers = types.ACL{GIDs: []int32{3}, Global: false}
+
+	got, sawAccessCall := newAccessMockServer(t, existing)
+
+	execute(t, setAccess().Action, []string{"search-123"})
+
+	if !*sawAccessCall {
+		t.Fatal("expected a PUT .../access request, got none")
+	}
+	if got.OwnerID != existing.OwnerID {
+		t.Errorf("OwnerID = %d, want unchanged %d", got.OwnerID, existing.OwnerID)
+	}
+	if !slices.Equal(got.Readers.GIDs, existing.Readers.GIDs) || got.Readers.Global != existing.Readers.Global {
+		t.Errorf("Readers = %+v, want unchanged %+v", got.Readers, existing.Readers)
+	}
+	if !slices.Equal(got.Writers.GIDs, existing.Writers.GIDs) || got.Writers.Global != existing.Writers.Global {
+		t.Errorf("Writers = %+v, want unchanged %+v", got.Writers, existing.Writers)
+	}
+}
+
+// TestSetAccessGroupAlias confirms the old "set-groups" command name still
+// resolves to set-access when dispatched by name (rather than invoked
+// directly), so existing scripts/muscle memory keep working after the
+// setGroup -> setAccess rename. Dispatched through a bare parent command
+// rather than the real queries.NewNav() tree, since NewNav() pulls in
+// sibling actions (e.g. info()) that panic outside of full CLI bootstrap
+// due to unrelated uninitialized global state (clilog.Writer).
+func TestSetAccessGroupAlias(t *testing.T) {
+	existing := types.SearchInfo{}
+	existing.OwnerID = 1
+	existing.Writers = types.ACL{GIDs: []int32{9}}
+
+	got, sawAccessCall := newAccessMockServer(t, existing)
+
+	root := &cobra.Command{Use: "root"}
+	group.AddActionGroup(root)
+	root.AddCommand(setAccess().Action)
+	execute(t, root, []string{"set-groups", "--reader-groups=1,2", "search-123"})
+
+	if !*sawAccessCall {
+		t.Fatal("expected a PUT .../access request, got none")
+	}
+	if want := []int32{1, 2}; !slices.Equal(got.Readers.GIDs, want) {
+		t.Errorf("Readers.GIDs = %v, want %v", got.Readers.GIDs, want)
+	}
+	if !slices.Equal(got.Writers.GIDs, existing.Writers.GIDs) {
+		t.Errorf("Writers.GIDs = %v, want unchanged %v", got.Writers.GIDs, existing.Writers.GIDs)
 	}
 }

--- a/gwcli/tree/queries/queries_test.go
+++ b/gwcli/tree/queries/queries_test.go
@@ -199,30 +199,31 @@ func TestSetAccessFlagsIndependently(t *testing.T) {
 	}
 }
 
-// TestSetAccessNoFlagsIsANoop confirms that calling set-access with no
-// access flags at all round-trips the search's existing state unchanged
-// (rather than, say, defaulting any field to its zero value).
-func TestSetAccessNoFlagsIsANoop(t *testing.T) {
+// TestSetAccessNoFlagsErrors is a regression test for a PR review comment on
+// gravwell/issues#2680: running set-access with zero access flags used to
+// silently perform a no-op PUT .../access and report "updated access for
+// search xxx" even though nothing changed -- and in interactive mode, it
+// would walk the user through picking searches first, only to no-op. It must
+// now fail validation before ever touching the network (or, interactively,
+// before ever showing the search picker).
+func TestSetAccessNoFlagsErrors(t *testing.T) {
 	existing := types.SearchInfo{}
 	existing.OwnerID = 7
 	existing.Readers = types.ACL{GIDs: []int32{1, 2}, Global: true}
 	existing.Writers = types.ACL{GIDs: []int32{3}, Global: false}
 
-	got, sawAccessCall := newAccessMockServer(t, existing)
+	_, sawAccessCall := newAccessMockServer(t, existing)
 
-	execute(t, setAccess().Action, []string{"search-123"})
-
-	if !*sawAccessCall {
-		t.Fatal("expected a PUT .../access request, got none")
+	var stderr bytes.Buffer
+	pair := setAccess()
+	pair.Action.SetOut(io.Discard)
+	pair.Action.SetErr(&stderr)
+	pair.Action.SetArgs([]string{"search-123"})
+	if err := pair.Action.Execute(); err == nil {
+		t.Fatal("expected an error when no access flags are given, got nil")
 	}
-	if got.OwnerID != existing.OwnerID {
-		t.Errorf("OwnerID = %d, want unchanged %d", got.OwnerID, existing.OwnerID)
-	}
-	if !slices.Equal(got.Readers.GIDs, existing.Readers.GIDs) || got.Readers.Global != existing.Readers.Global {
-		t.Errorf("Readers = %+v, want unchanged %+v", got.Readers, existing.Readers)
-	}
-	if !slices.Equal(got.Writers.GIDs, existing.Writers.GIDs) || got.Writers.Global != existing.Writers.Global {
-		t.Errorf("Writers = %+v, want unchanged %+v", got.Writers, existing.Writers)
+	if *sawAccessCall {
+		t.Error("expected no PUT .../access request, but one was sent")
 	}
 }
 


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses https://github.com/gravwell/gravwell/issues/2680

## This PR proposes...

- updates `gwcli` to allow setting global and readers/writers the same way the API does, allowing full support of that endpoint

## PR Tasks

<!-- Add tasks to this list as needed -->

- [x] e2e and/or unit tests included. If not, please provide an explanation.
- [ ] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
