### PR TITLE
fix(ingesters/kinesis): fail fast on cancellation and honor shutdowns everywhere

### DIFF
--- a/ingesters/KinesisIngester/main.go
+++ b/ingesters/KinesisIngester/main.go
@@ -273,13 +273,17 @@ func main() {
 					output, err := svc.GetShardIterator(ctx, gsii)
 					if err != nil {
 						_ = lg.Error("error on shard", log.KV("number", shardid), log.KV("stream", stream.Stream_Name), log.KV("shard", *shard.ShardId), log.KVErr(err))
-						utils.QuitableSleep(ctx, 5*time.Second)
+						if utils.QuitableSleep(ctx, 5*time.Second) {
+							break reconnectLoop
+						}
 						continue
 					}
 					if output.ShardIterator == nil {
 						// this is weird, we are going to bail out
 						_ = lg.Error("got nil initial shard iterator, sleeping and retrying")
-						utils.QuitableSleep(ctx, 5*time.Second)
+						if utils.QuitableSleep(ctx, 5*time.Second) {
+							break reconnectLoop
+						}
 						continue
 					}
 					iter := *output.ShardIterator
@@ -300,27 +304,45 @@ func main() {
 								}
 							}
 							if err != nil {
+								if ctx.Err() != nil {
+									// Shut down, stop retrying and let the goroutine exit.
+									break reconnectLoop
+								}
+
 								var throughputErr *types.ProvisionedThroughputExceededException
 								var iteratorErr *types.ExpiredIteratorException
+
 								switch {
 								case errors.As(err, &throughputErr):
 									_ = lg.Warn("throughput exceeded, trying again", log.KV("shard", *shard.ShardId), log.KV("stream",
 										stream.Stream_Name))
-									utils.QuitableSleep(ctx, 500*time.Millisecond)
+
+									if utils.QuitableSleep(ctx, 500*time.Millisecond) {
+										break reconnectLoop
+									}
 								case errors.As(err, &iteratorErr):
 									_ = lg.Info("Iterator expired, re-initializing", log.KV("shard", *shard.ShardId), log.KV("stream",
 										stream.Stream_Name))
-									utils.QuitableSleep(ctx, 100*time.Millisecond)
+
+									if utils.QuitableSleep(ctx, 100*time.Millisecond) {
+										break reconnectLoop
+									}
+
 									continue reconnectLoop
 								default:
 									_ = lg.Error("answer error", log.KVErr(err), log.KV("shard", *shard.ShardId), log.KV("stream",
 										stream.Stream_Name))
-									utils.QuitableSleep(ctx, 500*time.Millisecond)
+
+									if utils.QuitableSleep(ctx, 500*time.Millisecond) {
+										break reconnectLoop
+									}
 								}
 							} else {
 								// if we got no records, chill for a sec before we hit it again
 								if len(res.Records) == 0 {
-									utils.QuitableSleep(ctx, 100*time.Millisecond)
+									if utils.QuitableSleep(ctx, 100*time.Millisecond) {
+										break reconnectLoop
+									}
 								}
 								break
 							}

--- a/ingesters/KinesisIngester/main.go
+++ b/ingesters/KinesisIngester/main.go
@@ -422,17 +422,7 @@ func main() {
 		cancel()
 	}()
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		wg.Wait()
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(utils.ExitSyncTimeout):
-		lg.Error("timed out waiting for shard goroutines to exit, forcing shutdown")
-	}
+	wg.Wait()
 }
 
 func debugout(format string, args ...any) {

--- a/ingesters/KinesisIngester/main.go
+++ b/ingesters/KinesisIngester/main.go
@@ -262,6 +262,11 @@ func main() {
 				if err != nil {
 					lg.Fatal("preprocessor construction error", log.KVErr(err))
 				}
+				defer func() {
+					if cerr := procset.Close(); cerr != nil {
+						lg.Error("Failed to close processor set", log.KVErr(cerr))
+					}
+				}()
 
 				// make the shardMetrics and add it to the array
 				tracker := shardMetrics{}
@@ -400,9 +405,7 @@ func main() {
 							stateMan.UpdateSequenceNum(stream.Stream_Name, *shard.ShardId, lastSeqNum)
 						}
 					}
-					if err = procset.Close(); err != nil {
-						lg.Error("Failed to close processor set", log.KVErr(err))
-					}
+
 					// if we get to this point, exit the for loop
 					break
 				}

--- a/ingesters/KinesisIngester/main.go
+++ b/ingesters/KinesisIngester/main.go
@@ -157,7 +157,12 @@ func main() {
 		debugout("Read %d shards from stream %s\n", len(shards), stream.Stream_Name)
 
 		// Now start up the metrics reporter
+		// metricsTracker is written concurrently by every per-shard goroutine via append
+		// and read concurrently by the reporter goroutine below, so it MUST be guarded
+		// by a mutex to avoid race conditions.
 		var metricsTrackers []*shardMetrics
+		var metricsTrackersMu sync.Mutex
+
 		if stream.Metrics_Interval > 0 {
 			go func(stream streamDef) {
 				for {
@@ -165,15 +170,27 @@ func main() {
 					case <-dieChan:
 						return
 					case <-time.After(time.Duration(stream.Metrics_Interval) * time.Second):
+						metricsTrackersMu.Lock()
+						trackers := make([]*shardMetrics, len(metricsTrackers))
+						copy(trackers, metricsTrackers)
+						metricsTrackersMu.Unlock()
+
 						report := metricsReport{StreamName: stream.Stream_Name, ShardCount: len(shards)}
-						for i := range metricsTrackers {
-							l, b, e, r := metricsTrackers[i].ReadAndReset()
+						for i := range trackers {
+							l, b, e, r := trackers[i].ReadAndReset()
 							report.AverageLag += l
 							report.CompressedDataSize += b
 							report.EntryDataSize += e
 							report.KinesisRequests += r
 						}
-						report.AverageLag = report.AverageLag / int64(len(metricsTrackers))
+
+						// Avoid a divide-by-zero panic if the ticker fires
+						// before any shard goroutine has registered a tracker
+						// or if the stream currently has zero open shards.
+						if len(trackers) > 0 {
+							report.AverageLag = report.AverageLag / int64(len(trackers))
+						}
+
 						if stream.JSON_Metrics {
 							jr, err := json.Marshal(report)
 							if err == nil {
@@ -248,7 +265,11 @@ func main() {
 
 				// make the shardMetrics and add it to the array
 				tracker := shardMetrics{}
+
+				metricsTrackersMu.Lock()
 				metricsTrackers = append(metricsTrackers, &tracker)
+				metricsTrackersMu.Unlock()
+
 				if stream.Metrics_Interval == 0 {
 					// disable it
 					tracker.Disabled = true

--- a/ingesters/KinesisIngester/main.go
+++ b/ingesters/KinesisIngester/main.go
@@ -50,7 +50,6 @@ func main() {
 
 	var wg sync.WaitGroup
 	var cfg *cfgType
-	running := true
 
 	ibc := base.IngesterBaseConfig{
 		IngesterName:                 appName,
@@ -315,7 +314,7 @@ func main() {
 					iter := *output.ShardIterator
 
 					var lastSeqNum string
-					for running {
+					for ctx.Err() == nil {
 						gri := &kinesis.GetRecordsInput{
 							Limit:         new(int32(5000)),
 							ShardIterator: new(iter),
@@ -416,7 +415,6 @@ func main() {
 	utils.WaitForQuit()
 	ib.AnnounceShutdown()
 
-	running = false
 	close(dieChan)
 
 	go func() {
@@ -424,7 +422,17 @@ func main() {
 		cancel()
 	}()
 
-	wg.Wait()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		wg.Wait()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(utils.ExitSyncTimeout):
+		lg.Error("timed out waiting for shard goroutines to exit, forcing shutdown")
+	}
 }
 
 func debugout(format string, args ...any) {

--- a/ingesters/KinesisIngester/main.go
+++ b/ingesters/KinesisIngester/main.go
@@ -142,7 +142,10 @@ func main() {
 					// give up and LOUDLY quit
 					lg.Fatal("giving up fetch stream description for stream after 5 attempts, exiting.", log.KV("stream", stream.Stream_Name))
 				}
-				utils.QuitableSleep(ctx, 1*time.Second)
+				if utils.QuitableSleep(ctx, 1*time.Second) {
+					// Context has been cancelled. Let's bail out so cleanup can happen.
+					return
+				}
 				continue
 			}
 			newshards := streamdesc.StreamDescription.Shards

--- a/ingesters/KinesisIngester/main.go
+++ b/ingesters/KinesisIngester/main.go
@@ -273,14 +273,14 @@ func main() {
 				// make the shardMetrics and add it to the array
 				tracker := shardMetrics{}
 
-				metricsTrackersMu.Lock()
-				metricsTrackers = append(metricsTrackers, &tracker)
-				metricsTrackersMu.Unlock()
-
 				if stream.Metrics_Interval == 0 {
 					// disable it
 					tracker.Disabled = true
 				}
+
+				metricsTrackersMu.Lock()
+				metricsTrackers = append(metricsTrackers, &tracker)
+				metricsTrackersMu.Unlock()
 
 			reconnectLoop:
 				for {

--- a/ingesters/KinesisIngester/main.go
+++ b/ingesters/KinesisIngester/main.go
@@ -420,6 +420,7 @@ func main() {
 
 	close(dieChan)
 
+	// stop outstanding writes in 1 second while we wait
 	go func() {
 		time.Sleep(time.Second)
 		cancel()


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses https://github.com/gravwell/gravwell/issues/2739

### Cause of the Bug

The Kinesis ingester spins up one goroutine _per Kinesis shard_ that all share a single `context.Context`. When the ingester shuts down via `SIGINT|SIGTERM|SIGQUIT` we call `cancel()` on that context. Any shard goroutine that is in the middle of a retry when this cancellation happens will get a `context.Canceled` error back from the `GetRecords` API call. After we log this error, we sleep via `utils.QuittableSleep` but **never checked if that sleep returned because of a context cancellation** and never checked `ctx.Err()` before retrying. This causes the goroutine to immediately retry the `GetRecords` API call again, causing the same error, log, repeat. `wg.Done()` never fired, so `main` never exited. 

There are some other high priority fixes in here revolving around race conditions as well (see below).

## This PR proposes...

- failing fast on context cancellation instead of spinning forever
- fixing a race condition around `metricsTracker` by guarding with a mutex
- fixing a race condition around `running` that's not synced by removing it in favor of `ctx.Err() == nil`
- bounding `wg.Wait()` with `utils.SyncExitTimeout`
- fixing a possible divide by zero error on stats counting

## PR Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e and/or unit tests included. If not, please provide an explanation.
  - The Kinesis ingester is not readily testable via e2e or unit tests. We should follow up on this and make it testable (not in this pr to avoid scope creep) 
- [ ] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
