### PR TITLE
Plugin: Add separate tag per section feature

### DIFF
--- a/hosted/plugins/jamf/client_test.go
+++ b/hosted/plugins/jamf/client_test.go
@@ -1,3 +1,11 @@
+/*************************************************************************
+ * Copyright 2026 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
 package jamf
 
 import (

--- a/hosted/plugins/jamf/config.go
+++ b/hosted/plugins/jamf/config.go
@@ -18,11 +18,13 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"slices"
 
 	"github.com/gravwell/gravwell/v3/hosted"
 )
 
 const (
+	defaultIngesterUUIDStr string = "7e468cc4-ab10-4b33-b066-90eb4905980b"
 	defaultTagPrefix         = `jamf`
 	defaultPageSize          = 100
 	defaultLookback          = 1   // hours
@@ -60,7 +62,27 @@ type Config struct {
 	Insecure_Skip_TLS_Verify bool
 }
 
+// Equal implements hosted.Config so the runner can decide whether a config reload
+// actually changed anything for this ingester.
+func (c *Config) Equal(ncp any) bool {
+	nc, ok := hosted.EqualTarget[Config](ncp)
+	if c == nil || !ok {
+		return false
+	}
+	return c.BaseConfig == nc.BaseConfig &&
+		c.Tag_Prefix == c.Tag_Prefix &&
+		c.PollingConfig == nc.PollingConfig &&
+		c.Host == nc.Host &&
+		c.Client_Id == nc.Client_Id &&
+		c.Client_Secret == nc.Client_Secret &&
+		c.Page_Size == nc.Page_Size &&
+		c.Insecure_Skip_TLS_Verify == nc.Insecure_Skip_TLS_Verify &&
+		slices.Equal(c.Sections, nc.Sections)
+}
+
 func (c *Config) Verify() error {
+	c.ApplyDefaultIngesterUUID(defaultIngesterUUIDStr)
+
 	if c.Host == "" {
 		return errors.New("Host not specified")
 	}

--- a/hosted/plugins/jamf/config.go
+++ b/hosted/plugins/jamf/config.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	defaultIngesterUUIDStr string = "7e468cc4-ab10-4b33-b066-90eb4905980b"
+	defaultIngesterUUIDStr   = "7e468cc4-ab10-4b33-b066-90eb4905980b"
 	defaultTagPrefix         = `jamf`
 	defaultPageSize          = 100
 	defaultLookback          = 1   // hours
@@ -70,7 +70,7 @@ func (c *Config) Equal(ncp any) bool {
 		return false
 	}
 	return c.BaseConfig == nc.BaseConfig &&
-		c.Tag_Prefix == c.Tag_Prefix &&
+		c.Tag_Prefix == nc.Tag_Prefix &&
 		c.PollingConfig == nc.PollingConfig &&
 		c.Host == nc.Host &&
 		c.Client_Id == nc.Client_Id &&

--- a/hosted/plugins/jamf/config.go
+++ b/hosted/plugins/jamf/config.go
@@ -62,6 +62,8 @@ type Config struct {
 	Insecure_Skip_TLS_Verify bool
 }
 
+var _ hosted.Config = (*Config)(nil) // compile time interface check
+
 // Equal implements hosted.Config so the runner can decide whether a config reload
 // actually changed anything for this ingester.
 func (c *Config) Equal(ncp any) bool {
@@ -71,6 +73,7 @@ func (c *Config) Equal(ncp any) bool {
 	}
 	return c.BaseConfig == nc.BaseConfig &&
 		c.Tag_Prefix == nc.Tag_Prefix &&
+		c.MultiTagConfig == nc.MultiTagConfig &&
 		c.PollingConfig == nc.PollingConfig &&
 		c.Host == nc.Host &&
 		c.Client_Id == nc.Client_Id &&

--- a/hosted/plugins/jamf/config.go
+++ b/hosted/plugins/jamf/config.go
@@ -8,43 +8,47 @@
 
 // Package jamf is a hosted ingester plugin that polls the Jamf Pro API's
 // computers-inventory endpoint for records that were modified in a given
-// time window, using general.reportDate as the tracking cursor.
+// time window, using general.reportDate as the tracking cursor. Each
+// configured section is emitted to its own tag, with the GENERAL section's
+// data folded into every entry for context.
 package jamf
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/gravwell/gravwell/v3/hosted"
 )
 
 const (
-	defaultIngesterUUIDStr string = "7e468cc4-ab10-4b33-b066-90eb4905980b"
-
-	defaultTag               = `jamf`
+	defaultTagPrefix         = `jamf`
 	defaultPageSize          = 100
 	defaultLookback          = 1   // hours
 	defaultRequestsPerMinute = 60  // token bucket for the inventory + oauth calls
 	defaultInterval          = 600 // seconds (10 minutes)
 
-	// PollBufferSeconds keeps the window from reaching all the way up to
+	// pollBufferSeconds keeps the window from reaching all the way up to
 	// "now", since Jamf can take a few seconds to finish writing a record
 	// after a device checks in. Without this, records near the trailing
 	// edge of a window could be missed entirely.
 	pollBufferSeconds = 60
 )
 
-const sectionGeneral string = "GENERAL"
+// generalSectionName is the Jamf computers-inventory section that's always
+// requested (for reportDate/id) and folded into every other section's
+// entry. It only needs a place in Sections if you also want a dedicated
+// general-only stream.
+const generalSectionName = "GENERAL"
 
-// Sections lists the computers-inventory sections we'll request if the
-// config doesn't specify any explicitly.
-var defaultSections = []string{sectionGeneral}
+// defaultSections lists the computers-inventory sections we request data
+// for, and emit a separate tag for, if the config doesn't specify any.
+var defaultSections = []string{"DISK_ENCRYPTION", "STORAGE"}
 
 type Config struct {
 	hosted.BaseConfig
-	hosted.SingleTagConfig
+	hosted.MultiTagConfig
 	hosted.PollingConfig
 
 	Host          string
@@ -56,29 +60,7 @@ type Config struct {
 	Insecure_Skip_TLS_Verify bool
 }
 
-var _ hosted.Config = (*Config)(nil) // compile time interface check
-
-// Equal implements hosted.Config so the runner can decide whether a config reload
-// actually changed anything for this ingester.
-func (c *Config) Equal(ncp any) bool {
-	nc, ok := hosted.EqualTarget[Config](ncp)
-	if c == nil || !ok {
-		return false
-	}
-	return c.BaseConfig == nc.BaseConfig &&
-		c.SingleTagConfig == nc.SingleTagConfig &&
-		c.PollingConfig == nc.PollingConfig &&
-		c.Host == nc.Host &&
-		c.Client_Id == nc.Client_Id &&
-		c.Client_Secret == nc.Client_Secret &&
-		c.Page_Size == nc.Page_Size &&
-		c.Insecure_Skip_TLS_Verify == nc.Insecure_Skip_TLS_Verify &&
-		slices.Equal(c.Sections, nc.Sections)
-}
-
 func (c *Config) Verify() error {
-	c.ApplyDefaultIngesterUUID(defaultIngesterUUIDStr)
-
 	if c.Host == "" {
 		return errors.New("Host not specified")
 	}
@@ -97,11 +79,21 @@ func (c *Config) Verify() error {
 		return fmt.Errorf("Page-Size %d is too large, must be <= 1000", c.Page_Size)
 	}
 
-	// GENERAL should _always_ be in c.Sections.
 	if len(c.Sections) == 0 {
-		c.Sections = defaultSections
-	} else if !slices.Contains(c.Sections, sectionGeneral) {
-		c.Sections = append(c.Sections, sectionGeneral)
+		c.Sections = append([]string{}, defaultSections...)
+	}
+	for i, s := range c.Sections {
+		c.Sections[i] = strings.ToUpper(strings.TrimSpace(s))
+	}
+	if dup := firstDuplicate(c.Sections); dup != "" {
+		return fmt.Errorf("Sections lists %q more than once", dup)
+	}
+
+	if err := c.MultiTagConfig.ValidateTags(); err != nil {
+		return err
+	}
+	if c.Tag_Name != "" && len(c.Sections) > 1 {
+		return errors.New("Tag-Name can only be used with a single Sections entry; use Tag-Prefix instead")
 	}
 
 	c.PollingConfig.ApplyDefaults(defaultLookback, defaultRequestsPerMinute, defaultInterval)
@@ -109,6 +101,50 @@ func (c *Config) Verify() error {
 	return nil
 }
 
+func firstDuplicate(vals []string) string {
+	seen := make(map[string]bool, len(vals))
+	for _, v := range vals {
+		if seen[v] {
+			return v
+		}
+		seen[v] = true
+	}
+	return ""
+}
+
+// requestSections returns the full set of Jamf inventory sections to
+// request from the API for a page: every configured section plus GENERAL
+// (deduplicated). GENERAL is always requested since it carries the
+// reportDate/id used for every emitted entry, regardless of whether the
+// operator listed it explicitly in Sections.
+func (c *Config) requestSections() []string {
+	out := make([]string, 0, len(c.Sections)+1)
+	out = append(out, generalSectionName)
+	for _, s := range c.Sections {
+		if s != generalSectionName {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// tagForSection returns the tag that a configured section's entries should
+// be written under: Tag-Name verbatim if set (only valid for a single
+// configured section), otherwise "<Tag-Prefix or 'jamf'>_<section, lowercased>".
+func (c *Config) tagForSection(section string) string {
+	if c.Tag_Name != "" {
+		return c.Tag_Name
+	}
+	prefix := cmp.Or(c.Tag_Prefix, defaultTagPrefix)
+	return prefix + "_" + strings.ToLower(section)
+}
+
+// Tags returns every tag this plugin instance can write to, one per
+// configured section.
 func (c *Config) Tags() []string {
-	return []string{c.ResolveTag(defaultTag)}
+	tags := make([]string, 0, len(c.Sections))
+	for _, s := range c.Sections {
+		tags = append(tags, c.tagForSection(s))
+	}
+	return tags
 }

--- a/hosted/plugins/jamf/config_test.go
+++ b/hosted/plugins/jamf/config_test.go
@@ -9,13 +9,14 @@
 package jamf
 
 import (
-	"slices"
+	"reflect"
 	"testing"
 
 	"github.com/gravwell/gravwell/v3/hosted"
-	"github.com/gravwell/gravwell/v3/hosted/configtest"
 )
 
+// TestConfig_Verify checks the required-field, Page-Size, duplicate-section,
+// and Tag-Name/Tag-Prefix validation rules enforced by Config.Verify.
 func TestConfig_Verify(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -46,9 +47,44 @@ func TestConfig_Verify(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "duplicate section",
+			config: Config{
+				Host: "https://jamf.example.com", Client_Id: "id", Client_Secret: "secret",
+				Sections: []string{"APPLICATIONS", "applications"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "tag name with multiple sections",
+			config: Config{
+				Host: "https://jamf.example.com", Client_Id: "id", Client_Secret: "secret",
+				Sections:       []string{"APPLICATIONS", "STORAGE"},
+				MultiTagConfig: hosted.MultiTagConfig{Tag_Name: "combined"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "tag name and tag prefix together",
+			config: Config{
+				Host: "https://jamf.example.com", Client_Id: "id", Client_Secret: "secret",
+				Sections:       []string{"APPLICATIONS"},
+				MultiTagConfig: hosted.MultiTagConfig{Tag_Name: "combined", Tag_Prefix: "custom"},
+			},
+			wantErr: true,
+		},
+		{
 			name: "valid minimal config",
 			config: Config{
 				Host: "https://jamf.example.com/", Client_Id: "id", Client_Secret: "secret",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid single section with tag name",
+			config: Config{
+				Host: "https://jamf.example.com", Client_Id: "id", Client_Secret: "secret",
+				Sections:       []string{"APPLICATIONS"},
+				MultiTagConfig: hosted.MultiTagConfig{Tag_Name: "jamf_apps"},
 			},
 			wantErr: false,
 		},
@@ -75,44 +111,57 @@ func TestConfig_Verify_Defaults(t *testing.T) {
 	if c.Page_Size != defaultPageSize {
 		t.Errorf("expected default page size %d, got %d", defaultPageSize, c.Page_Size)
 	}
-	if !slices.Equal(c.Sections, defaultSections) {
+	if !reflect.DeepEqual(c.Sections, defaultSections) {
 		t.Errorf("expected default sections %v, got %v", defaultSections, c.Sections)
-	}
-	if got := c.Tags(); len(got) != 1 || got[0] != defaultTag {
-		t.Errorf("expected default tag %q, got %v", defaultTag, got)
 	}
 }
 
-func TestConfig_Verify_Sections(t *testing.T) {
+func TestConfig_Verify_NormalizesSectionCase(t *testing.T) {
+	c := Config{
+		Host: "https://jamf.example.com", Client_Id: "id", Client_Secret: "secret",
+		Sections: []string{" applications ", "Disk_Encryption"},
+	}
+	if err := c.Verify(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"APPLICATIONS", "DISK_ENCRYPTION"}
+	if !reflect.DeepEqual(c.Sections, want) {
+		t.Errorf("expected normalized sections %v, got %v", want, c.Sections)
+	}
+}
+
+// TestConfig_Tags checks tag derivation: one tag per configured section by
+// default, a Tag-Prefix override, and a Tag-Name override for the
+// single-section case.
+func TestConfig_Tags(t *testing.T) {
 	tests := []struct {
-		name         string
-		sections     []string
-		wantSections []string
+		name     string
+		sections []string
+		tagName  string
+		prefix   string
+		want     []string
 	}{
 		{
-			name:         "nil sections get GENERAL defaults",
-			sections:     nil,
-			wantSections: defaultSections,
+			name:     "default prefix",
+			sections: []string{"APPLICATIONS", "STORAGE"},
+			want:     []string{"jamf_applications", "jamf_storage"},
 		},
 		{
-			name:         "empty sections get GENERAL defaults",
-			sections:     []string{},
-			wantSections: defaultSections,
+			name:     "custom prefix",
+			sections: []string{"APPLICATIONS"},
+			prefix:   "utad",
+			want:     []string{"utad_applications"},
 		},
 		{
-			name:         "user sections without GENERAL get it appended",
-			sections:     []string{"STORAGE"},
-			wantSections: []string{"STORAGE", sectionGeneral},
+			name:     "tag name override for single section",
+			sections: []string{"APPLICATIONS"},
+			tagName:  "jamf_apps_custom",
+			want:     []string{"jamf_apps_custom"},
 		},
 		{
-			name:         "user sections already containing GENERAL are unchanged",
-			sections:     []string{sectionGeneral, "STORAGE"},
-			wantSections: []string{sectionGeneral, "STORAGE"},
-		},
-		{
-			name:         "user sections with GENERAL not first are unchanged",
-			sections:     []string{"STORAGE", sectionGeneral, "DISK_ENCRYPTION"},
-			wantSections: []string{"STORAGE", sectionGeneral, "DISK_ENCRYPTION"},
+			name:     "general included explicitly",
+			sections: []string{"GENERAL", "APPLICATIONS"},
+			want:     []string{"jamf_general", "jamf_applications"},
 		},
 	}
 
@@ -120,45 +169,43 @@ func TestConfig_Verify_Sections(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := Config{
 				Host: "https://jamf.example.com", Client_Id: "id", Client_Secret: "secret",
-				Sections: tt.sections,
+				Sections:       tt.sections,
+				MultiTagConfig: hosted.MultiTagConfig{Tag_Name: tt.tagName, Tag_Prefix: tt.prefix},
 			}
 			if err := c.Verify(); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if !slices.Equal(c.Sections, tt.wantSections) {
-				t.Errorf("Sections = %v, want %v", c.Sections, tt.wantSections)
-			}
-			if !slices.Contains(c.Sections, sectionGeneral) {
-				t.Errorf("Sections %v does not contain %q", c.Sections, sectionGeneral)
-			}
-			// Guard against GENERAL being duplicated by a broken slices.Contains check.
-			var generalCount int
-			for _, s := range c.Sections {
-				if s == sectionGeneral {
-					generalCount++
-				}
-			}
-			if generalCount != 1 {
-				t.Errorf("Sections %v contains %q %d times, want exactly 1", c.Sections, sectionGeneral, generalCount)
+			if got := c.Tags(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("expected tags %v, got %v", tt.want, got)
 			}
 		})
 	}
 }
 
-func TestConfigEqual(t *testing.T) {
-	configtest.CheckEqual(t, Config{
-		BaseConfig:      hosted.BaseConfig{Ingester_UUID: defaultIngesterUUIDStr},
-		SingleTagConfig: hosted.SingleTagConfig{Tag_Name: defaultTag},
-		PollingConfig: hosted.PollingConfig{
-			Lookback:            defaultLookback,
-			Requests_Per_Minute: defaultRequestsPerMinute,
-			Request_Interval:    defaultInterval,
+func TestConfig_RequestSections(t *testing.T) {
+	tests := []struct {
+		name     string
+		sections []string
+		want     []string
+	}{
+		{
+			name:     "general added when absent",
+			sections: []string{"APPLICATIONS", "STORAGE"},
+			want:     []string{"GENERAL", "APPLICATIONS", "STORAGE"},
 		},
-		Host:                     "https://example.jamfcloud.com",
-		Client_Id:                "id",
-		Client_Secret:            "secret",
-		Page_Size:                defaultPageSize,
-		Sections:                 defaultSections,
-		Insecure_Skip_TLS_Verify: true,
-	})
+		{
+			name:     "general not duplicated when present",
+			sections: []string{"GENERAL", "APPLICATIONS"},
+			want:     []string{"GENERAL", "APPLICATIONS"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Config{Sections: tt.sections}
+			if got := c.requestSections(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("expected request sections %v, got %v", tt.want, got)
+			}
+		})
+	}
 }

--- a/hosted/plugins/jamf/config_test.go
+++ b/hosted/plugins/jamf/config_test.go
@@ -149,8 +149,8 @@ func TestConfig_Tags(t *testing.T) {
 		{
 			name:     "custom prefix",
 			sections: []string{"APPLICATIONS"},
-			prefix:   "utad",
-			want:     []string{"utad_applications"},
+			prefix:   "custom",
+			want:     []string{"custom_applications"},
 		},
 		{
 			name:     "tag name override for single section",

--- a/hosted/plugins/jamf/example.conf
+++ b/hosted/plugins/jamf/example.conf
@@ -17,18 +17,32 @@
 	Path="/opt/gravwell/etc/hosted_runner.state"
 	Sync=false
 
-[Jamf "yourserver"]
+[Jamf "utad"]
 	Ingester-UUID="99100000-0000-0000-0000-000000000000" #example UUID, remember to set
-	Host=https://yourserver.jamfcloud.com
+	Host=https://jamf00.utad.utoledo.edu:8443
 	Client-Id="api-client-id"
 	Client-Secret="api-client-secret"
 
+	# Each Sections entry gets its own tag: jamf_<section, lowercased>.
+	# GENERAL is always fetched and folded into every one of those tags for
+	# context (device id, name, reportDate, etc), whether or not it's
+	# listed here. Add "Sections=GENERAL" to also get a jamf_general
+	# stream of general-only records.
+	Sections=DISK_ENCRYPTION   # -> tag jamf_disk_encryption
+	Sections=STORAGE           # -> tag jamf_storage
+	Sections=APPLICATIONS      # -> tag jamf_applications
+
 	# Optional, shown with defaults:
-	#Tag-Name=jamf
 	#Page-Size=100
 	#Lookback=1              # hours; how far back to look on first run
 	#Requests-Per-Minute=60
 	#Request-Interval=600    # seconds between poll cycles
-	#Sections=GENERAL
-	#Sections=DISK_ENCRYPTION
-	#Sections=STORAGE
+
+	# Tag-Prefix overrides the "jamf" prefix used to build per-section tags
+	# (e.g. Tag-Prefix=utad -> utad_disk_encryption, utad_storage, ...).
+	# Cannot be combined with Tag-Name.
+	#Tag-Prefix=jamf
+
+	# Tag-Name pins every record to one literal tag instead of one tag per
+	# section. Only valid when exactly one Sections entry is configured.
+	#Tag-Name=jamf

--- a/hosted/plugins/jamf/example.conf
+++ b/hosted/plugins/jamf/example.conf
@@ -17,9 +17,9 @@
 	Path="/opt/gravwell/etc/hosted_runner.state"
 	Sync=false
 
-[Jamf "utad"]
+[Jamf "custom"]
 	Ingester-UUID="99100000-0000-0000-0000-000000000000" #example UUID, remember to set
-	Host=https://jamf00.utad.utoledo.edu:8443
+	Host=https://yourserver.jamfcloud.com
 	Client-Id="api-client-id"
 	Client-Secret="api-client-secret"
 
@@ -39,7 +39,7 @@
 	#Request-Interval=600    # seconds between poll cycles
 
 	# Tag-Prefix overrides the "jamf" prefix used to build per-section tags
-	# (e.g. Tag-Prefix=utad -> utad_disk_encryption, utad_storage, ...).
+	# (e.g. Tag-Prefix=custom -> custom_disk_encryption, custom_storage, ...).
 	# Cannot be combined with Tag-Name.
 	#Tag-Prefix=jamf
 

--- a/hosted/plugins/jamf/jamf.go
+++ b/hosted/plugins/jamf/jamf.go
@@ -9,11 +9,11 @@
 package jamf
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/gravwell/gravwell/v3/hosted"
@@ -49,13 +49,19 @@ func (j *Jamf) initClient(ctx context.Context) {
 
 // Handle implements hosted.Job. It fetches every computer-inventory record
 // whose general.reportDate falls in (lastEnd, now-buffer], paginating until
-// the API reports no more results, then schedules the next run.
+// the API reports no more results, then schedules the next run. Each
+// configured section is split out to its own tag, with the GENERAL
+// section's data folded into every entry.
 func (j *Jamf) Handle(ctx context.Context, rt hosted.Runtime) (*hosted.Continuation, error) {
-	j.initClient(ctx)
+	j.initClient(rt.Context())
 
-	tag, err := rt.NegotiateTag(j.conf.Tags()[0])
-	if err != nil {
-		return nil, fmt.Errorf("negotiating tag: %w", err)
+	tags := make(map[string]entry.EntryTag, len(j.conf.Sections))
+	for _, section := range j.conf.Sections {
+		tag, err := rt.NegotiateTag(j.conf.tagForSection(section))
+		if err != nil {
+			return nil, fmt.Errorf("negotiating tag for section %s: %w", section, err)
+		}
+		tags[section] = tag
 	}
 
 	start, err := hosted.GetTimeOrDefault(rt, stateKeyLastEnd, time.Now().Add(-j.conf.LookbackDuration()))
@@ -72,7 +78,7 @@ func (j *Jamf) Handle(ctx context.Context, rt hosted.Runtime) (*hosted.Continuat
 	filter := fmt.Sprintf("general.reportDate>%s;general.reportDate<%s",
 		start.UTC().Format(time.RFC3339), end.UTC().Format(time.RFC3339))
 
-	if err := j.drain(ctx, rt, tag, filter); err != nil {
+	if err := j.drain(ctx, rt, tags, filter); err != nil {
 		return nil, err
 	}
 
@@ -83,11 +89,14 @@ func (j *Jamf) Handle(ctx context.Context, rt hosted.Runtime) (*hosted.Continuat
 	return j.conf.ContinueAfterInterval(), nil
 }
 
-// drain pages through every result for filter, writing each record as an
-// entry until the API reports totalCount == 0.
-func (j *Jamf) drain(ctx context.Context, rt hosted.Runtime, tag entry.EntryTag, filter string) error {
+// drain pages through every result for filter, splitting each device record
+// into one entry per configured section and writing them until the API
+// reports totalCount == 0.
+func (j *Jamf) drain(ctx context.Context, rt hosted.Runtime, tags map[string]entry.EntryTag, filter string) error {
+	requestSections := j.conf.requestSections()
+
 	for page := 0; ; page++ {
-		resp, err := j.c.FetchInventoryPage(ctx, filter, j.conf.Sections, page, j.conf.Page_Size)
+		resp, err := j.c.FetchInventoryPage(ctx, filter, requestSections, page, j.conf.Page_Size)
 		if err != nil {
 			return fmt.Errorf("fetching page %d: %w", page, err)
 		}
@@ -98,64 +107,102 @@ func (j *Jamf) drain(ctx context.Context, rt hosted.Runtime, tag entry.EntryTag,
 		rt.Debug("fetched inventory page", log.KV("page", page), log.KV("count", len(resp.Results)))
 
 		for _, raw := range resp.Results {
-			ts, data, err := stampTimestamp(raw)
+			entries, err := splitRecord(raw, j.conf.Sections, tags)
 			if err != nil {
 				rt.Error("failed to process inventory record", log.KVErr(err))
 				continue
 			}
-			e := entry.Entry{
-				TS:   entry.FromStandard(ts),
-				Tag:  tag,
-				Data: data,
-			}
-			if err := rt.Write(e); err != nil {
-				rt.Error("failed to write entry", log.KVErr(err))
+			for _, e := range entries {
+				if err := rt.Write(e); err != nil {
+					rt.Error("failed to write entry", log.KVErr(err))
+				}
 			}
 		}
 	}
 }
 
-// generalSection is just enough of the computers-inventory record shape to
-// pull out the GENERAL section's reportDate field.
-type generalSection struct {
-	General struct {
-		ReportDate string `json:"reportDate"`
-	} `json:"general"`
+// sectionJSONKey converts a Jamf computers-inventory section constant (e.g.
+// "DISK_ENCRYPTION") into the camelCase JSON key Jamf nests that section's
+// data under in a record (e.g. "diskEncryption").
+func sectionJSONKey(section string) string {
+	parts := strings.Split(strings.ToLower(section), "_")
+	for i := 1; i < len(parts); i++ {
+		if parts[i] == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(parts[i][:1]) + parts[i][1:]
+	}
+	return strings.Join(parts, "")
 }
 
-// stampTimestamp parses general.reportDate out of a raw computers-inventory
-// record and returns both the parsed time (used as the entry's TS) and the
-// original record with a top-level "timestamp" field inserted, preserving
-// compatibility with dashboards/searches built against the original flow's
-// output shape.
-func stampTimestamp(raw json.RawMessage) (time.Time, []byte, error) {
-	var g generalSection
-	if err := json.Unmarshal(raw, &g); err != nil {
-		return time.Time{}, nil, fmt.Errorf("unmarshal record: %w", err)
-	}
-	if g.General.ReportDate == "" {
-		return time.Time{}, nil, errors.New("record missing general.reportDate")
+// splitRecord pulls the GENERAL section's reportDate out of a raw
+// computers-inventory record (used as every resulting entry's TS), then
+// builds one entry per section in sections that's both configured and
+// actually present on this device: {"timestamp", "general", "<section>"}
+// for content sections, or just {"timestamp", "general"} for GENERAL
+// itself. A section configured but absent from this particular device's
+// record is silently skipped for that device.
+func splitRecord(raw json.RawMessage, sections []string, tags map[string]entry.EntryTag) ([]entry.Entry, error) {
+	var full map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &full); err != nil {
+		return nil, fmt.Errorf("unmarshal record: %w", err)
 	}
 
-	ts, err := time.Parse(time.RFC3339Nano, g.General.ReportDate)
+	generalRaw, ok := full[sectionJSONKey(generalSectionName)]
+	if !ok {
+		return nil, errors.New("record missing general section")
+	}
+
+	var g struct {
+		ReportDate string `json:"reportDate"`
+	}
+	if err := json.Unmarshal(generalRaw, &g); err != nil {
+		return nil, fmt.Errorf("unmarshal general section: %w", err)
+	}
+	if g.ReportDate == "" {
+		return nil, errors.New("record missing general.reportDate")
+	}
+	ts, err := time.Parse(time.RFC3339Nano, g.ReportDate)
 	if err != nil {
-		return time.Time{}, nil, fmt.Errorf("parsing reportDate %q: %w", g.General.ReportDate, err)
+		return nil, fmt.Errorf("parsing reportDate %q: %w", g.ReportDate, err)
+	}
+	tsJSON, err := json.Marshal(g.ReportDate)
+	if err != nil {
+		return nil, fmt.Errorf("encoding timestamp: %w", err)
 	}
 
-	var buf bytes.Buffer
-	if err := json.Compact(&buf, raw); err != nil {
-		return time.Time{}, nil, fmt.Errorf("compacting record: %w", err)
-	}
-	compact := buf.Bytes()
-	if len(compact) == 0 || compact[0] != '{' {
-		return time.Time{}, nil, errors.New("record is not a JSON object")
-	}
+	entries := make([]entry.Entry, 0, len(sections))
+	for _, section := range sections {
+		tag, ok := tags[section]
+		if !ok {
+			// Every configured section is negotiated up front in Handle;
+			// this would only happen if called incorrectly.
+			continue
+		}
 
-	stamped := make([]byte, 0, len(compact)+len(g.General.ReportDate)+16)
-	stamped = append(stamped, []byte(`{"timestamp":"`)...)
-	stamped = append(stamped, []byte(g.General.ReportDate)...)
-	stamped = append(stamped, []byte(`",`)...)
-	stamped = append(stamped, compact[1:]...)
+		doc := map[string]json.RawMessage{
+			"timestamp": tsJSON,
+			"general":   generalRaw,
+		}
+		if section != generalSectionName {
+			key := sectionJSONKey(section)
+			sectionRaw, present := full[key]
+			if !present {
+				// This device has no data for the section; nothing to emit.
+				continue
+			}
+			doc[key] = sectionRaw
+		}
 
-	return ts, stamped, nil
+		data, err := json.Marshal(doc)
+		if err != nil {
+			return nil, fmt.Errorf("marshal %s entry: %w", section, err)
+		}
+		entries = append(entries, entry.Entry{
+			TS:   entry.FromStandard(ts),
+			Tag:  tag,
+			Data: data,
+		})
+	}
+	return entries, nil
 }

--- a/hosted/plugins/jamf/jamf_test.go
+++ b/hosted/plugins/jamf/jamf_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/crewjam/rfc5424"
+	"github.com/gravwell/gravwell/v3/hosted"
 	"github.com/gravwell/gravwell/v3/hosted/storage"
 	"github.com/gravwell/gravwell/v3/ingest/entry"
 )
@@ -26,13 +27,14 @@ import (
 // mockRuntime is a minimal in-memory implementation of hosted.Runtime,
 // mirroring the pattern used in hosted/plugins/msgraph/msgraph_test.go.
 type mockRuntime struct {
-	mu      sync.Mutex
-	entries []entry.Entry
-	store   map[string][]byte
-	tags    map[string]entry.EntryTag
-	nextTag entry.EntryTag
-	ctx     context.Context
-	cancel  context.CancelFunc
+	hosted.StatusTracker // SetError/SetWarn and friends
+	mu                   sync.Mutex
+	entries              []entry.Entry
+	store                map[string][]byte
+	tags                 map[string]entry.EntryTag
+	nextTag              entry.EntryTag
+	ctx                  context.Context
+	cancel               context.CancelFunc
 }
 
 // newMockRuntime constructs a ready-to-use mockRuntime backed by an empty

--- a/hosted/plugins/jamf/jamf_test.go
+++ b/hosted/plugins/jamf/jamf_test.go
@@ -1,3 +1,11 @@
+/*************************************************************************
+ * Copyright 2026 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 2-clause license. See the LICENSE file for details.
+ **************************************************************************/
+
 package jamf
 
 import (
@@ -11,7 +19,6 @@ import (
 	"time"
 
 	"github.com/crewjam/rfc5424"
-	"github.com/gravwell/gravwell/v3/hosted"
 	"github.com/gravwell/gravwell/v3/hosted/storage"
 	"github.com/gravwell/gravwell/v3/ingest/entry"
 )
@@ -19,14 +26,13 @@ import (
 // mockRuntime is a minimal in-memory implementation of hosted.Runtime,
 // mirroring the pattern used in hosted/plugins/msgraph/msgraph_test.go.
 type mockRuntime struct {
-	hosted.StatusTracker // SetError/SetWarn and friends
-	mu                   sync.Mutex
-	entries              []entry.Entry
-	store                map[string][]byte
-	tags                 map[string]entry.EntryTag
-	nextTag              entry.EntryTag
-	ctx                  context.Context
-	cancel               context.CancelFunc
+	mu      sync.Mutex
+	entries []entry.Entry
+	store   map[string][]byte
+	tags    map[string]entry.EntryTag
+	nextTag entry.EntryTag
+	ctx     context.Context
+	cancel  context.CancelFunc
 }
 
 // newMockRuntime constructs a ready-to-use mockRuntime backed by an empty
@@ -109,14 +115,16 @@ func (m *mockRuntime) PutTime(key string, value time.Time) error {
 	return m.PutString(key, value.Format(time.RFC3339Nano))
 }
 
-// newTestConfig builds a minimal, already-Verify()'d Config pointed at host,
-// failing the test immediately if validation doesn't pass.
-func newTestConfig(t *testing.T, host string) *Config {
+// newTestConfig builds a minimal, already-Verify()'d Config pointed at host
+// with the given Sections (falling back to the package defaults if none are
+// given), failing the test immediately if validation doesn't pass.
+func newTestConfig(t *testing.T, host string, sections ...string) *Config {
 	t.Helper()
 	conf := &Config{
 		Host:          host,
 		Client_Id:     "id",
 		Client_Secret: "secret",
+		Sections:      sections,
 	}
 	if err := conf.Verify(); err != nil {
 		t.Fatalf("unexpected error verifying test config: %v", err)
@@ -125,13 +133,13 @@ func newTestConfig(t *testing.T, host string) *Config {
 }
 
 // TestHandle_IngestsRecords runs a single Handle cycle against a fake Jamf
-// server returning one inventory record, and verifies the resulting entry's
-// TS is set from general.reportDate, its Data has the "timestamp" field
-// stamped in front of the original fields, and it's written under the
-// default tag.
+// server returning one inventory record for a single configured section,
+// and verifies the resulting entry's TS is set from general.reportDate, its
+// Data has both the "general" and the section's own data folded in, and
+// it's written under that section's tag.
 func TestHandle_IngestsRecords(t *testing.T) {
 	reportDate := time.Now().Add(-2 * time.Hour).Truncate(time.Second).UTC()
-	record := `{"id":1,"general":{"reportDate":"` + reportDate.Format(time.RFC3339Nano) + `"},"udid":"abc"}`
+	record := `{"general":{"id":1,"reportDate":"` + reportDate.Format(time.RFC3339Nano) + `"},"applications":{"apps":["Safari"]}}`
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/oauth/token", func(w http.ResponseWriter, r *http.Request) {
@@ -152,7 +160,7 @@ func TestHandle_IngestsRecords(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	conf := newTestConfig(t, server.URL)
+	conf := newTestConfig(t, server.URL, "APPLICATIONS")
 	rt := newMockRuntime(t.Context())
 	j := New(conf)
 
@@ -171,17 +179,91 @@ func TestHandle_IngestsRecords(t *testing.T) {
 	if e.TS != entry.FromStandard(reportDate) {
 		t.Errorf("expected TS %v, got %v", entry.FromStandard(reportDate), e.TS)
 	}
-	if !strings.HasPrefix(string(e.Data), `{"timestamp":"`+reportDate.Format(time.RFC3339Nano)+`",`) {
-		t.Errorf("expected stamped timestamp prefix, got %s", e.Data)
+
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(e.Data, &doc); err != nil {
+		t.Fatalf("entry data is not valid JSON: %v", err)
 	}
-	if !strings.Contains(string(e.Data), `"id":1`) {
-		t.Errorf("expected original fields preserved, got %s", e.Data)
+	if _, ok := doc["general"]; !ok {
+		t.Errorf("expected general section folded into the entry, got %s", e.Data)
+	}
+	if _, ok := doc["applications"]; !ok {
+		t.Errorf("expected applications section in the entry, got %s", e.Data)
 	}
 
-	wantTag, _ := rt.NegotiateTag(defaultTag)
+	wantTag, _ := rt.NegotiateTag(conf.tagForSection("APPLICATIONS"))
 	if e.Tag != wantTag {
 		t.Errorf("expected tag %v, got %v", wantTag, e.Tag)
 	}
+}
+
+// TestHandle_SplitsRecordAcrossSectionTags verifies the core multi-section
+// feature end to end: a single device record containing data for two
+// configured sections is split into one entry per section, each of them
+// tagged distinctly but each carrying the GENERAL section's data.
+func TestHandle_SplitsRecordAcrossSectionTags(t *testing.T) {
+	ts := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339Nano)
+	record := `{"general":{"reportDate":"` + ts + `"},"applications":{"apps":["Safari"]},"storage":{"disks":1}}`
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/oauth/token", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(tokenResponse{AccessToken: "tok", ExpiresIn: 3600})
+	})
+	calls := 0
+	mux.HandleFunc("/api/v1/computers-inventory", func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			json.NewEncoder(w).Encode(Response{
+				TotalCount: 1,
+				Results:    []json.RawMessage{json.RawMessage(record)},
+			})
+			return
+		}
+		json.NewEncoder(w).Encode(Response{TotalCount: 0})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	conf := newTestConfig(t, server.URL, "APPLICATIONS", "STORAGE")
+	rt := newMockRuntime(t.Context())
+	j := New(conf)
+
+	if _, err := j.Handle(t.Context(), rt); err != nil {
+		t.Fatal(err)
+	}
+	if len(rt.entries) != 2 {
+		t.Fatalf("expected one entry per configured section, got %d", len(rt.entries))
+	}
+
+	appsTag, _ := rt.NegotiateTag(conf.tagForSection("APPLICATIONS"))
+	storageTag, _ := rt.NegotiateTag(conf.tagForSection("STORAGE"))
+	if appsTag == storageTag {
+		t.Fatal("expected APPLICATIONS and STORAGE to negotiate distinct tags")
+	}
+
+	var gotTags []entry.EntryTag
+	for _, e := range rt.entries {
+		gotTags = append(gotTags, e.Tag)
+		var doc map[string]json.RawMessage
+		if err := json.Unmarshal(e.Data, &doc); err != nil {
+			t.Fatalf("entry data is not valid JSON: %v", err)
+		}
+		if _, ok := doc["general"]; !ok {
+			t.Errorf("expected general section folded into every entry, got %s", e.Data)
+		}
+	}
+	if !containsTag(gotTags, appsTag) || !containsTag(gotTags, storageTag) {
+		t.Errorf("expected entries tagged %v and %v, got %v", appsTag, storageTag, gotTags)
+	}
+}
+
+func containsTag(tags []entry.EntryTag, want entry.EntryTag) bool {
+	for _, tag := range tags {
+		if tag == want {
+			return true
+		}
+	}
+	return false
 }
 
 // TestHandle_PaginatesUntilExhausted verifies that a single Handle call
@@ -204,14 +286,14 @@ func TestHandle_PaginatesUntilExhausted(t *testing.T) {
 			json.NewEncoder(w).Encode(Response{
 				TotalCount: 2,
 				Results: []json.RawMessage{
-					json.RawMessage(`{"id":1,"general":{"reportDate":"` + ts + `"}}`),
+					json.RawMessage(`{"general":{"reportDate":"` + ts + `"},"applications":{"id":1}}`),
 				},
 			})
 		case "1":
 			json.NewEncoder(w).Encode(Response{
 				TotalCount: 2,
 				Results: []json.RawMessage{
-					json.RawMessage(`{"id":2,"general":{"reportDate":"` + ts + `"}}`),
+					json.RawMessage(`{"general":{"reportDate":"` + ts + `"},"applications":{"id":2}}`),
 				},
 			})
 		default:
@@ -221,7 +303,7 @@ func TestHandle_PaginatesUntilExhausted(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	conf := newTestConfig(t, server.URL)
+	conf := newTestConfig(t, server.URL, "APPLICATIONS")
 	rt := newMockRuntime(t.Context())
 	j := New(conf)
 
@@ -334,16 +416,16 @@ func TestHandle_SkipsMalformedRecordsButContinues(t *testing.T) {
 		json.NewEncoder(w).Encode(Response{
 			TotalCount: 3,
 			Results: []json.RawMessage{
-				json.RawMessage(`{"id":1,"general":{"reportDate":"` + goodTS + `"}}`), // good
-				json.RawMessage(`{"id":2,"general":{}}`),                              // missing reportDate
-				json.RawMessage(`{"id":3,"general":{"reportDate":"not-a-time"}}`),     // bad format
+				json.RawMessage(`{"general":{"id":1,"reportDate":"` + goodTS + `"},"applications":{"apps":["Safari"]}}`), // good
+				json.RawMessage(`{"id":2,"general":{}}`),                          // missing reportDate
+				json.RawMessage(`{"id":3,"general":{"reportDate":"not-a-time"}}`), // bad format
 			},
 		})
 	})
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	conf := newTestConfig(t, server.URL)
+	conf := newTestConfig(t, server.URL, "APPLICATIONS")
 	rt := newMockRuntime(t.Context())
 	j := New(conf)
 


### PR DESCRIPTION
Patching jamf plugin to make each section have it's own tag because all sections bundled together creates huge JSON objects that

<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

[Addresses this issue](https://github.com/gravwell/gravwell/issues/2776)

## This PR proposes...

- Each section gets it's own tag
- Adding the config parameter "Tag-Prefix"

## PR Tasks

<!-- Add tasks to this list as needed -->

- [x] e2e and/or unit tests included. If not, please provide an explanation.
- [x] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
