### PR TITLE
hotfix(issues#1467): use compatibility options in v2 encoder

### DIFF
--- a/client/types/render.go
+++ b/client/types/render.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gravwell/gravwell/v4/ingest"
 	"github.com/gravwell/gravwell/v4/ingest/entry"
+	"github.com/gravwell/gravwell/v4/utils/jsoncompat"
 )
 
 const (
@@ -602,11 +603,11 @@ func (ee emptyPrintableEntries) MarshalJSON() ([]byte, error) {
 	for _, v := range ([]SearchEntry)(ee) {
 		pse = append(pse, PrintableSearchEntry(v))
 	}
-	return json.Marshal(pse)
+	return json.Marshal(pse, jsoncompat.Opts)
 }
 
 func (r RawResponse) MarshalJSON() ([]byte, error) {
-	base, err := json.Marshal(r.BaseResponse)
+	base, err := json.Marshal(r.BaseResponse, jsoncompat.Opts)
 	if err != nil {
 		return nil, err
 	}
@@ -623,7 +624,7 @@ func (r RawResponse) MarshalJSON() ([]byte, error) {
 			ContainsBinaryEntries: r.ContainsBinaryEntries,
 			Entries:               emptyPrintableEntries(r.Entries),
 			Explore:               r.Explore,
-		})
+		}, jsoncompat.Opts)
 	} else {
 		e, err = json.Marshal(&struct {
 			ContainsBinaryEntries bool //just a flag to tell the GUI that we might have data that needs some help
@@ -633,7 +634,7 @@ func (r RawResponse) MarshalJSON() ([]byte, error) {
 			ContainsBinaryEntries: r.ContainsBinaryEntries,
 			Entries:               r.Entries,
 			Explore:               r.Explore,
-		})
+		}, jsoncompat.Opts)
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses https://github.com/gravwell/issues/issues/1467.

## This PR makes some problematic types leverage the new compatibility options

I have a PR in the works to leverage JSON/v2 substantially more in order to support []/{} instead of null. The PATCH PRs (https://github.com/gravwell/gravwell/pull/2728 and https://github.com/gravwell/backend/pull/4469) introduced JSON/v2, but not in a particularly clean way.

This PR is just to fix a failing e2e test.

## PR Tasks

<!-- Add tasks to this list as needed -->

- [x] e2e and/or unit tests included. If not, please provide an explanation.
- [x] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
