### PR TITLE
fix(#2648): Make Min Max optional in gauge

### DIFF
--- a/client/types/table.go
+++ b/client/types/table.go
@@ -38,8 +38,8 @@ type TableResponse struct {
 type GaugeValue struct {
 	Name      string
 	Magnitude float64
-	Min       float64
-	Max       float64
+	Min       Optional[float64]
+	Max       Optional[float64]
 }
 
 type GaugeRequest struct {


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses https://github.com/gravwell/issues/issues/2648


> [!WARNING]  
> Please review this PR along with https://github.com/gravwell/backend/pull/4480 . The backend PR should be merged soon after this PR is merged.

## This PR proposes...

- Makes Min and Max optional in GaugeValue

## PR Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e and/or unit tests included. If not, please provide an explanation.
- [ ] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
